### PR TITLE
#4711 [Class] rework: remove isextrafieldmanaged from all classes

### DIFF
--- a/class/accident.class.php
+++ b/class/accident.class.php
@@ -1182,11 +1182,6 @@ class AccidentMetaData extends SaturneObject
 	public $ismultientitymanaged = 1;
 
 	/**
-	 * @var int  Does object support extrafields ? 0=No, 1=Yes
-	 */
-	public $isextrafieldmanaged = 1;
-
-	/**
 	 * @var string String with name of icon for digiriskelement. Must be the part after the 'object_' into object_digiriskelement.png
 	 */
 	public string $picto = 'fontawesome_fa-user-injured_fas_#d35968';

--- a/class/digiriskresources.class.php
+++ b/class/digiriskresources.class.php
@@ -55,11 +55,6 @@ class DigiriskResources extends SaturneObject
 	public $ismultientitymanaged = 1;
 
 	/**
-	 * @var int Does object support extrafields ? 0 = No, 1 = Yes.
-	 */
-	public $isextrafieldmanaged = 1;
-
-	/**
 	 * @var string String with name of icon for digiriskresources. Must be the part after the 'object_' into object_digiriskresources.png
 	 */
 	public string $picto = 'digiriskresources@digiriskdolibarr';

--- a/class/digiriskstandard.class.php
+++ b/class/digiriskstandard.class.php
@@ -51,11 +51,6 @@ class DigiriskStandard extends SaturneObject
     public $ismultientitymanaged = 1;
 
     /**
-     * @var int Does object support extrafields ? 0 = No, 1 = Yes.
-     */
-    public $isextrafieldmanaged = 1;
-
-    /**
      * @var string Name of icon for digiriskstandard. Must be a 'fa-xxx' fontawesome code (or 'fa-xxx_fa_color_size') or 'digiriskstandard@digiriskdolibarr' if picto is file 'img/object_digiriskstandard.png'
      */
     public string $picto = 'fontawesome_fa-sitemap_fas_#d35968';

--- a/class/evaluator.class.php
+++ b/class/evaluator.class.php
@@ -52,11 +52,6 @@ class Evaluator extends SaturneObject
     public $ismultientitymanaged = 1;
 
     /**
-     * @var int Does object support extrafields ? 0 = No, 1 = Yes.
-     */
-    public $isextrafieldmanaged = 1;
-
-    /**
      * @var string Name of icon for evaluator. Must be a 'fa-xxx' fontawesome code (or 'fa-xxx_fa_color_size') or 'evaluator@digiriskdolibarr' if picto is file 'img/object_evaluator.png'.
      */
     public string $picto = 'fontawesome_fa-user-check_fas_#d35968';

--- a/class/firepermit.class.php
+++ b/class/firepermit.class.php
@@ -57,11 +57,6 @@ class FirePermit extends SaturneObject
 	 */
 	public $ismultientitymanaged = 1;
 
-	/**
-	 * @var int Does object support extrafields ? 0 = No, 1 = Yes.
-	 */
-	public $isextrafieldmanaged = 1;
-
     /**
      * @var string Name of icon for firepermit. Must be a 'fa-xxx' fontawesome code (or 'fa-xxx_fa_color_size') or 'firepermit@digiriskdolibarr' if picto is file 'img/object_firepermit.png'.
      */

--- a/class/preventionplan.class.php
+++ b/class/preventionplan.class.php
@@ -56,10 +56,6 @@ class PreventionPlan extends SaturneObject
 	public $ismultientitymanaged = 1;
 
 	/**
-	 * @var int Does object support extrafields ? 0 = No, 1 = Yes.
-	 */
-	public $isextrafieldmanaged = 1;
-	/**
 	 * @var string String with name of icon for digiriskelement. Must be the part after the 'object_' into object_digiriskelement.png
 	 */
 	public string $picto = 'fontawesome_fa-info_fas_#d35968';

--- a/class/riskanalysis/risk.class.php
+++ b/class/riskanalysis/risk.class.php
@@ -57,11 +57,6 @@ class Risk extends SaturneObject
 	 */
 	public $ismultientitymanaged = 1;
 
-	/**
-	 * @var int Does object support extrafields ? 0 = No, 1 = Yes
-	 */
-	public $isextrafieldmanaged = 1;
-
     public const STATUS_DELETED   = -1;
     public const STATUS_DRAFT     = 0;
     public const STATUS_VALIDATED = 1;

--- a/class/riskanalysis/riskassessment.class.php
+++ b/class/riskanalysis/riskassessment.class.php
@@ -54,11 +54,6 @@ class RiskAssessment extends SaturneObject
 	 */
 	public $ismultientitymanaged = 1;
 
-	/**
-	 * @var int Does object support extrafields ? 0 = No, 1 = Yes.
-	 */
-	public $isextrafieldmanaged = 1;
-
     /**
      * @var string Name of icon for riskassessment. Must be a 'fa-xxx' fontawesome code (or 'fa-xxx_fa_color_size') or 'riskassessment@digiriskdolibarr' if picto is file 'img/object_riskassessment.png'
      */

--- a/class/riskanalysis/risksign.class.php
+++ b/class/riskanalysis/risksign.class.php
@@ -53,11 +53,6 @@ class RiskSign extends SaturneObject
 	public $ismultientitymanaged = 1;
 
 	/**
-	 * @var int Does object support extrafields ? 0 = No, 1 = Yes.
-	 */
-	public $isextrafieldmanaged = 1;
-
-	/**
 	 * @var string String with name of icon for risksign. Must be the part after the 'object_' into object_risksign.png
 	 */
 	public string $picto = 'risksign@digiriskdolibarr';


### PR DESCRIPTION
## Summary
- Remove `isextrafieldmanaged = 1` override from all DigiriskDolibarr classes (accident, digiriskstandard, digiriskresources, evaluator, digiriskelement, firepermit, preventionplan, risk, riskassessment, risksign)
- Classes now inherit `isextrafieldmanaged = 0` from SaturneObject, preventing SQL errors caused by LEFT JOIN on non-existent `_extrafields` tables

## Test plan
- [ ] Verify legal display page loads with all fields populated
- [ ] Verify risk analysis pages load correctly
- [ ] Verify accident, firepermit, and preventionplan pages work

🤖 Generated with [Claude Code](https://claude.com/claude-code)