### PR TITLE
#3573 [DigiriskStandard] fix: generation ODT with useless parameters

### DIFF
--- a/view/digiriskelement/digiriskelement_listingrisksaction.php
+++ b/view/digiriskelement/digiriskelement_listingrisksaction.php
@@ -85,10 +85,7 @@ if (empty($reshook)) {
 	if ($object->element == 'digiriskstandard') {
         $previousRef = $object->ref;
 		$object->ref = '';
-	} else {
-        $object->element = 'listingrisksaction';
-    }
-	$removeDocumentFromName = 1;
+	}
 
     // Actions builddoc, forcebuilddoc, remove_file.
     require_once __DIR__ . '/../../../saturne/core/tpl/documents/documents_action.tpl.php';
@@ -96,9 +93,6 @@ if (empty($reshook)) {
     // Action to generate pdf from odt file
     require_once __DIR__ . '/../../../saturne/core/tpl/documents/saturne_manual_pdf_generation_action.tpl.php';
 
-    if ($object->element == 'listingrisksaction') {
-        $object->element = 'digiriskelement';
-    }
     if ($object->element == 'digiriskstandard') {
         $object->ref = $previousRef;
     }

--- a/view/digiriskelement/digiriskelement_listingrisksphoto.php
+++ b/view/digiriskelement/digiriskelement_listingrisksphoto.php
@@ -85,10 +85,7 @@ if (empty($reshook)) {
     if ($object->element == 'digiriskstandard') {
         $previousRef = $object->ref;
         $object->ref = '';
-    } else {
-        $object->element = 'listingrisksphoto';
     }
-    $removeDocumentFromName = 1;
 
     // Actions builddoc, forcebuilddoc, remove_file.
     require_once __DIR__ . '/../../../saturne/core/tpl/documents/documents_action.tpl.php';
@@ -96,9 +93,6 @@ if (empty($reshook)) {
     // Action to generate pdf from odt file
     require_once __DIR__ . '/../../../saturne/core/tpl/documents/saturne_manual_pdf_generation_action.tpl.php';
 
-    if ($object->element == 'listingrisksphoto') {
-        $object->element = 'digiriskelement';
-    }
     if ($object->element == 'digiriskstandard') {
         $object->ref = $previousRef;
     }

--- a/view/digiriskstandard/digiriskstandard_informationssharing.php
+++ b/view/digiriskstandard/digiriskstandard_informationssharing.php
@@ -79,7 +79,6 @@ if (empty($reshook)) {
 	$error = 0;
     $previousRef = $object->ref;
     $object->ref = '';
-    $removeDocumentFromName = 1;
 
 	// Actions builddoc, forcebuilddoc, remove_file.
 	require_once __DIR__ . '/../../../saturne/core/tpl/documents/documents_action.tpl.php';

--- a/view/digiriskstandard/digiriskstandard_legaldisplay.php
+++ b/view/digiriskstandard/digiriskstandard_legaldisplay.php
@@ -82,7 +82,6 @@ if (empty($reshook)) {
     $error = 0;
     $previousRef = $object->ref;
     $object->ref = '';
-    $removeDocumentFromName = 1;
 
     // Actions builddoc, forcebuilddoc, remove_file.
     require_once __DIR__ . '/../../../saturne/core/tpl/documents/documents_action.tpl.php';

--- a/view/digiriskstandard/digiriskstandard_registerdocument.php
+++ b/view/digiriskstandard/digiriskstandard_registerdocument.php
@@ -79,7 +79,6 @@ if (empty($reshook)) {
 	$error = 0;
     $previousRef = $object->ref;
     $object->ref = '';
-    $removeDocumentFromName = 1;
 
 	// Actions builddoc, forcebuilddoc, remove_file.
 	require_once __DIR__ . '/../../../saturne/core/tpl/documents/documents_action.tpl.php';


### PR DESCRIPTION
Indeed use document element its better and avoid overwritting object element
