### PR TITLE
#4716 [Accident] fix: cast id to int to prevent TypeError on fetch

### DIFF
--- a/view/accident/accident_card.php
+++ b/view/accident/accident_card.php
@@ -50,7 +50,7 @@ global $conf, $db, $hookmanager, $langs, $moduleNameLowerCase, $mysoc, $user;
 saturne_load_langs();
 
 // Get parameters
-$id                  = (int) GETPOST('id', 'int');
+$id                  = GETPOSTINT('id');
 $lineid              = GETPOST('lineid', 'int');
 $ref                 = GETPOST('ref', 'alpha');
 $action              = GETPOST('action', 'aZ09');

--- a/view/accident/accident_card.php
+++ b/view/accident/accident_card.php
@@ -50,7 +50,7 @@ global $conf, $db, $hookmanager, $langs, $moduleNameLowerCase, $mysoc, $user;
 saturne_load_langs();
 
 // Get parameters
-$id                  = GETPOST('id', 'int');
+$id                  = (int) GETPOST('id', 'int');
 $lineid              = GETPOST('lineid', 'int');
 $ref                 = GETPOST('ref', 'alpha');
 $action              = GETPOST('action', 'aZ09');


### PR DESCRIPTION
## Changements
- Cast explicite de $id en int via (int) GETPOST pour eviter un TypeError

## Contexte
GETPOST retourne une chaine vide lorsque le parametre id est absent. SaturneObject::fetch() declare son premier parametre avec le type strict int. PHP 8 leve donc un TypeError: Argument 1 passed to SaturneObject::fetch() must be of the type int, string given.

## Fichiers modifies
- view/accident/accident_card.php

## Issue
#4716