### PR TITLE
Fix fatal error on screen rendering

### DIFF
--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
@@ -1023,7 +1023,9 @@ while ($i < ($limit ? min($num, $limit) : $num)) {
                             $digiriskElementIds = array_reverse($digiriskElementIds);
 
                             foreach ($digiriskElementIds as $key => $digiriskElementId) {
-                                print str_repeat(' &#160', $key + 1) . '&#x21B3' . $activeDigiriskElementList[$digiriskElementId]->getNomUrl(1, 'blank', 0, '', -1, 1) . '<br>';
+                                if ($activeDigiriskElementList[$digiriskElementId]) {
+                                    print str_repeat(' &#160', $key + 1) . '&#x21B3' . $activeDigiriskElementList[$digiriskElementId]->getNomUrl(1, 'blank', 0, '', -1, 1) . '<br>';
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Add check for active Digirisk element before printing to avoid this error :
```

[admin.nltechno.com] [Fri Dec 19 13:41:31.616503 2025] [php:warn] [pid 2943837:tid [client 82.64.109.15:45566] PHP Warning:  Undefined array key "fk_element" in /home/admin/wwwroot/dolibarr/htdocs/custom/digiriskdolibarr/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php on line 897, referer https://admin.nltechno.com/custom/digiriskdolibarr/view/digiriskstandard/digiriskstandard_card.php?risk_type=risk&idmenu=120559&mainmenu=digiriskdolibarr&leftmenu=
[admin.nltechno.com] [Fri Dec 19 13:41:31.625018 2025] [php:warn] [pid 2943837:tid [client 82.64.109.15:45566] PHP Warning:  Undefined array key 1 in /home/admin/wwwroot/dolibarr/htdocs/custom/digiriskdolibarr/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php on line 1026, referer https://admin.nltechno.com/custom/digiriskdolibarr/view/digiriskstandard/digiriskstandard_card.php?risk_type=risk&idmenu=120559&mainmenu=digiriskdolibarr&leftmenu=
[admin.nltechno.com] [Fri Dec 19 13:41:31.625084 2025] [php:error] [pid 2943837:tid [client 82.64.109.15:45566] PHP Fatal error:  Uncaught Error: Call to a member function getNomUrl() on null in /home/admin/wwwroot/dolibarr/htdocs/custom/digiriskdolibarr/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php:1026\nStack trace:\n#0 /home/admin/wwwroot/dolibarr/htdocs/custom/digiriskdolibarr/view/digiriskelement/risk_list.php(243): require_once()\n#1 {main}\n  thrown in /home/admin/wwwroot/dolibarr/htdocs/custom/digiriskdolibarr/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php on line 1026, referer https://admin.nltechno.com/custom/digiriskdolibarr/view/digiriskstandard/digiriskstandard_card.php?risk_type=risk&idmenu=120559&mainmenu=digiriskdolibarr&leftmenu=
```

So screen was 
<img width="1607" height="283" alt="image" src="https://github.com/user-attachments/assets/f2f6c2fd-9758-4cda-bb86-e78affd20954" />

And after the patch, it is 
<img width="1599" height="621" alt="image" src="https://github.com/user-attachments/assets/8fc61ecb-c3f5-4544-b883-c6ff49ddd539" />
