### PR TITLE
Eldy patch 1

### DIFF
--- a/view/preventionplan/preventionplan_list.php
+++ b/view/preventionplan/preventionplan_list.php
@@ -494,7 +494,7 @@ while ($i < ($limit ? min($num, $limit) : $num)) {
 		if ($key == 'Custom') {
 			foreach ($val as $name => $resource) {
 				if ($resource['checked']) {
-					print '<td class="tdoverflowmax150">';
+					print '<td class="tdoverflowmax125">';
 					if ($resource['label'] == 'MasterWorker') {
 						$element = $signatory->fetchSignatory('MasterWorker', $object->id, 'preventionplan');
 						if (is_array($element) && !empty($element)) {

--- a/view/preventionplan/preventionplan_list.php
+++ b/view/preventionplan/preventionplan_list.php
@@ -494,7 +494,7 @@ while ($i < ($limit ? min($num, $limit) : $num)) {
 		if ($key == 'Custom') {
 			foreach ($val as $name => $resource) {
 				if ($resource['checked']) {
-					print '<td>';
+					print '<td class="tdoverflowmax150">';
 					if ($resource['label'] == 'MasterWorker') {
 						$element = $signatory->fetchSignatory('MasterWorker', $object->id, 'preventionplan');
 						if (is_array($element) && !empty($element)) {


### PR DESCRIPTION
As i saw a lot of table with anarchic height when using digirisk and digiquali, i send you a PR as example to show you about a tip that may be interesting for you:
It is just a suggestion to use the "tdoverflowmaxXXX" css on td fields for columns that are filled with a content coming from a object-> getNomUrl()  to avoid the wrap of content.

For getNomUrl() ref, first chars are often enough and all information can already be visible with tooltip so adding the css tdoverflow allow the browser to truncate when required by browser to avoid lines to have an anarchic height.

Note: As you have a high number of large column on this page, you can also use   tdoverflowmax100 or tdoverflowmax75 instead of tdoverflowmax125
Note: in dolibarr we are using tdoverflowmax100 for getNomUrl of a user object and tdoverflowmax125 for a thirdparty.

Example with tdoverflowmax125

BEFORE:
<img width="666" height="489" alt="image" src="https://github.com/user-attachments/assets/47d234bd-dd49-4ccb-9c71-413146747020" />

AFTER (lines have the same height):
<img width="870" height="364" alt="image" src="https://github.com/user-attachments/assets/a443f545-42d8-4699-80b5-0f7ec9b0aac8" />

