### PR TITLE
#4753 [Ticket] feat: kanban picker 4 onglets + edition inline

### DIFF
--- a/core/tpl/ticket/ticket_action_card_picker.tpl.php
+++ b/core/tpl/ticket/ticket_action_card_picker.tpl.php
@@ -12,16 +12,27 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 /**
  * \file    core/tpl/ticket/ticket_action_card_picker.tpl.php
  * \ingroup digiriskdolibarr
- * \brief   Picker shown when ticket_action_card.php is opened without an id/track_id.
+ * \brief   Kanban picker with 3 classification tabs (Type, Groupe, Sévérité).
+ *          Each tab shows a drag-and-drop kanban whose columns correspond to
+ *          the values in the respective ticket dictionary.
  *
- * The following vars must be defined before include:
- *   $db, $langs, $user
+ * Variables expected from ticket_action_card.php:
+ *   $conf, $db, $langs, $user
+ *   $pickerAllUsers           array  Active internal users
+ *   $pickerAllCategories      array  All ticket tag categories
+ *   $pickerTicketsJson        array  All ticket data (flat)
+ *   $pickerTypeColumns        array  Column defs for Type dimension
+ *   $pickerTypeTickets        array  Tickets grouped by type_code
+ *   $pickerGroupColumns       array  Column defs for Group dimension
+ *   $pickerGroupTickets       array  Tickets grouped by category_code
+ *   $pickerSeverityColumns    array  Column defs for Severity dimension
+ *   $pickerSeverityTickets    array  Tickets grouped by severity_code
  */
 
 if (empty($conf) || empty($db) || empty($langs) || empty($user)) {
@@ -29,69 +40,237 @@ if (empty($conf) || empty($db) || empty($langs) || empty($user)) {
     exit;
 }
 
-require_once DOL_DOCUMENT_ROOT . '/ticket/class/ticket.class.php';
+/**
+ * Render a single kanban board for one dimension.
+ *
+ * @param  array  $columns     Column definitions  [code => [label, icon, color]]
+ * @param  array  $colTickets  Tickets per column  [code => [ticket data, ...]]
+ * @param  string $dim         Dimension key: 'type', 'group', 'severity'
+ * @param  array  $allUsers    All active users (for assignee select)
+ * @param  array  $allCats     All tag categories
+ * @param  array  $allSevCols  Severity column definitions (for inline severity select)
+ * @param  object $langs       $langs global
+ * @return void
+ */
+function renderDimKanban($columns, $colTickets, $dim, $allUsers, $allCats, $allSevCols, $langs)
+{
+    $sevColors = [
+        'LOW'      => ['bg' => '#e9ecef', 'text' => '#495057'],
+        'NORMAL'   => ['bg' => '#cfe2ff', 'text' => '#0a58ca'],
+        'HIGH'     => ['bg' => '#fff3cd', 'text' => '#664d03'],
+        'BLOCKING' => ['bg' => '#f8d7da', 'text' => '#842029'],
+    ];
 
-// User's watchlist (CSV of ticket ids stored in llx_user_param) for the "watched" filter + star.
-$rawWatchList = $user->conf->DIGIRISK_TICKET_WATCHLIST ?? '';
-$watchSet     = array_flip(array_filter(array_map('intval', explode(',', (string) $rawWatchList))));
-$showOnlyWatched = (GETPOST('watched', 'aZ09') === '1');
+    echo '<div class="kanban-board tac-picker-kanban-board tac-picker-kanban-' . dol_escape_htmltag($dim) . '" '
+        . 'data-dim="' . dol_escape_htmltag($dim) . '" '
+        . 'data-token="' . newToken() . '">';
 
-// Open tickets only.
-$pickerTicket = new Ticket($db);
-$filter       = [
-    't.fk_statut' => [
-        Ticket::STATUS_NOT_READ,
-        Ticket::STATUS_READ,
-        Ticket::STATUS_ASSIGNED,
-        Ticket::STATUS_IN_PROGRESS,
-        Ticket::STATUS_NEED_MORE_INFO,
-        Ticket::STATUS_WAITING,
-    ],
-];
-$pickerTicket->fetchAll($user, 'DESC', 't.datec', 50, 0, 0, $filter);
+    foreach ($columns as $colCode => $colDef) {
+        $colTicketList = $colTickets[$colCode] ?? [];
+        $safeCode = dol_escape_htmltag((string) $colCode);
+        $safeColor = dol_escape_htmltag($colDef['color']);
+        ?>
+        <div class="kanban-column tac-picker-column" data-dim-value="<?= $safeCode ?>">
+            <div class="kanban-column-header" style="border-top: 3px solid <?= $safeColor ?>">
+                <span class="kanban-column-icon"><i class="fas <?= dol_escape_htmltag($colDef['icon']) ?>"></i></span>
+                <span class="kanban-column-title"><?= dol_escape_htmltag($colDef['label']) ?></span>
+                <span class="kanban-column-count"><?= count($colTicketList) ?></span>
+            </div>
+            <div class="kanban-column-body kanban-picker-sortable" data-dim="<?= dol_escape_htmltag($dim) ?>" data-dim-value="<?= $safeCode ?>">
+                <?php if (empty($colTicketList)) : ?>
+                    <div class="kanban-empty"><?= $langs->trans('NoTickets') ?></div>
+                <?php endif; ?>
 
-// Restrict to watched tickets when the toggle is on.
-$tickets = is_array($pickerTicket->lines) ? $pickerTicket->lines : [];
-if ($showOnlyWatched) {
-    $tickets = array_filter($tickets, static fn($t) => isset($watchSet[(int) $t->id]));
-}
+                <?php foreach ($colTicketList as $t) :
+                    $sevKey = strtoupper((string) $t['severity_code']);
+                    $sevBg   = $sevColors[$sevKey]['bg']   ?? '';
+                    $sevText = $sevColors[$sevKey]['text']  ?? '';
+                ?>
+                    <?php
+                    $dimFieldMap   = ['type' => 'type_code', 'group' => 'category_code', 'severity' => 'severity_code', 'status' => 'status'];
+                    $dimValueField = $dimFieldMap[$dim] ?? 'status';
+                    ?>
+                    <div class="kanban-card tac-picker-card"
+                         data-ticket-id="<?= (int) $t['id'] ?>"
+                         data-dim-value="<?= dol_escape_htmltag((string) $t[$dimValueField]) ?>">
 
-$watchedCount = count($watchSet);
+                        <div class="kanban-card-header">
+                            <a href="<?= dol_escape_htmltag($t['url']) ?>" class="kanban-card-ref"><?= dol_escape_htmltag($t['ref']) ?></a>
 
-print load_fiche_titre($langs->trans('TicketActionCard'), '', 'ticket');
+                            <?php if (!empty($t['severity_code']) && !empty($sevBg)) : ?>
+                                <span class="tac-picker-card__severity tac-picker-sev-badge"
+                                      style="background:<?= $sevBg ?>;color:<?= $sevText ?>"
+                                      data-ticket-id="<?= (int) $t['id'] ?>"
+                                      data-severity-code="<?= dol_escape_htmltag($t['severity_code']) ?>">
+                                    <?= dol_escape_htmltag($t['severity_label'] ?? $t['severity_code']) ?>
+                                </span>
+                                <select class="tac-picker-sev-inline-select" data-ticket-id="<?= (int) $t['id'] ?>">
+                                    <?php foreach ($allSevCols as $sevColCode => $sevColDef) :
+                                        if ($sevColCode === '__none__') { continue; }
+                                    ?>
+                                        <option value="<?= dol_escape_htmltag($sevColCode) ?>" <?= ($t['severity_code'] === $sevColCode) ? 'selected' : '' ?>>
+                                            <?= dol_escape_htmltag($sevColDef['label']) ?>
+                                        </option>
+                                    <?php endforeach; ?>
+                                </select>
+                            <?php endif; ?>
 
-print '<div class="ticket-action-picker">';
-print '<p class="opacitymedium">' . $langs->trans('TicketActionCardPickerIntro') . '</p>';
+                            <?php if (!empty($t['company_name'])) : ?>
+                                <span class="tac-picker-card__company" title="<?= dol_escape_htmltag($t['company_name']) ?>">
+                                    <i class="fas fa-building"></i> <?= dol_escape_htmltag(dol_trunc($t['company_name'], 18)) ?>
+                                </span>
+                            <?php endif; ?>
 
-// Filter toolbar: Tous / Suivis seulement.
-$baseUrl  = dol_buildpath('/custom/digiriskdolibarr/view/ticket/ticket_action_card.php', 1);
-$allUrl   = $baseUrl;
-$watchUrl = $baseUrl . '?watched=1';
-print '<div class="ticket-action-picker-toolbar">';
-print '<a class="ticket-action-picker-toolbar__btn' . (!$showOnlyWatched ? ' is-active' : '') . '" href="' . dol_escape_htmltag($allUrl) . '">'
-    . $langs->trans('AllTickets') . '</a>';
-print '<a class="ticket-action-picker-toolbar__btn' . ($showOnlyWatched ? ' is-active' : '') . '" href="' . dol_escape_htmltag($watchUrl) . '">'
-    . '<i class="fas fa-star"></i> ' . $langs->trans('WatchedOnly') . ' (' . (int) $watchedCount . ')</a>';
-print '</div>';
+                            <?php if (!empty($t['date_c'])) : ?>
+                                <span class="tac-picker-card__date">
+                                    <i class="fas fa-calendar-alt"></i> <?= dol_escape_htmltag($t['date_c']) ?>
+                                </span>
+                            <?php endif; ?>
+                        </div>
 
-if (!empty($tickets)) {
-    print '<div class="ticket-action-picker-grid">';
-    foreach ($tickets as $tkt) {
-        $url = $baseUrl . '?id=' . (int) $tkt->id;
-        $isWatched = isset($watchSet[(int) $tkt->id]);
+                        <div class="kanban-card-label">
+                            <span class="tac-picker-card__subject-text"
+                                  contenteditable="true"
+                                  data-ticket-id="<?= (int) $t['id'] ?>"><?= dol_escape_htmltag($t['subject']) ?></span>
+                            <a href="<?= dol_escape_htmltag($t['url']) ?>" class="tac-picker-card__subject-link" title="<?= dol_escape_htmltag($langs->trans('OpenTicket') !== 'OpenTicket' ? $langs->trans('OpenTicket') : 'Ouvrir') ?>">
+                                <i class="fas fa-external-link-alt"></i>
+                            </a>
+                        </div>
 
-        print '<a class="ticket-action-picker-item' . ($isWatched ? ' ticket-action-picker-item--watched' : '') . '" href="' . dol_escape_htmltag($url) . '">';
-        if ($isWatched) {
-            print '<i class="fas fa-star ticket-action-picker-item__star" title="' . dol_escape_htmltag($langs->trans('WatchedTicket')) . '"></i>';
-        }
-        print '<div class="ticket-action-picker-item__ref">' . dol_escape_htmltag($tkt->ref) . '</div>';
-        print '<div class="ticket-action-picker-item__subject">' . dol_escape_htmltag(dol_trunc((string) $tkt->subject, 80)) . '</div>';
-        print '<div class="ticket-action-picker-item__status">' . $tkt->getLibStatut(2) . '</div>';
-        print '</a>';
+                        <div class="kanban-card-contacts">
+                            <div class="kanban-responsible-wrapper" data-ticket-id="<?= (int) $t['id'] ?>" data-current-user="<?= (int) $t['assign_id'] ?>">
+                                <?php
+                                $hasAssign = $t['assign_id'] > 0;
+                                ?>
+                                <?php if (!empty($t['assign_photo'])) : ?>
+                                    <img class="kanban-initial kanban-initial-responsible tac-picker-card__assignee-img"
+                                         src="<?= dol_escape_htmltag($t['assign_photo']) ?>"
+                                         alt="<?= dol_escape_htmltag($t['assign_initials']) ?>"
+                                         title="<?= dol_escape_htmltag($t['assign_fullname']) ?>"
+                                         style="background:<?= dol_escape_htmltag($colDef['color']) ?>">
+                                <?php else : ?>
+                                    <span class="kanban-initial kanban-initial-responsible<?= !$hasAssign ? ' kanban-initial-empty' : '' ?>"
+                                          title="<?= dol_escape_htmltag($hasAssign ? $t['assign_fullname'] : $langs->trans('Unassigned')) ?>"
+                                          style="background:<?= dol_escape_htmltag($colDef['color']) ?>">
+                                        <?= dol_escape_htmltag($hasAssign ? $t['assign_initials'] : '?') ?>
+                                    </span>
+                                <?php endif; ?>
+
+                                <select class="kanban-responsible-select tac-picker-assignee-select" data-ticket-id="<?= (int) $t['id'] ?>">
+                                    <option value="0"><?= dol_escape_htmltag($langs->trans('Unassigned')) ?></option>
+                                    <?php foreach ($allUsers as $u) : ?>
+                                        <option value="<?= (int) $u['id'] ?>"
+                                                data-initial="<?= dol_escape_htmltag($u['initials']) ?>"
+                                                data-photo="<?= dol_escape_htmltag($u['photo']) ?>"
+                                                <?= ($t['assign_id'] == $u['id']) ? 'selected' : '' ?>>
+                                            <?= dol_escape_htmltag($u['fullname']) ?>
+                                        </option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </div>
+                        </div>
+
+                        <div class="kanban-card-tags" data-ticket-id="<?= (int) $t['id'] ?>">
+                            <?php foreach ($t['categories'] as $cat) :
+                                $tagBg = !empty($cat['color']) ? '#' . dol_escape_htmltag($cat['color']) : '#8c8c8c';
+                            ?>
+                                <span class="kanban-tag" data-cat-id="<?= (int) $cat['id'] ?>" style="background:<?= $tagBg ?>">
+                                    <?= dol_escape_htmltag($cat['label']) ?>
+                                    <span class="kanban-tag-remove" title="<?= dol_escape_htmltag($langs->trans('Remove')) ?>">&times;</span>
+                                </span>
+                            <?php endforeach; ?>
+
+                            <div class="kanban-tag-dropdown-wrapper">
+                                <button class="kanban-add-tag-btn" title="<?= dol_escape_htmltag($langs->trans('AddCategory')) ?>">
+                                    <i class="fas fa-tag"></i><i class="fas fa-plus" style="font-size:7px;margin-left:1px"></i>
+                                </button>
+                                <?php $assignedCatIds = array_column($t['categories'], 'id'); ?>
+                                <div class="kanban-tag-dropdown" data-ticket-id="<?= (int) $t['id'] ?>">
+                                    <?php foreach ($allCats as $ac) :
+                                        $isAssigned = in_array($ac['id'], $assignedCatIds);
+                                        $dotColor   = !empty($ac['color']) ? '#' . dol_escape_htmltag($ac['color']) : '#8c8c8c';
+                                    ?>
+                                        <div class="kanban-tag-option<?= $isAssigned ? ' assigned' : '' ?>"
+                                             data-value="<?= (int) $ac['id'] ?>"
+                                             data-color="<?= dol_escape_htmltag($ac['color']) ?>">
+                                            <span class="kanban-tag-dot" style="background:<?= $dotColor ?>"></span>
+                                            <?= dol_escape_htmltag($ac['label']) ?>
+                                            <?php if ($isAssigned) : ?>
+                                                <i class="fas fa-check" style="margin-left:auto;font-size:9px;color:#28a745"></i>
+                                            <?php endif; ?>
+                                        </div>
+                                    <?php endforeach; ?>
+                                </div>
+                            </div>
+                        </div>
+
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        </div>
+        <?php
     }
-    print '</div>';
-} else {
-    print '<div class="opacitymedium center">' . $langs->trans($showOnlyWatched ? 'NoWatchedTicket' : 'NoTicketOpen') . '</div>';
-}
 
-print '</div>';
+    echo '</div>'; // .tac-picker-kanban-board
+}
+?>
+
+<div class="tac-picker-wrapper">
+
+    <!-- Settings popover (shared across all tabs) -->
+    <div class="kanban-settings-wrapper">
+        <button type="button" class="kanban-settings-btn" id="kanbanPickerSettingsBtn" title="<?= dol_escape_htmltag($langs->trans('Settings')) ?>">
+            <i class="fas fa-cog"></i>
+        </button>
+        <div class="kanban-settings-popover" id="kanbanPickerSettingsPopover">
+            <div class="ksp-row">
+                <label><i class="fas fa-arrows-alt-h"></i> <?= $langs->trans('ColumnWidth') ?></label>
+                <input type="range" id="kanbanPickerColWidth" min="220" max="500" value="300" step="10">
+                <span class="ksp-val" id="kanbanPickerColWidthVal">300px</span>
+            </div>
+            <div class="ksp-row">
+                <label><i class="fas fa-columns"></i> <?= $langs->trans('ColumnGap') ?></label>
+                <input type="range" id="kanbanPickerColGap" min="8" max="50" value="16" step="2">
+                <span class="ksp-val" id="kanbanPickerColGapVal">16px</span>
+            </div>
+        </div>
+    </div>
+
+    <!-- Tab navigation -->
+    <div class="tac-dim-tabs" id="tacDimTabs">
+        <button class="tac-dim-tab active" data-dim="status">
+            <i class="fas fa-list-ol"></i> <?= $langs->trans('Status') ?>
+        </button>
+        <button class="tac-dim-tab" data-dim="type">
+            <i class="fas fa-tag"></i> <?= $langs->trans('Type') ?>
+        </button>
+        <button class="tac-dim-tab" data-dim="group">
+            <i class="fas fa-folder"></i> <?= $langs->trans('TicketCategory') ?>
+        </button>
+        <button class="tac-dim-tab" data-dim="severity">
+            <i class="fas fa-exclamation-triangle"></i> <?= $langs->trans('Severity') ?>
+        </button>
+    </div>
+
+    <!-- Board panels -->
+    <div class="tac-dim-panels" id="tacDimPanels">
+
+        <div class="tac-dim-panel active" data-dim="status">
+            <?php renderDimKanban($pickerStatusColumns, $pickerStatusTickets, 'status', $pickerAllUsers, $pickerAllCategories, $pickerSeverityColumns, $langs); ?>
+        </div>
+
+        <div class="tac-dim-panel" data-dim="type">
+            <?php renderDimKanban($pickerTypeColumns, $pickerTypeTickets, 'type', $pickerAllUsers, $pickerAllCategories, $pickerSeverityColumns, $langs); ?>
+        </div>
+
+        <div class="tac-dim-panel" data-dim="group">
+            <?php renderDimKanban($pickerGroupColumns, $pickerGroupTickets, 'group', $pickerAllUsers, $pickerAllCategories, $pickerSeverityColumns, $langs); ?>
+        </div>
+
+        <div class="tac-dim-panel" data-dim="severity">
+            <?php renderDimKanban($pickerSeverityColumns, $pickerSeverityTickets, 'severity', $pickerAllUsers, $pickerAllCategories, $pickerSeverityColumns, $langs); ?>
+        </div>
+
+    </div>
+
+</div>

--- a/css/scss/page/_page-ticket-action-card.scss
+++ b/css/scss/page/_page-ticket-action-card.scss
@@ -1736,3 +1736,217 @@ $tac-border:       #e5e7eb;
 .ticket-action-tile {
     // Empty placeholder, real styles live under .tac-sticky-bar__btn above.
 }
+
+// ---------------------------------------------------------------------------
+// Kanban picker board — ticket_action_card.php without a selected ticket.
+// Reuses all .kanban-* base rules from _page-actionplan.scss.
+// Only ticket-specific additions live here.
+// ---------------------------------------------------------------------------
+
+.tac-picker-kanban-board {
+    // Slightly narrower default column than actionplan (tickets have fewer meta fields).
+    .tac-picker-column {
+        min-width: 260px;
+        max-width: 300px;
+    }
+}
+
+// Severity badge inside a kanban card (inline pill, no icon).
+.tac-picker-card__severity {
+    font-size: 9px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    padding: 1px 6px;
+    border-radius: 4px;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+// Company name inside a kanban card header.
+.tac-picker-card__company {
+    font-size: 10px;
+    color: #6a7491;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100px;
+
+    i { margin-right: 2px; }
+}
+
+// Creation date inside a kanban card header.
+.tac-picker-card__date {
+    font-size: 10px;
+    color: #aaa;
+    white-space: nowrap;
+    margin-left: auto;
+
+    i { margin-right: 2px; }
+}
+
+// Subject link — looks like plain text but navigates on click.
+.tac-picker-card__subject-link {
+    color: inherit;
+    text-decoration: none;
+
+    &:hover {
+        color: $tac-blue;
+        text-decoration: underline;
+    }
+}
+
+// Photo avatar in the assignee slot.
+.tac-picker-card__assignee-img {
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    object-fit: cover;
+    cursor: pointer;
+    border: 2px solid #fff;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+
+    &:hover {
+        transform: scale(1.15);
+        box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.3);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Picker wrapper — outer container holding tabs + boards.
+// ---------------------------------------------------------------------------
+.tac-picker-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    position: relative;
+}
+
+// ---------------------------------------------------------------------------
+// Dimension tab bar.
+// ---------------------------------------------------------------------------
+.tac-dim-tabs {
+    display: flex;
+    gap: 4px;
+    padding: 0 0 0 2px;
+    margin-bottom: 12px;
+    border-bottom: 2px solid #e2e6ea;
+}
+
+.tac-dim-tab {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 7px 16px 8px;
+    background: none;
+    border: none;
+    border-bottom: 3px solid transparent;
+    margin-bottom: -2px;
+    font-size: 13px;
+    font-weight: 500;
+    color: #6c757d;
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s;
+
+    i { font-size: 11px; }
+
+    &:hover {
+        color: $tac-blue;
+    }
+
+    &.active {
+        color: $tac-blue;
+        border-bottom-color: $tac-blue;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Dimension panels — only the active panel is shown.
+// ---------------------------------------------------------------------------
+.tac-dim-panels {
+    flex: 1;
+}
+
+.tac-dim-panel {
+    display: none;
+
+    &.active {
+        display: block;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Subject contenteditable on picker kanban cards.
+// ---------------------------------------------------------------------------
+
+// Card label — flex row so the icon sits at end.
+.tac-picker-kanban-board .kanban-card-label {
+    display: flex;
+    align-items: baseline;
+    gap: 4px;
+}
+
+// Contenteditable subject span: truncated at rest, expanded when focused.
+.tac-picker-card__subject-text {
+    flex: 1 1 0;
+    min-width: 0;
+    display: block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    cursor: text;
+    border-radius: 3px;
+    padding: 1px 3px;
+    margin: -1px -3px;
+    outline: none;
+    transition: background 0.12s ease, box-shadow 0.12s ease;
+
+    &:hover {
+        background: rgba(13, 138, 255, 0.05);
+    }
+
+    &:focus,
+    &.tac-picker-subject--editing {
+        white-space: pre-wrap;
+        overflow: visible;
+        word-break: break-word;
+        background: #fff;
+        box-shadow: 0 0 0 2px $tac-blue;
+    }
+}
+
+// External link icon — never shown in the label area.
+.tac-picker-kanban-board .tac-picker-card__subject-link {
+    display: none;
+}
+
+// ---------------------------------------------------------------------------
+// Severity badge inline select on picker kanban cards.
+// ---------------------------------------------------------------------------
+
+// Severity badge becomes a click target.
+.tac-picker-sev-badge {
+    cursor: pointer;
+    transition: opacity 0.1s ease;
+
+    &:hover { opacity: 0.75; }
+}
+
+// Inline select — hidden by default, shown when badge is clicked.
+.tac-picker-sev-inline-select {
+    display: none;
+    padding: 2px 4px;
+    font-size: 0.82em;
+    font-family: inherit;
+    border: 1px solid $tac-blue;
+    border-radius: 4px;
+    background: #fff;
+    color: #1f2937;
+    cursor: pointer;
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(13, 138, 255, 0.15);
+    max-width: 120px;
+
+    &.visible { display: inline-block; }
+}

--- a/js/modules/actionplan_kanban.js
+++ b/js/modules/actionplan_kanban.js
@@ -9,6 +9,9 @@ window.digiriskdolibarr.actionplanKanban = {};
  * Init — auto-called by saturne.js on document.ready
  */
 window.digiriskdolibarr.actionplanKanban.init = function() {
+    if (!$('.actionplan-kanban-board').length) {
+        return;
+    }
     window.digiriskdolibarr.actionplanKanban.event();
     window.digiriskdolibarr.actionplanKanban.initSortable();
     window.digiriskdolibarr.actionplanKanban.initSettings();

--- a/js/modules/ticket_action_card.js
+++ b/js/modules/ticket_action_card.js
@@ -1659,3 +1659,615 @@ window.digiriskdolibarr.ticketActionCard.flash = function($card, message, kind) 
     $toast.removeClass('is-error is-success').addClass('is-' + kind).text(message);
     setTimeout(function() { $toast.text(''); $toast.removeClass('is-error is-success'); }, 2500);
 };
+
+/* ============================================================
+ * KANBAN PICKER — ticket_action_card.php picker view
+ * Three dimension tabs: Type / Group / Severity.
+ * ============================================================ */
+
+window.digiriskdolibarr.ticketPickerKanban = {};
+
+/**
+ * Auto-invoked by digiriskdolibarr.js on document.ready.
+ *
+ * @return {void}
+ */
+window.digiriskdolibarr.ticketPickerKanban.init = function() {
+    if (!$('.tac-picker-kanban-board').length) {
+        return;
+    }
+    window.digiriskdolibarr.ticketPickerKanban.event();
+    window.digiriskdolibarr.ticketPickerKanban.initSortable();
+    window.digiriskdolibarr.ticketPickerKanban.initSettings();
+
+    // Restore the last active tab from localStorage.
+    var savedDim = localStorage.getItem('tacPickerActiveDim');
+    if (savedDim && $('#tacDimTabs .tac-dim-tab[data-dim="' + savedDim + '"]').length) {
+        $('#tacDimTabs .tac-dim-tab').removeClass('active');
+        $('#tacDimTabs .tac-dim-tab[data-dim="' + savedDim + '"]').addClass('active');
+        $('#tacDimPanels .tac-dim-panel').removeClass('active');
+        $('#tacDimPanels .tac-dim-panel[data-dim="' + savedDim + '"]').addClass('active');
+    }
+};
+
+/**
+ * Register delegated events for the kanban picker.
+ *
+ * @return {void}
+ */
+window.digiriskdolibarr.ticketPickerKanban.event = function() {
+    // Assignee initial: click → show select
+    $(document).on('click', '.tac-picker-kanban-board .kanban-initial-responsible, .tac-picker-kanban-board .tac-picker-card__assignee-img', function(e) {
+        e.stopPropagation();
+        var $wrapper = $(this).closest('.kanban-responsible-wrapper');
+        var $select  = $wrapper.find('.tac-picker-assignee-select');
+        $(this).hide();
+        $select.addClass('visible').trigger('focus');
+    });
+
+    // Assignee select: change → save + hide select → update avatar
+    $(document).on('change', '.tac-picker-assignee-select', function() {
+        var $select  = $(this);
+        var $wrapper = $select.closest('.kanban-responsible-wrapper');
+        var $avatar  = $wrapper.find('.kanban-initial-responsible, .tac-picker-card__assignee-img');
+        var ticketId = $select.data('ticket-id');
+        var userId   = parseInt($select.val(), 10);
+        var selOpt   = $select.find('option:selected');
+        var newInit  = userId > 0 ? (selOpt.data('initial') || selOpt.text().substring(0, 2).toUpperCase()) : '?';
+        var photo    = userId > 0 ? (selOpt.data('photo') || '') : '';
+
+        $select.removeClass('visible');
+
+        if (photo) {
+            $avatar.attr('src', photo).attr('title', selOpt.text().trim()).show();
+        } else {
+            $avatar.text(newInit)
+                   .attr('title', userId > 0 ? selOpt.text().trim() : '')
+                   .toggleClass('kanban-initial-empty', userId === 0)
+                   .show();
+        }
+
+        window.digiriskdolibarr.ticketPickerKanban.saveAssignee(ticketId, userId, $select);
+    });
+
+    // Assignee select blur → hide
+    $(document).on('blur', '.tac-picker-assignee-select', function() {
+        var $select = $(this);
+        var $avatar = $select.siblings('.kanban-initial-responsible, .tac-picker-card__assignee-img');
+        setTimeout(function() {
+            $select.removeClass('visible');
+            $avatar.show();
+        }, 200);
+    });
+
+    // Prevent card drag when touching the assignee controls
+    $(document).on('mousedown', '.tac-picker-assignee-select, .tac-picker-card__assignee-img, .kanban-responsible-wrapper', function(e) {
+        e.stopPropagation();
+    });
+
+    // Tag: toggle dropdown
+    $(document).on('click', '.tac-picker-kanban-board .kanban-add-tag-btn', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        $('.tac-picker-kanban-board .kanban-tag-dropdown.visible')
+            .not($(this).siblings('.kanban-tag-dropdown'))
+            .each(function() {
+                $(this).removeClass('visible');
+                $(this).closest('.tac-picker-card').removeClass('kanban-card-dropdown-open');
+            });
+        var $dropdown = $(this).siblings('.kanban-tag-dropdown');
+        var $card = $(this).closest('.tac-picker-card');
+        $dropdown.toggleClass('visible');
+        $card.toggleClass('kanban-card-dropdown-open', $dropdown.hasClass('visible'));
+    });
+
+    // Tag option click: add category
+    $(document).on('click', '.tac-picker-kanban-board .kanban-tag-option', function(e) {
+        e.stopPropagation();
+        var $opt = $(this);
+        if ($opt.hasClass('assigned')) {
+            return;
+        }
+        var $dropdown = $opt.closest('.kanban-tag-dropdown');
+        var ticketId  = $dropdown.data('ticket-id');
+        var catId     = $opt.data('value');
+        var $card     = $opt.closest('.tac-picker-card');
+        var $tagsRow  = $card.find('.kanban-card-tags');
+
+        $dropdown.removeClass('visible');
+        $card.removeClass('kanban-card-dropdown-open');
+
+        window.digiriskdolibarr.ticketPickerKanban.saveTagAdd(ticketId, catId, $opt, $tagsRow, $card);
+    });
+
+    // Close tag dropdown on outside click
+    $(document).on('click', function() {
+        $('.tac-picker-kanban-board .kanban-tag-dropdown.visible').each(function() {
+            $(this).removeClass('visible');
+            $(this).closest('.tac-picker-card').removeClass('kanban-card-dropdown-open');
+        });
+    });
+    $(document).on('click', '.tac-picker-kanban-board .kanban-tag-dropdown', function(e) {
+        e.stopPropagation();
+    });
+
+    // Tag remove
+    $(document).on('click', '.tac-picker-kanban-board .kanban-tag-remove', function(e) {
+        e.stopPropagation();
+        var $tag     = $(this).closest('.kanban-tag');
+        var catId    = $tag.data('cat-id');
+        var $card    = $tag.closest('.tac-picker-card');
+        var ticketId = $card.data('ticket-id');
+
+        $tag.css('opacity', '0.4');
+        window.digiriskdolibarr.ticketPickerKanban.saveTagRemove(ticketId, catId, $tag, $card);
+    });
+
+    // Prevent drag on tag elements
+    $(document).on('mousedown', '.tac-picker-kanban-board .kanban-tag, .tac-picker-kanban-board .kanban-tag-remove, .tac-picker-kanban-board .kanban-add-tag-btn, .tac-picker-kanban-board .kanban-tag-dropdown, .tac-picker-kanban-board .kanban-tag-option', function(e) {
+        e.stopPropagation();
+    });
+
+    // Tab switching — persist active dim in localStorage so F5 keeps the current tab.
+    $(document).on('click', '#tacDimTabs .tac-dim-tab', function() {
+        var dim = $(this).data('dim');
+        $('#tacDimTabs .tac-dim-tab').removeClass('active');
+        $(this).addClass('active');
+        $('#tacDimPanels .tac-dim-panel').removeClass('active');
+        $('#tacDimPanels .tac-dim-panel[data-dim="' + dim + '"]').addClass('active');
+        localStorage.setItem('tacPickerActiveDim', dim);
+    });
+
+    // Subject: focus on contenteditable span → store original for rollback.
+    $(document).on('focus', '.tac-picker-kanban-board .tac-picker-card__subject-text', function() {
+        var $span = $(this);
+        $span.data('editOriginal', this.innerText || $span.text());
+        $span.addClass('tac-picker-subject--editing');
+        // Select all text so user can replace immediately.
+        var el = this;
+        setTimeout(function() {
+            var range = document.createRange();
+            range.selectNodeContents(el);
+            var sel = window.getSelection();
+            sel.removeAllRanges();
+            sel.addRange(range);
+        }, 0);
+    });
+
+    // Subject: Enter saves, Escape restores.
+    $(document).on('keydown', '.tac-picker-kanban-board .tac-picker-card__subject-text', function(e) {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            this.blur();
+        }
+        if (e.key === 'Escape') {
+            e.preventDefault();
+            var original = $(this).data('editOriginal') || '';
+            this.textContent = original;
+            this.blur();
+        }
+    });
+
+    // Subject: plain-text paste only.
+    $(document).on('paste', '.tac-picker-kanban-board .tac-picker-card__subject-text', function(e) {
+        e.preventDefault();
+        var text = (e.originalEvent.clipboardData || window.clipboardData).getData('text/plain');
+        var sel  = window.getSelection();
+        if (sel.rangeCount) {
+            var range = sel.getRangeAt(0);
+            range.deleteContents();
+            range.insertNode(document.createTextNode(text));
+            range.collapse(false);
+            sel.removeAllRanges();
+            sel.addRange(range);
+        }
+    });
+
+    // Subject: blur → save if changed.
+    $(document).on('blur', '.tac-picker-kanban-board .tac-picker-card__subject-text', function() {
+        var $span      = $(this);
+        $span.removeClass('tac-picker-subject--editing');
+        var newSubject = $.trim(this.innerText || this.textContent || '');
+        var original   = $span.data('editOriginal') || '';
+        var ticketId   = $span.data('ticket-id');
+
+        if (!newSubject) {
+            this.textContent = original;
+            return;
+        }
+        if (newSubject === original) {
+            return;
+        }
+
+        var $card = $span.closest('.tac-picker-card');
+        window.digiriskdolibarr.ticketPickerKanban.saveSubject(ticketId, newSubject, $span, original, $card);
+    });
+
+    // Prevent drag when clicking the subject text.
+    $(document).on('mousedown', '.tac-picker-kanban-board .tac-picker-card__subject-text', function(e) {
+        e.stopPropagation();
+    });
+
+    // Severity badge click → show inline select.
+    $(document).on('click', '.tac-picker-kanban-board .tac-picker-sev-badge', function(e) {
+        e.stopPropagation();
+        var $badge  = $(this);
+        var $card   = $badge.closest('.tac-picker-card');
+        var $select = $card.find('.tac-picker-sev-inline-select');
+
+        $badge.hide();
+        $select.addClass('visible').trigger('focus');
+    });
+
+    // Severity inline select change → save + update badge.
+    $(document).on('change', '.tac-picker-kanban-board .tac-picker-sev-inline-select', function() {
+        var $select  = $(this);
+        var $card    = $select.closest('.tac-picker-card');
+        var $badge   = $card.find('.tac-picker-sev-badge');
+        var ticketId = $select.data('ticket-id');
+        var newVal   = $select.val();
+        var selText  = $select.find('option:selected').text().trim();
+
+        $select.removeClass('visible');
+
+        var sevColors = {
+            'LOW':      {bg: '#e9ecef', text: '#495057'},
+            'NORMAL':   {bg: '#cfe2ff', text: '#0a58ca'},
+            'HIGH':     {bg: '#fff3cd', text: '#664d03'},
+            'BLOCKING': {bg: '#f8d7da', text: '#842029'}
+        };
+        var col = sevColors[(newVal || '').toUpperCase()] || {bg: '#e9ecef', text: '#495057'};
+
+        $badge.css({'background': col.bg, 'color': col.text}).text(selText).show();
+        $badge.attr('data-severity-code', newVal);
+
+        window.digiriskdolibarr.ticketPickerKanban.saveDim(ticketId, 'severity', newVal || '__none__', $card);
+    });
+
+    // Severity inline select blur → restore badge.
+    $(document).on('blur', '.tac-picker-kanban-board .tac-picker-sev-inline-select', function() {
+        var $select = $(this);
+        var $badge  = $select.closest('.tac-picker-card').find('.tac-picker-sev-badge');
+        setTimeout(function() {
+            if ($select.hasClass('visible')) {
+                $select.removeClass('visible');
+                $badge.show();
+            }
+        }, 200);
+    });
+
+    // Prevent drag when clicking severity badge or select.
+    $(document).on('mousedown', '.tac-picker-kanban-board .tac-picker-sev-badge, .tac-picker-kanban-board .tac-picker-sev-inline-select', function(e) {
+        e.stopPropagation();
+    });
+};
+
+/**
+ * Initialize jQuery UI Sortable for all three dimension kanban boards.
+ * Each board's column bodies use the class kanban-picker-sortable and
+ * are connected only within the same board (same data-dim value).
+ *
+ * @return {void}
+ */
+window.digiriskdolibarr.ticketPickerKanban.initSortable = function() {
+    if (!$('.kanban-picker-sortable').length) {
+        return;
+    }
+
+    var dims = ['status', 'type', 'group', 'severity'];
+    var actionMap = {
+        status:   'updateTicketStatus',
+        type:     'updateTicketType',
+        group:    'updateTicketGroup',
+        severity: 'updateTicketSeverity'
+    };
+    var cancelSel = '.kanban-responsible-wrapper, .tac-picker-assignee-select, .kanban-tag, '
+        + '.kanban-tag-remove, .kanban-add-tag-btn, .kanban-tag-dropdown, .kanban-tag-option, '
+        + '.tac-picker-card__assignee-img, .kanban-initial-responsible, .kanban-card-label, '
+        + '.tac-picker-card__subject-text, .tac-picker-sev-badge, .tac-picker-sev-inline-select';
+
+    $.each(dims, function(i, dim) {
+        var $cols = $('.kanban-picker-sortable[data-dim="' + dim + '"]');
+        if (!$cols.length) {
+            return;
+        }
+        $cols.sortable({
+            connectWith:  '.kanban-picker-sortable[data-dim="' + dim + '"]',
+            placeholder:  'kanban-card-placeholder',
+            tolerance:    'pointer',
+            cursor:       'grabbing',
+            cancel:       cancelSel,
+            receive: function(event, ui) {
+                var $card    = ui.item;
+                var $column  = $(this);
+                var ticketId = $card.data('ticket-id');
+                var newVal   = $column.data('dim-value');
+
+                $card.data('dim-value', newVal);
+
+                $column.find('.kanban-empty').remove();
+
+                var $source = ui.sender;
+                if ($source.children('.tac-picker-card').length === 0) {
+                    $source.append('<div class="kanban-empty">Aucun ticket</div>');
+                }
+
+                window.digiriskdolibarr.ticketPickerKanban.updateCounts();
+                window.digiriskdolibarr.ticketPickerKanban.saveDim(ticketId, dim, newVal, $card);
+            }
+        });
+    });
+};
+
+/**
+ * Update column header counters after a card move.
+ *
+ * @return {void}
+ */
+window.digiriskdolibarr.ticketPickerKanban.updateCounts = function() {
+    $('.tac-picker-column').each(function() {
+        var count = $(this).find('.tac-picker-card').length;
+        $(this).find('.kanban-column-count').text(count);
+    });
+};
+
+/**
+ * AJAX — save a dimension change (type / group / severity) after drag & drop.
+ *
+ * @param {number} ticketId  Ticket row ID
+ * @param {string} dim       Dimension: 'type' | 'group' | 'severity'
+ * @param {string} newVal    New code value for that dimension
+ * @param {jQuery} $card     The card element
+ * @return {void}
+ */
+window.digiriskdolibarr.ticketPickerKanban.saveDim = function(ticketId, dim, newVal, $card) {
+    var token     = window.saturne.toolbox.getToken();
+    var sep       = window.saturne.toolbox.getQuerySeparator(document.URL);
+    var actionMap = {type: 'updateTicketType', group: 'updateTicketGroup', severity: 'updateTicketSeverity'};
+    var action    = actionMap[dim];
+    if (!action) {
+        return;
+    }
+
+    $card.addClass('kanban-card-saving');
+
+    $.ajax({
+        url:      document.URL + sep + 'action=' + action + '&ticket_id=' + ticketId + '&dim_value=' + encodeURIComponent(newVal) + '&token=' + token,
+        type:     'POST',
+        dataType: 'json',
+        success: function(response) {
+            $card.removeClass('kanban-card-saving');
+            if (response.success) {
+                $card.addClass('kanban-card-saved');
+                setTimeout(function() { $card.removeClass('kanban-card-saved'); }, 2000);
+            } else {
+                $card.addClass('kanban-card-error');
+                setTimeout(function() { $card.removeClass('kanban-card-error'); }, 3000);
+            }
+        },
+        error: function() {
+            $card.removeClass('kanban-card-saving');
+            $card.addClass('kanban-card-error');
+            setTimeout(function() { $card.removeClass('kanban-card-error'); }, 3000);
+        }
+    });
+};
+
+/**
+ * AJAX — save new assignee for a ticket card.
+ *
+ * @param {number} ticketId   Ticket row ID
+ * @param {number} userId     User row ID (0 = unassign)
+ * @param {jQuery} $select    The select element
+ * @return {void}
+ */
+window.digiriskdolibarr.ticketPickerKanban.saveAssignee = function(ticketId, userId, $select) {
+    var token = window.saturne.toolbox.getToken();
+    var sep   = window.saturne.toolbox.getQuerySeparator(document.URL);
+    var $card = $select.closest('.tac-picker-card');
+
+    $card.addClass('kanban-card-saving');
+
+    $.ajax({
+        url: document.URL + sep + 'action=updateTicketAssignee&ticket_id=' + ticketId + '&user_id=' + userId + '&token=' + token,
+        type: 'POST',
+        dataType: 'json',
+        success: function(response) {
+            $card.removeClass('kanban-card-saving');
+            if (response.success) {
+                $card.addClass('kanban-card-saved');
+                setTimeout(function() { $card.removeClass('kanban-card-saved'); }, 2000);
+            } else {
+                $card.addClass('kanban-card-error');
+                setTimeout(function() { $card.removeClass('kanban-card-error'); }, 3000);
+            }
+        },
+        error: function() {
+            $card.removeClass('kanban-card-saving');
+            $card.addClass('kanban-card-error');
+            setTimeout(function() { $card.removeClass('kanban-card-error'); }, 3000);
+        }
+    });
+};
+
+/**
+ * AJAX — add a category to a ticket, then inject the new tag chip.
+ *
+ * @param {number} ticketId  Ticket row ID
+ * @param {number} catId     Category row ID
+ * @param {jQuery} $opt      The clicked option element
+ * @param {jQuery} $tagsRow  The .kanban-card-tags container
+ * @param {jQuery} $card     The card element
+ * @return {void}
+ */
+window.digiriskdolibarr.ticketPickerKanban.saveTagAdd = function(ticketId, catId, $opt, $tagsRow, $card) {
+    var token = window.saturne.toolbox.getToken();
+    var sep   = window.saturne.toolbox.getQuerySeparator(document.URL);
+
+    $card.addClass('kanban-card-saving');
+
+    $.ajax({
+        url: document.URL + sep + 'action=addTicketCategory&ticket_id=' + ticketId + '&cat_id=' + catId + '&token=' + token,
+        type: 'POST',
+        dataType: 'json',
+        success: function(response) {
+            $card.removeClass('kanban-card-saving');
+            if (response.success) {
+                var bgColor = response.color ? '#' + response.color : '#8c8c8c';
+                var $tag = $('<span class="kanban-tag" data-cat-id="' + response.id + '" style="background:' + bgColor + '">'
+                    + response.label
+                    + '<span class="kanban-tag-remove" title="Supprimer">&times;</span></span>');
+                $tagsRow.find('.kanban-tag-dropdown-wrapper').before($tag);
+                $opt.addClass('assigned').append('<i class="fas fa-check" style="margin-left:auto;font-size:9px;color:#28a745"></i>');
+                $card.addClass('kanban-card-saved');
+                setTimeout(function() { $card.removeClass('kanban-card-saved'); }, 2000);
+            } else {
+                $card.addClass('kanban-card-error');
+                setTimeout(function() { $card.removeClass('kanban-card-error'); }, 3000);
+            }
+        },
+        error: function() {
+            $card.removeClass('kanban-card-saving');
+            $card.addClass('kanban-card-error');
+            setTimeout(function() { $card.removeClass('kanban-card-error'); }, 3000);
+        }
+    });
+};
+
+/**
+ * AJAX — remove a category from a ticket, then remove the tag chip.
+ *
+ * @param {number} ticketId  Ticket row ID
+ * @param {number} catId     Category row ID
+ * @param {jQuery} $tag      The tag chip element
+ * @param {jQuery} $card     The card element
+ * @return {void}
+ */
+window.digiriskdolibarr.ticketPickerKanban.saveTagRemove = function(ticketId, catId, $tag, $card) {
+    var token = window.saturne.toolbox.getToken();
+    var sep   = window.saturne.toolbox.getQuerySeparator(document.URL);
+
+    $.ajax({
+        url: document.URL + sep + 'action=removeTicketCategory&ticket_id=' + ticketId + '&cat_id=' + catId + '&token=' + token,
+        type: 'POST',
+        dataType: 'json',
+        success: function(response) {
+            if (response.success) {
+                $tag.slideUp(150, function() {
+                    $(this).remove();
+                    $card.find('.kanban-tag-option[data-value="' + catId + '"]').removeClass('assigned').find('.fa-check').remove();
+                });
+                $card.addClass('kanban-card-saved');
+                setTimeout(function() { $card.removeClass('kanban-card-saved'); }, 2000);
+            } else {
+                $tag.css('opacity', '1');
+                $card.addClass('kanban-card-error');
+                setTimeout(function() { $card.removeClass('kanban-card-error'); }, 3000);
+            }
+        },
+        error: function() {
+            $tag.css('opacity', '1');
+        }
+    });
+};
+
+/**
+ * AJAX — save an updated subject after contenteditable edit.
+ *
+ * @param {number} ticketId     Ticket row ID
+ * @param {string} newSubject   New subject text
+ * @param {jQuery} $span        The contenteditable .tac-picker-card__subject-text element
+ * @param {string} originalText Subject before editing (for rollback)
+ * @param {jQuery} $card        The card element
+ * @return {void}
+ */
+window.digiriskdolibarr.ticketPickerKanban.saveSubject = function(ticketId, newSubject, $span, originalText, $card) {
+    var token = window.saturne.toolbox.getToken();
+    var sep   = window.saturne.toolbox.getQuerySeparator(document.URL);
+
+    $card.addClass('kanban-card-saving');
+
+    $.ajax({
+        url:      document.URL + sep + 'action=updateTicketSubject&ticket_id=' + ticketId + '&token=' + token,
+        type:     'POST',
+        data:     {subject: newSubject},
+        dataType: 'json',
+        success: function(response) {
+            $card.removeClass('kanban-card-saving');
+            if (response.success) {
+                var saved = response.subject || newSubject;
+                $span[0].textContent = saved;
+                $span.data('editOriginal', saved);
+                $card.addClass('kanban-card-saved');
+                setTimeout(function() { $card.removeClass('kanban-card-saved'); }, 2000);
+            } else {
+                $span[0].textContent = originalText;
+                $span.data('editOriginal', originalText);
+                $card.addClass('kanban-card-error');
+                setTimeout(function() { $card.removeClass('kanban-card-error'); }, 3000);
+            }
+        },
+        error: function() {
+            $card.removeClass('kanban-card-saving');
+            $span[0].textContent = originalText;
+            $span.data('editOriginal', originalText);
+            $card.addClass('kanban-card-error');
+            setTimeout(function() { $card.removeClass('kanban-card-error'); }, 3000);
+        }
+    });
+};
+
+/**
+ * Column width & gap settings with localStorage persistence.
+ *
+ * @return {void}
+ */
+window.digiriskdolibarr.ticketPickerKanban.initSettings = function() {
+    var $btn      = $('#kanbanPickerSettingsBtn');
+    var $popover  = $('#kanbanPickerSettingsPopover');
+    var $board    = $('.tac-picker-kanban-board');
+    var $wSlider  = $('#kanbanPickerColWidth');
+    var $gSlider  = $('#kanbanPickerColGap');
+    var $wVal     = $('#kanbanPickerColWidthVal');
+    var $gVal     = $('#kanbanPickerColGapVal');
+
+    if (!$btn.length) {
+        return;
+    }
+
+    var savedW = localStorage.getItem('tacPickerKanbanColWidth');
+    var savedG = localStorage.getItem('tacPickerKanbanColGap');
+    if (savedW) {
+        $wSlider.val(savedW);
+        $wVal.text(savedW + 'px');
+        $board.find('.tac-picker-column').css({'min-width': savedW + 'px', 'max-width': savedW + 'px'});
+    }
+    if (savedG) {
+        $gSlider.val(savedG);
+        $gVal.text(savedG + 'px');
+        $board.css('gap', savedG + 'px');
+    }
+
+    $btn.on('click', function(e) {
+        e.stopPropagation();
+        $popover.toggleClass('open');
+    });
+    $(document).on('click', function(e) {
+        if (!$(e.target).closest('#kanbanPickerSettingsBtn, #kanbanPickerSettingsPopover').length) {
+            $popover.removeClass('open');
+        }
+    });
+
+    $wSlider.on('input', function() {
+        var val = $(this).val();
+        $wVal.text(val + 'px');
+        $board.find('.tac-picker-column').css({'min-width': val + 'px', 'max-width': val + 'px'});
+        localStorage.setItem('tacPickerKanbanColWidth', val);
+    });
+    $gSlider.on('input', function() {
+        var val = $(this).val();
+        $gVal.text(val + 'px');
+        $board.css('gap', val + 'px');
+        localStorage.setItem('tacPickerKanbanColGap', val);
+    });
+};

--- a/view/ticket/ticket_action_card.php
+++ b/view/ticket/ticket_action_card.php
@@ -19,6 +19,7 @@
  * \file    view/ticket/ticket_action_card.php
  * \ingroup digiriskdolibarr
  * \brief   One-click ticket action card — large tile UI for fast status / assignment / link actions.
+ *          Picker (no ticket selected) renders a Kanban board of all open tickets.
  *
  * Issue #4443 — IHM ticket registre.
  */
@@ -40,6 +41,7 @@ if (file_exists('../digiriskdolibarr.main.inc.php')) {
 // Load Dolibarr libraries
 require_once DOL_DOCUMENT_ROOT . '/ticket/class/ticket.class.php';
 require_once DOL_DOCUMENT_ROOT . '/user/class/user.class.php';
+require_once DOL_DOCUMENT_ROOT . '/categories/class/categorie.class.php';
 
 // Global variables definitions
 global $conf, $db, $hookmanager, $langs, $moduleNameLowerCase, $user;
@@ -69,6 +71,242 @@ $permissionToWrite = $user->hasRight('ticket', 'write');
 saturne_check_access($permissionToRead);
 
 /*
+ * Actions
+ */
+
+// AJAX: update ticket status from kanban drag & drop
+if ($action == 'updateTicketStatus' && !empty(GETPOSTINT('ticket_id'))) {
+    header('Content-Type: application/json');
+
+    $ticketId  = GETPOSTINT('ticket_id');
+    $dimValue  = GETPOST('dim_value', 'alpha');
+    $newStatus = $dimValue !== '' ? (int) $dimValue : GETPOSTINT('new_status');
+
+    $ticketToUpdate = new Ticket($db);
+    $result         = $ticketToUpdate->fetch($ticketId);
+
+    if ($result > 0) {
+        $res = $ticketToUpdate->setStatut($newStatus, $user);
+        if ($res > 0) {
+            print json_encode(['success' => 1]);
+        } else {
+            http_response_code(500);
+            print json_encode(['success' => 0, 'error' => $ticketToUpdate->error]);
+        }
+    } else {
+        http_response_code(404);
+        print json_encode(['success' => 0, 'error' => 'Ticket not found']);
+    }
+    $db->close();
+    exit;
+}
+
+// AJAX: update ticket assignee from inline edit
+if ($action == 'updateTicketAssignee' && !empty(GETPOSTINT('ticket_id'))) {
+    header('Content-Type: application/json');
+
+    $ticketId = GETPOSTINT('ticket_id');
+    $userId   = GETPOSTINT('user_id');
+
+    $ticketToUpdate = new Ticket($db);
+    $result         = $ticketToUpdate->fetch($ticketId);
+
+    if ($result > 0) {
+        $ticketToUpdate->fk_user_assign = $userId > 0 ? $userId : null;
+        $res = $ticketToUpdate->update($user);
+        if ($res > 0) {
+            $fullname  = '';
+            $initials  = '';
+            if ($userId > 0) {
+                $assignedUser = new User($db);
+                $assignedUser->fetch($userId);
+                $fullname = $assignedUser->getFullName($langs);
+                $initials = strtoupper(mb_substr($assignedUser->firstname, 0, 1) . mb_substr($assignedUser->lastname, 0, 1));
+            }
+            print json_encode(['success' => 1, 'fullname' => $fullname, 'initials' => $initials]);
+        } else {
+            http_response_code(500);
+            print json_encode(['success' => 0, 'error' => $ticketToUpdate->error]);
+        }
+    } else {
+        http_response_code(404);
+        print json_encode(['success' => 0, 'error' => 'Ticket not found']);
+    }
+    $db->close();
+    exit;
+}
+
+// AJAX: add a category to a ticket
+if ($action == 'addTicketCategory' && !empty(GETPOSTINT('ticket_id'))) {
+    header('Content-Type: application/json');
+
+    $ticketId = GETPOSTINT('ticket_id');
+    $catId    = GETPOSTINT('cat_id');
+
+    $ticketToUpdate = new Ticket($db);
+    $result         = $ticketToUpdate->fetch($ticketId);
+
+    if ($result > 0) {
+        $cat    = new Categorie($db);
+        $resCat = $cat->fetch($catId);
+        if ($resCat > 0) {
+            $res = $cat->add_type($ticketToUpdate, 'ticket');
+            if ($res > 0 || $res == -3) {
+                print json_encode(['success' => 1, 'label' => $cat->label, 'color' => $cat->color, 'id' => $cat->id]);
+            } else {
+                print json_encode(['success' => 0, 'error' => $cat->error]);
+            }
+        } else {
+            print json_encode(['success' => 0, 'error' => 'Category not found']);
+        }
+    } else {
+        http_response_code(404);
+        print json_encode(['success' => 0, 'error' => 'Ticket not found']);
+    }
+    $db->close();
+    exit;
+}
+
+// AJAX: remove a category from a ticket
+if ($action == 'removeTicketCategory' && !empty(GETPOSTINT('ticket_id'))) {
+    header('Content-Type: application/json');
+
+    $ticketId = GETPOSTINT('ticket_id');
+    $catId    = GETPOSTINT('cat_id');
+
+    $ticketToUpdate = new Ticket($db);
+    $result         = $ticketToUpdate->fetch($ticketId);
+
+    if ($result > 0) {
+        $cat    = new Categorie($db);
+        $resCat = $cat->fetch($catId);
+        if ($resCat > 0) {
+            $res = $cat->del_type($ticketToUpdate, 'ticket');
+            if ($res >= 0) {
+                print json_encode(['success' => 1]);
+            } else {
+                print json_encode(['success' => 0, 'error' => $cat->error]);
+            }
+        } else {
+            print json_encode(['success' => 0, 'error' => 'Category not found']);
+        }
+    } else {
+        http_response_code(404);
+        print json_encode(['success' => 0, 'error' => 'Ticket not found']);
+    }
+    $db->close();
+    exit;
+}
+
+// AJAX: update ticket type (dim kanban drag & drop)
+if ($action == 'updateTicketType' && !empty(GETPOSTINT('ticket_id'))) {
+    header('Content-Type: application/json');
+
+    $ticketId = GETPOSTINT('ticket_id');
+    $dimValue = GETPOST('dim_value', 'alpha');
+
+    $ticketToUpdate = new Ticket($db);
+    $result         = $ticketToUpdate->fetch($ticketId);
+
+    if ($result > 0) {
+        $ticketToUpdate->type_code = !empty($dimValue) && $dimValue !== '__none__' ? $dimValue : '';
+        $res = $ticketToUpdate->update($user);
+        if ($res > 0) {
+            print json_encode(['success' => 1]);
+        } else {
+            http_response_code(500);
+            print json_encode(['success' => 0, 'error' => $ticketToUpdate->error]);
+        }
+    } else {
+        http_response_code(404);
+        print json_encode(['success' => 0, 'error' => 'Ticket not found']);
+    }
+    $db->close();
+    exit;
+}
+
+// AJAX: update ticket group/category (dim kanban drag & drop)
+if ($action == 'updateTicketGroup' && !empty(GETPOSTINT('ticket_id'))) {
+    header('Content-Type: application/json');
+
+    $ticketId = GETPOSTINT('ticket_id');
+    $dimValue = GETPOST('dim_value', 'alpha');
+
+    $ticketToUpdate = new Ticket($db);
+    $result         = $ticketToUpdate->fetch($ticketId);
+
+    if ($result > 0) {
+        $ticketToUpdate->category_code = !empty($dimValue) && $dimValue !== '__none__' ? $dimValue : '';
+        $res = $ticketToUpdate->update($user);
+        if ($res > 0) {
+            print json_encode(['success' => 1]);
+        } else {
+            http_response_code(500);
+            print json_encode(['success' => 0, 'error' => $ticketToUpdate->error]);
+        }
+    } else {
+        http_response_code(404);
+        print json_encode(['success' => 0, 'error' => 'Ticket not found']);
+    }
+    $db->close();
+    exit;
+}
+
+// AJAX: update ticket severity (dim kanban drag & drop)
+if ($action == 'updateTicketSeverity' && !empty(GETPOSTINT('ticket_id'))) {
+    header('Content-Type: application/json');
+
+    $ticketId = GETPOSTINT('ticket_id');
+    $dimValue = GETPOST('dim_value', 'alpha');
+
+    $ticketToUpdate = new Ticket($db);
+    $result         = $ticketToUpdate->fetch($ticketId);
+
+    if ($result > 0) {
+        $ticketToUpdate->severity_code = !empty($dimValue) && $dimValue !== '__none__' ? $dimValue : '';
+        $res = $ticketToUpdate->update($user);
+        if ($res > 0) {
+            print json_encode(['success' => 1]);
+        } else {
+            http_response_code(500);
+            print json_encode(['success' => 0, 'error' => $ticketToUpdate->error]);
+        }
+    } else {
+        http_response_code(404);
+        print json_encode(['success' => 0, 'error' => 'Ticket not found']);
+    }
+    $db->close();
+    exit;
+}
+
+// AJAX: update ticket subject (inline edit on kanban card)
+if ($action == 'updateTicketSubject' && !empty(GETPOSTINT('ticket_id'))) {
+    header('Content-Type: application/json');
+
+    $ticketId   = GETPOSTINT('ticket_id');
+    $newSubject = GETPOST('subject', 'nohtml');
+
+    $ticketToUpdate = new Ticket($db);
+    $result         = $ticketToUpdate->fetch($ticketId);
+
+    if ($result > 0) {
+        $ticketToUpdate->subject = $newSubject;
+        $res = $ticketToUpdate->update($user);
+        if ($res > 0) {
+            print json_encode(['success' => 1, 'subject' => $newSubject]);
+        } else {
+            http_response_code(500);
+            print json_encode(['success' => 0, 'error' => $ticketToUpdate->error]);
+        }
+    } else {
+        http_response_code(404);
+        print json_encode(['success' => 0, 'error' => 'Ticket not found']);
+    }
+    $db->close();
+    exit;
+}
+
+/*
  * View
  */
 
@@ -77,7 +315,319 @@ $helpUrl = 'FR:Module_Digirisk';
 
 saturne_header(0, '', $title, $helpUrl);
 
-// Page entry point — picker if no ticket loaded, otherwise the tile card.
+// Kanban picker data — loaded only when no specific ticket is requested.
+$pickerAllUsers          = [];
+$pickerAllCategories     = [];
+$pickerTicketsJson       = [];
+$pickerTypeColumns       = [];
+$pickerTypeTickets       = [];
+$pickerGroupColumns      = [];
+$pickerGroupTickets      = [];
+$pickerSeverityColumns   = [];
+$pickerSeverityTickets   = [];
+$pickerStatusColumns     = [];
+$pickerStatusTickets     = [];
+
+if ($object->id <= 0) {
+    // Hidden token for AJAX requests
+    print '<input type="hidden" name="token" value="' . newToken() . '">';
+
+    // All active internal users for the assignee picker
+    $sqlUsers = 'SELECT u.rowid, u.firstname, u.lastname, u.photo FROM ' . MAIN_DB_PREFIX . 'user u'
+        . ' WHERE u.statut = 1 AND u.entity IN (' . getEntity('user') . ')'
+        . ' ORDER BY u.lastname, u.firstname';
+    $resUsers = $db->query($sqlUsers);
+    if ($resUsers) {
+        while ($objU = $db->fetch_object($resUsers)) {
+            $photoUrl = '';
+            if (!empty($objU->photo)) {
+                $photoFile = DOL_DATA_ROOT . '/users/' . (int) $objU->rowid . '/' . $objU->photo;
+                if (file_exists($photoFile)) {
+                    $photoUrl = DOL_URL_ROOT . '/viewimage.php?modulepart=userphoto&entity=' . $conf->entity
+                        . '&file=' . urlencode($objU->rowid . '/' . $objU->photo)
+                        . '&cache=' . (int) $objU->rowid;
+                }
+            }
+            $pickerAllUsers[] = [
+                'id'       => (int) $objU->rowid,
+                'fullname' => trim($objU->firstname . ' ' . $objU->lastname),
+                'initials' => strtoupper(mb_substr($objU->firstname, 0, 1) . mb_substr($objU->lastname, 0, 1)),
+                'photo'    => $photoUrl,
+            ];
+        }
+        $db->free($resUsers);
+    }
+
+    // All available ticket categories
+    $categorie       = new Categorie($db);
+    $ticketCatTypeId = (int) $categorie->MAP_ID['ticket'];
+    $sqlCats         = 'SELECT rowid, label, color FROM ' . MAIN_DB_PREFIX . 'categorie'
+        . ' WHERE type = ' . $ticketCatTypeId . ' AND entity IN (' . getEntity('category') . ')'
+        . ' ORDER BY label';
+    $resCats = $db->query($sqlCats);
+    if ($resCats) {
+        while ($objCat = $db->fetch_object($resCats)) {
+            $pickerAllCategories[] = ['id' => (int) $objCat->rowid, 'label' => $objCat->label, 'color' => $objCat->color];
+        }
+        $db->free($resCats);
+    }
+
+    // Tickets with enriched data (assignee, severity, type, group, company)
+    $sqlTickets = 'SELECT t.rowid, t.ref, t.subject, t.fk_statut, t.datec, t.severity_code,'
+        . ' t.type_code, t.category_code,'
+        . ' t.fk_user_assign, t.fk_soc,'
+        . ' u.firstname as assign_firstname, u.lastname as assign_lastname, u.photo as assign_photo,'
+        . ' s.nom as company_name'
+        . ' FROM ' . MAIN_DB_PREFIX . 'ticket t'
+        . ' LEFT JOIN ' . MAIN_DB_PREFIX . 'user u ON u.rowid = t.fk_user_assign'
+        . ' LEFT JOIN ' . MAIN_DB_PREFIX . 'societe s ON s.rowid = t.fk_soc'
+        . ' WHERE t.entity IN (' . getEntity('ticket') . ')'
+        . ' ORDER BY t.datec DESC'
+        . ' LIMIT 500';
+    $resTickets = $db->query($sqlTickets);
+    $ticketIds  = [];
+    if ($resTickets) {
+        while ($row = $db->fetch_object($resTickets)) {
+            $assignId       = (int) $row->fk_user_assign;
+            $assignInitials = '';
+            $assignFullname = '';
+            $assignPhoto    = '';
+            if ($assignId > 0) {
+                $assignFullname = trim($row->assign_firstname . ' ' . $row->assign_lastname);
+                $assignInitials = strtoupper(mb_substr($row->assign_firstname, 0, 1) . mb_substr($row->assign_lastname, 0, 1));
+                if (!empty($row->assign_photo)) {
+                    $photoFile = DOL_DATA_ROOT . '/users/' . $assignId . '/' . $row->assign_photo;
+                    if (file_exists($photoFile)) {
+                        $assignPhoto = DOL_URL_ROOT . '/viewimage.php?modulepart=userphoto&entity=' . $conf->entity
+                            . '&file=' . urlencode($assignId . '/' . $row->assign_photo)
+                            . '&cache=' . $assignId;
+                    }
+                }
+            }
+
+            $detailUrl = dol_buildpath('/custom/digiriskdolibarr/view/ticket/ticket_action_card.php', 1) . '?id=' . (int) $row->rowid;
+
+            $sevCode  = strtoupper((string) ($row->severity_code ?: ''));
+            $sevTrans = $sevCode !== '' ? $langs->trans('TicketSeverityShort' . $sevCode) : '';
+            if ($sevTrans === 'TicketSeverityShort' . $sevCode) {
+                $sevTrans = $sevCode;
+            }
+
+            $pickerTicketsJson[] = [
+                'id'              => (int) $row->rowid,
+                'ref'             => $row->ref,
+                'subject'         => $row->subject,
+                'status'          => (int) $row->fk_statut,
+                'severity_code'   => $sevCode,
+                'severity_label'  => $sevTrans,
+                'type_code'       => (string) ($row->type_code ?: ''),
+                'category_code'   => (string) ($row->category_code ?: ''),
+                'date_c'          => $row->datec ? dol_print_date($db->jdate($row->datec), 'day') : '',
+                'company_name'    => $row->company_name ?: '',
+                'assign_id'       => $assignId,
+                'assign_fullname' => $assignFullname,
+                'assign_initials' => $assignInitials,
+                'assign_photo'    => $assignPhoto,
+                'categories'      => [],
+                'url'             => $detailUrl,
+            ];
+            $ticketIds[] = (int) $row->rowid;
+        }
+        $db->free($resTickets);
+    }
+
+    // Batch-load categories for all tickets
+    if (!empty($ticketIds)) {
+        $sqlTktCats = 'SELECT ct.fk_ticket, c.rowid, c.label, c.color'
+            . ' FROM ' . MAIN_DB_PREFIX . 'categorie c'
+            . ' JOIN ' . MAIN_DB_PREFIX . 'categorie_ticket ct ON ct.fk_categorie = c.rowid'
+            . ' WHERE ct.fk_ticket IN (' . implode(',', $ticketIds) . ')';
+        $resTktCats = $db->query($sqlTktCats);
+        $catsByTicket = [];
+        if ($resTktCats) {
+            while ($row = $db->fetch_object($resTktCats)) {
+                $catsByTicket[(int) $row->fk_ticket][] = [
+                    'id'    => (int) $row->rowid,
+                    'label' => $row->label,
+                    'color' => $row->color,
+                ];
+            }
+            $db->free($resTktCats);
+        }
+        foreach ($pickerTicketsJson as &$t) {
+            if (isset($catsByTicket[$t['id']])) {
+                $t['categories'] = $catsByTicket[$t['id']];
+            }
+        }
+        unset($t);
+    }
+
+    // -----------------------------------------------------------------------
+    // Dimension 1 — Type
+    // -----------------------------------------------------------------------
+    $pickerTypeColumns  = [];
+    $pickerTypeTickets  = [];
+    $dimColorPalette    = ['#5b8cdb', '#e9ad4f', '#28a745', '#9c6ade', '#17a2b8', '#fd7e14', '#6f42c1', '#6c757d'];
+
+    $sqlTypes = 'SELECT code, label FROM ' . MAIN_DB_PREFIX . 'c_ticket_type'
+        . ' WHERE active = 1 AND entity IN (' . getEntity('c_ticket_type') . ')'
+        . ' ORDER BY label';
+    $resTypes = $db->query($sqlTypes);
+    $typeColorIdx = 0;
+    if ($resTypes) {
+        while ($r = $db->fetch_object($resTypes)) {
+            $transKey = 'TicketTypeShort' . $r->code;
+            $label    = $langs->trans($transKey);
+            if ($label === $transKey) {
+                $label = $r->label;
+            }
+            $pickerTypeColumns[$r->code] = [
+                'label' => $label,
+                'icon'  => 'fa-tag',
+                'color' => $dimColorPalette[$typeColorIdx % count($dimColorPalette)],
+            ];
+            $typeColorIdx++;
+        }
+        $db->free($resTypes);
+    }
+    $pickerTypeColumns['__none__'] = ['label' => $langs->trans('Undefined'), 'icon' => 'fa-tag', 'color' => '#adb5bd'];
+
+    foreach (array_keys($pickerTypeColumns) as $tc) {
+        $pickerTypeTickets[$tc] = [];
+    }
+    foreach ($pickerTicketsJson as $t) {
+        $tc = !empty($t['type_code']) ? $t['type_code'] : '__none__';
+        if (!isset($pickerTypeTickets[$tc])) {
+            $pickerTypeTickets['__none__'][] = $t;
+        } else {
+            $pickerTypeTickets[$tc][] = $t;
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Dimension 2 — Group (category_code)
+    // -----------------------------------------------------------------------
+    $pickerGroupColumns = [];
+    $pickerGroupTickets = [];
+
+    $sqlGroups = 'SELECT code, label FROM ' . MAIN_DB_PREFIX . 'c_ticket_category'
+        . ' WHERE active = 1 AND entity IN (' . getEntity('c_ticket_category') . ')'
+        . ' ORDER BY label';
+    $resGroups = $db->query($sqlGroups);
+    $groupColorIdx = 0;
+    if ($resGroups) {
+        while ($r = $db->fetch_object($resGroups)) {
+            $transKey = 'TicketCategoryShort' . $r->code;
+            $label    = $langs->trans($transKey);
+            if ($label === $transKey) {
+                $label = $r->label;
+            }
+            $pickerGroupColumns[$r->code] = [
+                'label' => $label,
+                'icon'  => 'fa-folder',
+                'color' => $dimColorPalette[$groupColorIdx % count($dimColorPalette)],
+            ];
+            $groupColorIdx++;
+        }
+        $db->free($resGroups);
+    }
+    $pickerGroupColumns['__none__'] = ['label' => $langs->trans('Undefined'), 'icon' => 'fa-folder', 'color' => '#adb5bd'];
+
+    foreach (array_keys($pickerGroupColumns) as $gc) {
+        $pickerGroupTickets[$gc] = [];
+    }
+    foreach ($pickerTicketsJson as $t) {
+        $gc = !empty($t['category_code']) ? $t['category_code'] : '__none__';
+        if (!isset($pickerGroupTickets[$gc])) {
+            $pickerGroupTickets['__none__'][] = $t;
+        } else {
+            $pickerGroupTickets[$gc][] = $t;
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Dimension 3 — Severity
+    // -----------------------------------------------------------------------
+    $pickerSeverityColumns = [];
+    $pickerSeverityTickets = [];
+    $sevColorMap = [
+        'LOW'      => '#28a745',
+        'NORMAL'   => '#007bff',
+        'HIGH'     => '#fd7e14',
+        'BLOCKING' => '#dc3545',
+    ];
+
+    $sqlSevs = 'SELECT code, label FROM ' . MAIN_DB_PREFIX . 'c_ticket_severity'
+        . ' WHERE active = 1 AND entity IN (' . getEntity('c_ticket_severity') . ')'
+        . ' ORDER BY code';
+    $resSevs = $db->query($sqlSevs);
+    if ($resSevs) {
+        while ($r = $db->fetch_object($resSevs)) {
+            $transKey = 'TicketSeverityShort' . $r->code;
+            $label    = $langs->trans($transKey);
+            if ($label === $transKey) {
+                $label = $r->label;
+            }
+            $pickerSeverityColumns[$r->code] = [
+                'label' => $label,
+                'icon'  => 'fa-exclamation-triangle',
+                'color' => $sevColorMap[$r->code] ?? '#6c757d',
+            ];
+        }
+        $db->free($resSevs);
+    }
+    $pickerSeverityColumns['__none__'] = ['label' => $langs->trans('Undefined'), 'icon' => 'fa-exclamation-triangle', 'color' => '#adb5bd'];
+
+    foreach (array_keys($pickerSeverityColumns) as $sc) {
+        $pickerSeverityTickets[$sc] = [];
+    }
+    foreach ($pickerTicketsJson as $t) {
+        $sc = !empty($t['severity_code']) ? $t['severity_code'] : '__none__';
+        if (!isset($pickerSeverityTickets[$sc])) {
+            $pickerSeverityTickets['__none__'][] = $t;
+        } else {
+            $pickerSeverityTickets[$sc][] = $t;
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Dimension 4 — Status (fk_statut)
+    // -----------------------------------------------------------------------
+    $tempTicket = new Ticket($db);
+    $statusDefs = [
+        Ticket::STATUS_NOT_READ    => ['icon' => 'fa-inbox',          'color' => '#6c757d'],
+        Ticket::STATUS_READ        => ['icon' => 'fa-eye',            'color' => '#17a2b8'],
+        Ticket::STATUS_ASSIGNED    => ['icon' => 'fa-user',           'color' => '#5b8cdb'],
+        Ticket::STATUS_IN_PROGRESS => ['icon' => 'fa-cogs',           'color' => '#e9ad4f'],
+        Ticket::STATUS_NEED_MORE_INFO => ['icon' => 'fa-question-circle', 'color' => '#9c6ade'],
+        Ticket::STATUS_CLOSED      => ['icon' => 'fa-check-circle',   'color' => '#28a745'],
+    ];
+
+    foreach ($statusDefs as $statusInt => $statusMeta) {
+        $transKey = !empty($tempTicket->labelStatusShort[$statusInt]) ? $tempTicket->labelStatusShort[$statusInt] : '';
+        $label    = $transKey !== '' ? $langs->transnoentitiesnoconv($transKey) : (string) $statusInt;
+        $pickerStatusColumns[$statusInt] = [
+            'label' => $label,
+            'icon'  => $statusMeta['icon'],
+            'color' => $statusMeta['color'],
+        ];
+    }
+    $pickerStatusColumns['__none__'] = ['label' => $langs->trans('Other'), 'icon' => 'fa-question', 'color' => '#adb5bd'];
+
+    foreach (array_keys($pickerStatusColumns) as $sts) {
+        $pickerStatusTickets[$sts] = [];
+    }
+    foreach ($pickerTicketsJson as $t) {
+        $sts = isset($pickerStatusColumns[$t['status']]) ? $t['status'] : '__none__';
+        if (!isset($pickerStatusTickets[$sts])) {
+            $pickerStatusTickets['__none__'][] = $t;
+        } else {
+            $pickerStatusTickets[$sts][] = $t;
+        }
+    }
+}
+
+// Page entry point — kanban picker if no ticket loaded, otherwise the tile card.
 if ($object->id <= 0) {
     require_once __DIR__ . '/../../core/tpl/ticket/ticket_action_card_picker.tpl.php';
 } else {


### PR DESCRIPTION
#4753

## Resume

- Kanban picker a 4 onglets (Statut par defaut, Type, Groupe, Severite) sur ticket_action_card.php
- Drag & drop entre colonnes pour mettre a jour le champ correspondant (AJAX)
- Edition inline du sujet via contenteditable (Enter/Escape/blur)
- Edition inline de la severite via badge cliquable + select integre
- Onglet actif persiste en localStorage (survive F5)
- Labels de statut traduits via Ticket::labelStatusShort + transnoentitiesnoconv
- Fix guard early-return manquant dans actionplan_kanban.js init()

## Plan de test

- [ ] Ouvrir ticket_action_card.php sans ticket -> voir le kanban Statut par defaut
- [ ] Changer d'onglet (Type/Groupe/Severite) -> F5 -> verifier restauration
- [ ] Glisser une carte vers une autre colonne -> verifier la mise a jour en base
- [ ] Cliquer sur le sujet -> modifier -> Enter -> verifier la sauvegarde AJAX
- [ ] Cliquer sur le badge de severite -> selectionner une valeur -> verifier
- [ ] Verifier que les colonnes Statut affichent des liberaux textuels

Closes #4753

Generated with Claude Code