### PR TITLE
#4719 [DigiriskElement] fix: use GETPOSTINT for id parameter to avoid TypeError on fetch()

### DIFF
--- a/view/digiriskelement/digiriskelement_card.php
+++ b/view/digiriskelement/digiriskelement_card.php
@@ -50,7 +50,7 @@ global $conf, $db, $hookmanager, $langs, $user;
 saturne_load_langs(['other']);
 
 // Get parameters
-$id                  = GETPOST('id', 'int');
+$id                  = GETPOSTINT('id');
 $ref                 = GETPOST('ref', 'alpha');
 $action              = GETPOST('action', 'aZ09');
 $subaction           = GETPOST('subaction', 'aZ09');


### PR DESCRIPTION
## Changements - Remplacement de GETPOST id int par GETPOSTINT id dans digiriskelement_card.php ## Contexte SaturneObject::fetch() declare int id comme type strict. GETPOST retourne une string ce qui provoque un TypeError fatal. ## Fichiers modifies - view/digiriskelement/digiriskelement_card.php ## Issue #4719