### PR TITLE
#4729 [Ticket] fix: prevent fatal in printFieldListValue when service is empty

### DIFF
--- a/class/actions_digiriskdolibarr.class.php
+++ b/class/actions_digiriskdolibarr.class.php
@@ -1341,7 +1341,10 @@ class ActionsDigiriskdolibarr
             </script>
             <?php
 
-            $serviceId = $parameters['obj']->options_digiriskdolibarr_ticket_service;
+            $serviceId = (int) ($parameters['obj']->options_digiriskdolibarr_ticket_service ?? 0);
+            if ($serviceId <= 0) {
+                return 0;
+            }
 
             $digiriskelement = new DigiriskElement($db);
             $res = $digiriskelement->fetch($serviceId);


### PR DESCRIPTION
Closes #4729

## Summary
- Cast `options_digiriskdolibarr_ticket_service` to `int` with a `0` fallback and bail out of the hook when no service is attached, so `DigiriskElement::fetch()` (strict `int` signature from `SaturneObject`) is no longer called with `null`.
- Fixes the fatal that broke the ticket list as soon as a row had no Digirisk service set.

## Test plan
- [ ] Open the ticket list with a mix of tickets having and not having a Digirisk service → the list renders fully (no fatal)
- [ ] On a ticket with a service set, the service link still appears in the dedicated column
- [ ] On a ticket without a service, the column stays empty (no error in the page or in the JS console)