### PR TITLE
#4753 [Ticket] feat: audit ActionComm, dol_syslog, statuts 7/9, limite tickets fermes

### DIFF
--- a/admin/config/ticket_kanban.php
+++ b/admin/config/ticket_kanban.php
@@ -1,0 +1,163 @@
+<?php
+/* Copyright (C) 2026 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    admin/config/ticket_kanban.php
+ * \ingroup digiriskdolibarr
+ * \brief   Digiriskdolibarr ticket kanban configuration page.
+ *          Controls ActionComm audit logging for each inline edit action.
+ */
+
+// Load DigiriskDolibarr environment
+if (file_exists('../digiriskdolibarr.main.inc.php')) {
+    require_once __DIR__ . '/../digiriskdolibarr.main.inc.php';
+} elseif (file_exists('../../digiriskdolibarr.main.inc.php')) {
+    require_once __DIR__ . '/../../digiriskdolibarr.main.inc.php';
+} else {
+    die('Include of digiriskdolibarr main fails');
+}
+
+global $conf, $db, $langs, $user;
+
+// Libraries
+require_once DOL_DOCUMENT_ROOT . '/core/lib/admin.lib.php';
+
+require_once __DIR__ . '/../../lib/digiriskdolibarr.lib.php';
+
+// Translations
+saturne_load_langs(['admin']);
+
+// Parameters
+$action     = GETPOST('action', 'alpha');
+$backtopage = GETPOST('backtopage', 'alpha');
+
+// Security check
+$permissiontoread = $user->rights->digiriskdolibarr->adminpage->read;
+saturne_check_access($permissiontoread);
+
+/*
+ * Actions
+ */
+
+// Initialize ticket kanban logging constants with defaults (all OFF)
+$ticketKanbanLogDefaults = [
+    'DIGIRISKDOLIBARR_TICKET_KANBAN_LOG_STATUS'          => 0,
+    'DIGIRISKDOLIBARR_TICKET_KANBAN_LOG_ASSIGNEE'        => 0,
+    'DIGIRISKDOLIBARR_TICKET_KANBAN_LOG_CATEGORY_ADD'    => 0,
+    'DIGIRISKDOLIBARR_TICKET_KANBAN_LOG_CATEGORY_REMOVE' => 0,
+    'DIGIRISKDOLIBARR_TICKET_KANBAN_LOG_TYPE'            => 0,
+    'DIGIRISKDOLIBARR_TICKET_KANBAN_LOG_GROUP'           => 0,
+    'DIGIRISKDOLIBARR_TICKET_KANBAN_LOG_SEVERITY'        => 0,
+    'DIGIRISKDOLIBARR_TICKET_KANBAN_LOG_SUBJECT'         => 0,
+    'DIGIRISKDOLIBARR_TICKET_KANBAN_LOG_DEADLINE'        => 0,
+    'DIGIRISKDOLIBARR_TICKET_KANBAN_CLOSED_LIMIT'        => 50,
+];
+foreach ($ticketKanbanLogDefaults as $constName => $defaultVal) {
+    if (!isset($conf->global->$constName)) {
+        dolibarr_set_const($db, $constName, $defaultVal, 'chaine', 0, '', $conf->entity);
+    }
+}
+
+if ($action == 'set_closed_limit') {
+    $newLimit = max(0, GETPOSTINT('closed_limit'));
+    dolibarr_set_const($db, 'DIGIRISKDOLIBARR_TICKET_KANBAN_CLOSED_LIMIT', $newLimit, 'chaine', 0, '', $conf->entity);
+    header('Location: ' . $_SERVER['PHP_SELF']);
+    exit;
+}
+
+/*
+ * View
+ */
+
+$title   = $langs->trans('ModuleSetup', $moduleName);
+$helpUrl = 'FR:Module_Digirisk';
+
+saturne_header(0, '', $title, $helpUrl);
+
+// Subheader
+$linkback = '<a href="' . ($backtopage ?: DOL_URL_ROOT . '/admin/modules.php?restore_lastsearch_values=1') . '">' . $langs->trans('BackToModuleList') . '</a>';
+
+print load_fiche_titre($title, $linkback, 'title_setup');
+
+// Configuration header
+$head = digiriskdolibarr_admin_prepare_head();
+print dol_get_fiche_head($head, 'ticket_kanban', $title, -1, 'digiriskdolibarr_color@digiriskdolibarr');
+
+print load_fiche_titre('<i class="fas fa-columns"></i> ' . $langs->trans('TicketKanbanLogging'), '', '');
+print '<hr>';
+
+// ActionComm logging toggles
+print '<table class="noborder centpercent">';
+print '<tr class="liste_titre">';
+print '<td>' . $langs->trans('Name') . '</td>';
+print '<td>' . $langs->trans('Description') . '</td>';
+print '<td class="center">' . $langs->trans('Status') . '</td>';
+print '</tr>';
+
+$ticketKanbanLogs = [
+    'DIGIRISKDOLIBARR_TICKET_KANBAN_LOG_STATUS'          => ['TicketKanbanLogStatus',         'TicketKanbanLogStatusDesc'],
+    'DIGIRISKDOLIBARR_TICKET_KANBAN_LOG_ASSIGNEE'        => ['TicketKanbanLogAssignee',        'TicketKanbanLogAssigneeDesc'],
+    'DIGIRISKDOLIBARR_TICKET_KANBAN_LOG_CATEGORY_ADD'    => ['TicketKanbanLogCategoryAdd',     'TicketKanbanLogCategoryAddDesc'],
+    'DIGIRISKDOLIBARR_TICKET_KANBAN_LOG_CATEGORY_REMOVE' => ['TicketKanbanLogCategoryRemove',  'TicketKanbanLogCategoryRemoveDesc'],
+    'DIGIRISKDOLIBARR_TICKET_KANBAN_LOG_TYPE'            => ['TicketKanbanLogType',            'TicketKanbanLogTypeDesc'],
+    'DIGIRISKDOLIBARR_TICKET_KANBAN_LOG_GROUP'           => ['TicketKanbanLogGroup',           'TicketKanbanLogGroupDesc'],
+    'DIGIRISKDOLIBARR_TICKET_KANBAN_LOG_SEVERITY'        => ['TicketKanbanLogSeverity',        'TicketKanbanLogSeverityDesc'],
+    'DIGIRISKDOLIBARR_TICKET_KANBAN_LOG_SUBJECT'         => ['TicketKanbanLogSubject',         'TicketKanbanLogSubjectDesc'],
+    'DIGIRISKDOLIBARR_TICKET_KANBAN_LOG_DEADLINE'        => ['TicketKanbanLogDeadline',        'TicketKanbanLogDeadlineDesc'],
+];
+
+foreach ($ticketKanbanLogs as $constName => $transKeys) {
+    print '<tr class="oddeven"><td>';
+    print $langs->trans($transKeys[0]);
+    print '</td><td>';
+    print $langs->trans($transKeys[1]);
+    print '</td>';
+    print '<td class="center">';
+    print ajax_constantonoff($constName);
+    print '</td>';
+    print '</tr>';
+}
+
+print '</table>';
+
+// Closed tickets limit
+print load_fiche_titre('<i class="fas fa-eye-slash"></i> ' . $langs->trans('TicketKanbanClosedLimit'), '', '');
+print '<hr>';
+
+$currentLimit = getDolGlobalInt('DIGIRISKDOLIBARR_TICKET_KANBAN_CLOSED_LIMIT', 50);
+print '<form method="post" action="' . $_SERVER['PHP_SELF'] . '">';
+print '<input type="hidden" name="action" value="set_closed_limit">';
+print '<input type="hidden" name="token" value="' . newToken() . '">';
+print '<table class="noborder centpercent">';
+print '<tr class="liste_titre">';
+print '<td>' . $langs->trans('Name') . '</td>';
+print '<td>' . $langs->trans('Description') . '</td>';
+print '<td class="center">' . $langs->trans('Value') . '</td>';
+print '</tr>';
+print '<tr class="oddeven"><td>' . $langs->trans('TicketKanbanClosedLimit') . '</td>';
+print '<td>' . $langs->trans('TicketKanbanClosedLimitDesc') . '</td>';
+print '<td class="center">';
+print '<input type="number" name="closed_limit" value="' . (int) $currentLimit . '" min="0" max="9999" style="width:80px;text-align:center;">';
+print ' <input type="submit" class="button smallpaddingimp" value="' . $langs->trans('Modify') . '">';
+print '</td></tr>';
+print '</table>';
+print '</form>';
+
+// Page end
+print dol_get_fiche_end();
+llxFooter();
+$db->close();

--- a/js/modules/ticket_action_card.js
+++ b/js/modules/ticket_action_card.js
@@ -2023,7 +2023,12 @@ window.digiriskdolibarr.ticketPickerKanban.updateCounts = function() {
 window.digiriskdolibarr.ticketPickerKanban.saveDim = function(ticketId, dim, newVal, $card) {
     var token     = window.saturne.toolbox.getToken();
     var sep       = window.saturne.toolbox.getQuerySeparator(document.URL);
-    var actionMap = {type: 'updateTicketType', group: 'updateTicketGroup', severity: 'updateTicketSeverity'};
+    var actionMap = {
+        status:   'updateTicketStatus',
+        type:     'updateTicketType',
+        group:    'updateTicketGroup',
+        severity: 'updateTicketSeverity'
+    };
     var action    = actionMap[dim];
     if (!action) {
         return;

--- a/langs/fr_FR/digiriskdolibarr.lang
+++ b/langs/fr_FR/digiriskdolibarr.lang
@@ -1815,3 +1815,30 @@ Move                                  = Déplacer
 Hide                                  = Masquer
 Show                                  = Afficher
 
+# ===========================================================================
+# Ticket kanban — admin logging config — issue #4753
+# ===========================================================================
+TicketKanban                           = Kanban tickets
+TicketKanbanLogging                    = Kanban tickets — Historique des modifications
+TicketKanbanLoggingDescription         = Activer la création d'événements lors des modifications dans le kanban
+TicketKanbanLogStatus                  = Modification du statut
+TicketKanbanLogStatusDesc              = Créer un événement lorsque le statut d'un ticket est modifié via le kanban
+TicketKanbanLogAssignee                = Modification de l'assigné
+TicketKanbanLogAssigneeDesc            = Créer un événement lorsque l'assigné d'un ticket est modifié via le kanban
+TicketKanbanLogCategoryAdd             = Ajout d'un tag
+TicketKanbanLogCategoryAddDesc         = Créer un événement lorsqu'un tag est ajouté à un ticket via le kanban
+TicketKanbanLogCategoryRemove          = Retrait d'un tag
+TicketKanbanLogCategoryRemoveDesc      = Créer un événement lorsqu'un tag est retiré d'un ticket via le kanban
+TicketKanbanLogType                    = Modification du type
+TicketKanbanLogTypeDesc                = Créer un événement lorsque le type d'un ticket est modifié via le kanban
+TicketKanbanLogGroup                   = Modification du groupe
+TicketKanbanLogGroupDesc               = Créer un événement lorsque le groupe d'un ticket est modifié via le kanban
+TicketKanbanLogSeverity                = Modification de la sévérité
+TicketKanbanLogSeverityDesc            = Créer un événement lorsque la sévérité d'un ticket est modifiée via le kanban
+TicketKanbanLogSubject                 = Modification du sujet
+TicketKanbanLogSubjectDesc             = Créer un événement lorsque le sujet d'un ticket est modifié via le kanban
+TicketKanbanLogDeadline                = Modification de la date limite
+TicketKanbanLogDeadlineDesc            = Créer un événement lorsque la date limite d'un ticket est modifiée via le kanban
+TicketKanbanClosedLimit                = Limite tickets fermés
+TicketKanbanClosedLimitDesc            = Nombre maximum de tickets fermés/annulés affichés dans le kanban (0 = illimité)
+

--- a/lib/digiriskdolibarr.lib.php
+++ b/lib/digiriskdolibarr.lib.php
@@ -58,6 +58,11 @@ function digiriskdolibarr_admin_prepare_head(): array
     $head[$h][2] = 'actionplan';
     $h++;
 
+    $head[$h][0] = dol_buildpath('/digiriskdolibarr/admin/config/ticket_kanban.php', 1);
+    $head[$h][1] = $conf->browser->layout != 'phone' ? '<i class="fas fa-th-large pictofixedwidth"></i>' . $langs->trans('TicketKanban') : '<i class="fas fa-th-large"></i>';
+    $head[$h][2] = 'ticket_kanban';
+    $h++;
+
     $head[$h][0] = dol_buildpath('/digiriskdolibarr/admin/config/firepermit.php', 1);
     $head[$h][1] = $conf->browser->layout != 'phone' ? '<i class="fas fa-fire-alt pictofixedwidth"></i>' . $langs->trans('FirePermit') : '<i class="fas fa-fire-alt"></i>';
     $head[$h][2] = 'firepermit';

--- a/view/ticket/ticket_action_card.php
+++ b/view/ticket/ticket_action_card.php
@@ -42,6 +42,7 @@ if (file_exists('../digiriskdolibarr.main.inc.php')) {
 require_once DOL_DOCUMENT_ROOT . '/ticket/class/ticket.class.php';
 require_once DOL_DOCUMENT_ROOT . '/user/class/user.class.php';
 require_once DOL_DOCUMENT_ROOT . '/categories/class/categorie.class.php';
+require_once DOL_DOCUMENT_ROOT . '/comm/action/class/actioncomm.class.php';
 
 // Global variables definitions
 global $conf, $db, $hookmanager, $langs, $moduleNameLowerCase, $user;
@@ -70,6 +71,37 @@ $permissionToRead  = $user->hasRight('ticket', 'read') && $user->hasRight($modul
 $permissionToWrite = $user->hasRight('ticket', 'write');
 saturne_check_access($permissionToRead);
 
+/**
+ * Create an ActionComm audit event for a ticket kanban modification.
+ * Only fires when the given config constant is enabled (non-zero).
+ *
+ * @param DoliDB $db         Database connection
+ * @param User   $user       Current user
+ * @param Ticket $ticket     The modified ticket
+ * @param string $constName  Config constant controlling whether this event is logged
+ * @param string $label      Short event label
+ * @param string $note       Detailed private note
+ * @return void
+ */
+function createTicketKanbanEvent($db, $user, $ticket, $constName, $label, $note)
+{
+    if (empty(getDolGlobalInt($constName))) {
+        return;
+    }
+
+    $actioncomm               = new ActionComm($db);
+    $actioncomm->type_code    = 'AC_OTH_AUTO';
+    $actioncomm->code         = 'AC_OTH_AUTO';
+    $actioncomm->label        = $label;
+    $actioncomm->note_private = $note;
+    $actioncomm->fk_element   = $ticket->id;
+    $actioncomm->elementtype  = 'ticket';
+    $actioncomm->userownerid  = $user->id;
+    $actioncomm->datep        = dol_now();
+    $actioncomm->percentage   = -1;
+    $actioncomm->create($user);
+}
+
 /*
  * Actions
  */
@@ -88,12 +120,16 @@ if ($action == 'updateTicketStatus' && !empty(GETPOSTINT('ticket_id'))) {
     if ($result > 0) {
         $res = $ticketToUpdate->setStatut($newStatus, $user);
         if ($res > 0) {
+            createTicketKanbanEvent($db, $user, $ticketToUpdate, 'DIGIRISKDOLIBARR_TICKET_KANBAN_LOG_STATUS',
+                'Statut modifié (kanban)', 'Statut modifié → ' . $newStatus);
             print json_encode(['success' => 1]);
         } else {
+            dol_syslog('ticket_action_card.php updateTicketStatus: setStatut failed ticketId=' . $ticketId . ' - ' . $ticketToUpdate->error, LOG_ERR);
             http_response_code(500);
             print json_encode(['success' => 0, 'error' => $ticketToUpdate->error]);
         }
     } else {
+        dol_syslog('ticket_action_card.php updateTicketStatus: ticket not found ticketId=' . $ticketId, LOG_ERR);
         http_response_code(404);
         print json_encode(['success' => 0, 'error' => 'Ticket not found']);
     }
@@ -123,12 +159,16 @@ if ($action == 'updateTicketAssignee' && !empty(GETPOSTINT('ticket_id'))) {
                 $fullname = $assignedUser->getFullName($langs);
                 $initials = strtoupper(mb_substr($assignedUser->firstname, 0, 1) . mb_substr($assignedUser->lastname, 0, 1));
             }
+            createTicketKanbanEvent($db, $user, $ticketToUpdate, 'DIGIRISKDOLIBARR_TICKET_KANBAN_LOG_ASSIGNEE',
+                'Assigné modifié (kanban)', 'Assigné → ' . ($fullname ?: $langs->trans('Unassigned')));
             print json_encode(['success' => 1, 'fullname' => $fullname, 'initials' => $initials]);
         } else {
+            dol_syslog('ticket_action_card.php updateTicketAssignee: update failed ticketId=' . $ticketId . ' - ' . $ticketToUpdate->error, LOG_ERR);
             http_response_code(500);
             print json_encode(['success' => 0, 'error' => $ticketToUpdate->error]);
         }
     } else {
+        dol_syslog('ticket_action_card.php updateTicketAssignee: ticket not found ticketId=' . $ticketId, LOG_ERR);
         http_response_code(404);
         print json_encode(['success' => 0, 'error' => 'Ticket not found']);
     }
@@ -152,14 +192,19 @@ if ($action == 'addTicketCategory' && !empty(GETPOSTINT('ticket_id'))) {
         if ($resCat > 0) {
             $res = $cat->add_type($ticketToUpdate, 'ticket');
             if ($res > 0 || $res == -3) {
+                createTicketKanbanEvent($db, $user, $ticketToUpdate, 'DIGIRISKDOLIBARR_TICKET_KANBAN_LOG_CATEGORY_ADD',
+                    'Tag ajouté (kanban)', 'Tag ajouté : ' . $cat->label);
                 print json_encode(['success' => 1, 'label' => $cat->label, 'color' => $cat->color, 'id' => $cat->id]);
             } else {
+                dol_syslog('ticket_action_card.php addTicketCategory: add_type failed ticketId=' . $ticketId . ' catId=' . $catId . ' - ' . $cat->error, LOG_ERR);
                 print json_encode(['success' => 0, 'error' => $cat->error]);
             }
         } else {
+            dol_syslog('ticket_action_card.php addTicketCategory: category not found catId=' . $catId, LOG_ERR);
             print json_encode(['success' => 0, 'error' => 'Category not found']);
         }
     } else {
+        dol_syslog('ticket_action_card.php addTicketCategory: ticket not found ticketId=' . $ticketId, LOG_ERR);
         http_response_code(404);
         print json_encode(['success' => 0, 'error' => 'Ticket not found']);
     }
@@ -183,14 +228,19 @@ if ($action == 'removeTicketCategory' && !empty(GETPOSTINT('ticket_id'))) {
         if ($resCat > 0) {
             $res = $cat->del_type($ticketToUpdate, 'ticket');
             if ($res >= 0) {
+                createTicketKanbanEvent($db, $user, $ticketToUpdate, 'DIGIRISKDOLIBARR_TICKET_KANBAN_LOG_CATEGORY_REMOVE',
+                    'Tag retiré (kanban)', 'Tag retiré : ' . $cat->label);
                 print json_encode(['success' => 1]);
             } else {
+                dol_syslog('ticket_action_card.php removeTicketCategory: del_type failed ticketId=' . $ticketId . ' catId=' . $catId . ' - ' . $cat->error, LOG_ERR);
                 print json_encode(['success' => 0, 'error' => $cat->error]);
             }
         } else {
+            dol_syslog('ticket_action_card.php removeTicketCategory: category not found catId=' . $catId, LOG_ERR);
             print json_encode(['success' => 0, 'error' => 'Category not found']);
         }
     } else {
+        dol_syslog('ticket_action_card.php removeTicketCategory: ticket not found ticketId=' . $ticketId, LOG_ERR);
         http_response_code(404);
         print json_encode(['success' => 0, 'error' => 'Ticket not found']);
     }
@@ -212,12 +262,16 @@ if ($action == 'updateTicketType' && !empty(GETPOSTINT('ticket_id'))) {
         $ticketToUpdate->type_code = !empty($dimValue) && $dimValue !== '__none__' ? $dimValue : '';
         $res = $ticketToUpdate->update($user);
         if ($res > 0) {
+            createTicketKanbanEvent($db, $user, $ticketToUpdate, 'DIGIRISKDOLIBARR_TICKET_KANBAN_LOG_TYPE',
+                'Type modifié (kanban)', 'Type modifié → ' . ($dimValue ?: 'Non défini'));
             print json_encode(['success' => 1]);
         } else {
+            dol_syslog('ticket_action_card.php updateTicketType: update failed ticketId=' . $ticketId . ' - ' . $ticketToUpdate->error, LOG_ERR);
             http_response_code(500);
             print json_encode(['success' => 0, 'error' => $ticketToUpdate->error]);
         }
     } else {
+        dol_syslog('ticket_action_card.php updateTicketType: ticket not found ticketId=' . $ticketId, LOG_ERR);
         http_response_code(404);
         print json_encode(['success' => 0, 'error' => 'Ticket not found']);
     }
@@ -239,12 +293,16 @@ if ($action == 'updateTicketGroup' && !empty(GETPOSTINT('ticket_id'))) {
         $ticketToUpdate->category_code = !empty($dimValue) && $dimValue !== '__none__' ? $dimValue : '';
         $res = $ticketToUpdate->update($user);
         if ($res > 0) {
+            createTicketKanbanEvent($db, $user, $ticketToUpdate, 'DIGIRISKDOLIBARR_TICKET_KANBAN_LOG_GROUP',
+                'Groupe modifié (kanban)', 'Groupe modifié → ' . ($dimValue ?: 'Non défini'));
             print json_encode(['success' => 1]);
         } else {
+            dol_syslog('ticket_action_card.php updateTicketGroup: update failed ticketId=' . $ticketId . ' - ' . $ticketToUpdate->error, LOG_ERR);
             http_response_code(500);
             print json_encode(['success' => 0, 'error' => $ticketToUpdate->error]);
         }
     } else {
+        dol_syslog('ticket_action_card.php updateTicketGroup: ticket not found ticketId=' . $ticketId, LOG_ERR);
         http_response_code(404);
         print json_encode(['success' => 0, 'error' => 'Ticket not found']);
     }
@@ -266,12 +324,16 @@ if ($action == 'updateTicketSeverity' && !empty(GETPOSTINT('ticket_id'))) {
         $ticketToUpdate->severity_code = !empty($dimValue) && $dimValue !== '__none__' ? $dimValue : '';
         $res = $ticketToUpdate->update($user);
         if ($res > 0) {
+            createTicketKanbanEvent($db, $user, $ticketToUpdate, 'DIGIRISKDOLIBARR_TICKET_KANBAN_LOG_SEVERITY',
+                'Sévérité modifiée (kanban)', 'Sévérité modifiée → ' . ($dimValue ?: 'Non définie'));
             print json_encode(['success' => 1]);
         } else {
+            dol_syslog('ticket_action_card.php updateTicketSeverity: update failed ticketId=' . $ticketId . ' - ' . $ticketToUpdate->error, LOG_ERR);
             http_response_code(500);
             print json_encode(['success' => 0, 'error' => $ticketToUpdate->error]);
         }
     } else {
+        dol_syslog('ticket_action_card.php updateTicketSeverity: ticket not found ticketId=' . $ticketId, LOG_ERR);
         http_response_code(404);
         print json_encode(['success' => 0, 'error' => 'Ticket not found']);
     }
@@ -293,12 +355,16 @@ if ($action == 'updateTicketSubject' && !empty(GETPOSTINT('ticket_id'))) {
         $ticketToUpdate->subject = $newSubject;
         $res = $ticketToUpdate->update($user);
         if ($res > 0) {
+            createTicketKanbanEvent($db, $user, $ticketToUpdate, 'DIGIRISKDOLIBARR_TICKET_KANBAN_LOG_SUBJECT',
+                'Sujet modifié (kanban)', 'Sujet modifié → "' . $newSubject . '"');
             print json_encode(['success' => 1, 'subject' => $newSubject]);
         } else {
+            dol_syslog('ticket_action_card.php updateTicketSubject: update failed ticketId=' . $ticketId . ' - ' . $ticketToUpdate->error, LOG_ERR);
             http_response_code(500);
             print json_encode(['success' => 0, 'error' => $ticketToUpdate->error]);
         }
     } else {
+        dol_syslog('ticket_action_card.php updateTicketSubject: ticket not found ticketId=' . $ticketId, LOG_ERR);
         http_response_code(404);
         print json_encode(['success' => 0, 'error' => 'Ticket not found']);
     }
@@ -372,7 +438,12 @@ if ($object->id <= 0) {
         $db->free($resCats);
     }
 
-    // Tickets with enriched data (assignee, severity, type, group, company)
+    // Tickets with enriched data (assignee, severity, type, group, company).
+    // Closed and canceled tickets are limited by the admin config to avoid overloading the board.
+    $closedStatusList  = implode(',', [Ticket::STATUS_CLOSED, Ticket::STATUS_CANCELED]);
+    $closedLimit       = getDolGlobalInt('DIGIRISKDOLIBARR_TICKET_KANBAN_CLOSED_LIMIT', 50);
+    $closedLimitClause = $closedLimit > 0 ? ' AND t.fk_statut NOT IN (' . $closedStatusList . ')' : '';
+
     $sqlTickets = 'SELECT t.rowid, t.ref, t.subject, t.fk_statut, t.datec, t.severity_code,'
         . ' t.type_code, t.category_code,'
         . ' t.fk_user_assign, t.fk_soc,'
@@ -382,8 +453,24 @@ if ($object->id <= 0) {
         . ' LEFT JOIN ' . MAIN_DB_PREFIX . 'user u ON u.rowid = t.fk_user_assign'
         . ' LEFT JOIN ' . MAIN_DB_PREFIX . 'societe s ON s.rowid = t.fk_soc'
         . ' WHERE t.entity IN (' . getEntity('ticket') . ')'
+        . $closedLimitClause
         . ' ORDER BY t.datec DESC'
         . ' LIMIT 500';
+
+    if ($closedLimit > 0) {
+        $sqlClosed = 'SELECT t.rowid, t.ref, t.subject, t.fk_statut, t.datec, t.severity_code,'
+            . ' t.type_code, t.category_code,'
+            . ' t.fk_user_assign, t.fk_soc,'
+            . ' u.firstname as assign_firstname, u.lastname as assign_lastname, u.photo as assign_photo,'
+            . ' s.nom as company_name'
+            . ' FROM ' . MAIN_DB_PREFIX . 'ticket t'
+            . ' LEFT JOIN ' . MAIN_DB_PREFIX . 'user u ON u.rowid = t.fk_user_assign'
+            . ' LEFT JOIN ' . MAIN_DB_PREFIX . 'societe s ON s.rowid = t.fk_soc'
+            . ' WHERE t.entity IN (' . getEntity('ticket') . ')'
+            . ' AND t.fk_statut IN (' . $closedStatusList . ')'
+            . ' ORDER BY t.datec DESC'
+            . ' LIMIT ' . (int) $closedLimit;
+    }
     $resTickets = $db->query($sqlTickets);
     $ticketIds  = [];
     if ($resTickets) {
@@ -434,6 +521,59 @@ if ($object->id <= 0) {
             $ticketIds[] = (int) $row->rowid;
         }
         $db->free($resTickets);
+    }
+
+    // Append closed/canceled tickets (limited by admin config)
+    if ($closedLimit > 0 && !empty($sqlClosed)) {
+        $resClosed = $db->query($sqlClosed);
+        if ($resClosed) {
+            while ($row = $db->fetch_object($resClosed)) {
+                $assignId       = (int) $row->fk_user_assign;
+                $assignInitials = '';
+                $assignFullname = '';
+                $assignPhoto    = '';
+                if ($assignId > 0) {
+                    $assignFullname = trim($row->assign_firstname . ' ' . $row->assign_lastname);
+                    $assignInitials = strtoupper(mb_substr($row->assign_firstname, 0, 1) . mb_substr($row->assign_lastname, 0, 1));
+                    if (!empty($row->assign_photo)) {
+                        $photoFile = DOL_DATA_ROOT . '/users/' . $assignId . '/' . $row->assign_photo;
+                        if (file_exists($photoFile)) {
+                            $assignPhoto = DOL_URL_ROOT . '/viewimage.php?modulepart=userphoto&entity=' . $conf->entity
+                                . '&file=' . urlencode($assignId . '/' . $row->assign_photo)
+                                . '&cache=' . $assignId;
+                        }
+                    }
+                }
+
+                $detailUrl = dol_buildpath('/custom/digiriskdolibarr/view/ticket/ticket_action_card.php', 1) . '?id=' . (int) $row->rowid;
+                $sevCode   = strtoupper((string) ($row->severity_code ?: ''));
+                $sevTrans  = $sevCode !== '' ? $langs->trans('TicketSeverityShort' . $sevCode) : '';
+                if ($sevTrans === 'TicketSeverityShort' . $sevCode) {
+                    $sevTrans = $sevCode;
+                }
+
+                $pickerTicketsJson[] = [
+                    'id'              => (int) $row->rowid,
+                    'ref'             => $row->ref,
+                    'subject'         => $row->subject,
+                    'status'          => (int) $row->fk_statut,
+                    'severity_code'   => $sevCode,
+                    'severity_label'  => $sevTrans,
+                    'type_code'       => (string) ($row->type_code ?: ''),
+                    'category_code'   => (string) ($row->category_code ?: ''),
+                    'date_c'          => $row->datec ? dol_print_date($db->jdate($row->datec), 'day') : '',
+                    'company_name'    => $row->company_name ?: '',
+                    'assign_id'       => $assignId,
+                    'assign_fullname' => $assignFullname,
+                    'assign_initials' => $assignInitials,
+                    'assign_photo'    => $assignPhoto,
+                    'categories'      => [],
+                    'url'             => $detailUrl,
+                ];
+                $ticketIds[] = (int) $row->rowid;
+            }
+            $db->free($resClosed);
+        }
     }
 
     // Batch-load categories for all tickets
@@ -595,13 +735,19 @@ if ($object->id <= 0) {
     // -----------------------------------------------------------------------
     $tempTicket = new Ticket($db);
     $statusDefs = [
-        Ticket::STATUS_NOT_READ    => ['icon' => 'fa-inbox',          'color' => '#6c757d'],
-        Ticket::STATUS_READ        => ['icon' => 'fa-eye',            'color' => '#17a2b8'],
-        Ticket::STATUS_ASSIGNED    => ['icon' => 'fa-user',           'color' => '#5b8cdb'],
-        Ticket::STATUS_IN_PROGRESS => ['icon' => 'fa-cogs',           'color' => '#e9ad4f'],
-        Ticket::STATUS_NEED_MORE_INFO => ['icon' => 'fa-question-circle', 'color' => '#9c6ade'],
-        Ticket::STATUS_CLOSED      => ['icon' => 'fa-check-circle',   'color' => '#28a745'],
+        Ticket::STATUS_NOT_READ       => ['icon' => 'fa-inbox',            'color' => '#6c757d'],
+        Ticket::STATUS_READ           => ['icon' => 'fa-eye',              'color' => '#17a2b8'],
+        Ticket::STATUS_ASSIGNED       => ['icon' => 'fa-user',             'color' => '#5b8cdb'],
+        Ticket::STATUS_IN_PROGRESS    => ['icon' => 'fa-cogs',             'color' => '#e9ad4f'],
+        Ticket::STATUS_NEED_MORE_INFO => ['icon' => 'fa-question-circle',  'color' => '#9c6ade'],
+        Ticket::STATUS_CLOSED         => ['icon' => 'fa-check-circle',     'color' => '#28a745'],
+        Ticket::STATUS_CANCELED       => ['icon' => 'fa-times-circle',     'color' => '#dc3545'],
     ];
+
+    // STATUS_WAITING (7 = OnHold) is only available when TICKET_INCLUDE_SUSPENDED_STATUS is enabled
+    if (getDolGlobalString('TICKET_INCLUDE_SUSPENDED_STATUS')) {
+        $statusDefs[Ticket::STATUS_WAITING] = ['icon' => 'fa-pause-circle', 'color' => '#fd7e14'];
+    }
 
     foreach ($statusDefs as $statusInt => $statusMeta) {
         $transKey = !empty($tempTicket->labelStatusShort[$statusInt]) ? $tempTicket->labelStatusShort[$statusInt] : '';


### PR DESCRIPTION
## Summary

- Ajout de `dol_syslog(..., LOG_ERR)` sur toutes les branches d'erreur (500/404) dans les 8 handlers AJAX du kanban picker
- Helper `createTicketKanbanEvent()` + appels ActionComm après chaque modification réussie (statut, assigné, tag +/-, type, groupe, sévérité, sujet)
- Page admin `admin/config/ticket_kanban.php` avec 9 toggles `ajax_constantonoff` pour activer/désactiver l'audit par action
- Statuts 7 (OnHold) et 9 (Annulé) ajoutés aux colonnes kanban (STATUS_WAITING conditionné à `TICKET_INCLUDE_SUSPENDED_STATUS`)
- Constante `DIGIRISKDOLIBARR_TICKET_KANBAN_CLOSED_LIMIT` (défaut 50) : requête séparée avec LIMIT pour les tickets fermés/annulés, configurable sur la page admin
- Fix bug JS : `saveDim()` ne mappait pas `status` vers `updateTicketStatus`, les drag-drops dans l'onglet Statut ne sauvegardaient jamais

Closes #4753

## Test plan

- [ ] Déplacer un ticket dans l'onglet Statut et vérifier que le statut est bien enregistré
- [ ] Activer un toggle sur la page admin Kanban Tickets, effectuer l'action correspondante et vérifier l'événement dans l'historique du ticket
- [ ] Vérifier que les colonnes OnHold et Annulé apparaissent correctement (OnHold uniquement si `TICKET_INCLUDE_SUSPENDED_STATUS` activé)
- [ ] Réduire la limite tickets fermés à 5, recharger le kanban et vérifier que seuls 5 tickets fermés/annulés sont affichés
- [ ] Provoquer une erreur et vérifier le `dol_syslog` dans les logs Dolibarr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
