### PR TITLE
#4727 [ProjectDocument] fix: add default value to moreParam in write_file

### DIFF
--- a/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/projectdocument/pdf_papripact_a3_paysage_projectdocument.modules.php
+++ b/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/projectdocument/pdf_papripact_a3_paysage_projectdocument.modules.php
@@ -225,9 +225,13 @@ class pdf_papripact_a3_paysage_projectdocument
      * @return int                               1 if OK, <=0 if KO
      * @throws Exception
      */
-    public function write_file(SaturneDocuments $objectDocument, Translate $outputLangs, string $srcTemplatePath, int $hideDetails = 0, int $hideDesc = 0, int $hideRef = 0, array $moreParam): int
+    public function write_file(SaturneDocuments $objectDocument, Translate $outputLangs, string $srcTemplatePath, int $hideDetails = 0, int $hideDesc = 0, int $hideRef = 0, array $moreParam = []): int
     {
         global $action, $conf, $hookmanager, $langs, $moduleNameLowerCase, $user;
+
+        if (empty($moreParam)) {
+            $moreParam = $objectDocument->context['moreparams'] ?? [];
+        }
 
         $object = $moreParam['object'];
 


### PR DESCRIPTION
## Changements
- Ajout de la valeur par defaut = [] au parametre moreParam de write_file
- Fallback sur objectDocument->context['moreparams'] si moreParam est vide (chemin d'appel via commonobject.class.php)

## Fichiers modifies
- core/modules/digiriskdolibarr/digiriskdolibarrdocuments/projectdocument/pdf_papripact_a3_paysage_projectdocument.modules.php

## Issue
#4727