### PR TITLE
#4725 [DigiriskeElement] fix: set isCategoryManaged to 0 to prevent invalid SQL on GP/UT creation

### DIFF
--- a/class/digiriskelement.class.php
+++ b/class/digiriskelement.class.php
@@ -66,6 +66,11 @@ class DigiriskElement extends SaturneObject
      */
     public $isextrafieldmanaged = 1;
 
+    /**
+     * @var int Does object support category module ? 0 = No, 1 = Yes.
+     */
+    public int $isCategoryManaged = 0;
+
     public const STATUS_TRASHED   = -2;
     public const STATUS_DELETED   = -1;
     public const STATUS_VALIDATED = 1;


### PR DESCRIPTION
#4725

## Changements
- Ajout de `public int $isCategoryManaged = 0` dans `DigiriskElement`

## Pourquoi

`DigiriskElement` etend `SaturneObject` qui declare `isCategoryManaged = 1` par defaut. Lors de la creation d'un GP ou UT, `setCategories()` utilisait `workunit@digiriskdolibarr` comme type de categorie, produisant une requete SQL invalide. Les GP/UT ne gerent pas les categories - `isCategoryManaged = 0` court-circuite l'appel immediatement.

## Fichiers modifies
- `class/digiriskelement.class.php`