### PR TITLE
#4443 [Ticket] feat: drawer de creation rapide depuis le kanban

### DIFF
--- a/core/modules/modDigiriskDolibarr.class.php
+++ b/core/modules/modDigiriskDolibarr.class.php
@@ -1751,13 +1751,30 @@ class modDigiriskdolibarr extends DolibarrModules
 		$this->menu[$r++] = [
 			'fk_menu'  => 'fk_mainmenu=ticket,fk_leftmenu=ticketstats',
 			'type'     => 'left',
-			'titre'    => $langs->transnoentities('TicketActionCard'),
-			'prefix'   => '<i class="fas fa-hand-pointer pictofixedwidth"></i>',
+			'titre'    => $langs->transnoentities('TicketKanban'),
+			'prefix'   => '<i class="fas fa-columns pictofixedwidth"></i>',
 			'mainmenu' => 'ticket',
-			'leftmenu' => 'digiriskticketactioncard',
+			'leftmenu' => 'digiriskticketkanban',
 			'url'      => '/digiriskdolibarr/view/ticket/ticket_action_card.php',
 			'langs'    => 'digiriskdolibarr@digiriskdolibarr',
 			'position' => 100 + $r,
+			'enabled'  => '$conf->digiriskdolibarr->enabled && $conf->ticket->enabled',
+			'perms'    => '$user->rights->ticket->read && $user->rights->digiriskdolibarr->lire',
+			'target'   => '',
+			'user'     => 0,
+		];
+
+		// Entrée liste de tickets (vue standard Dolibarr).
+		$this->menu[$r++] = [
+			'fk_menu'  => 'fk_mainmenu=ticket,fk_leftmenu=ticketstats',
+			'type'     => 'left',
+			'titre'    => $langs->transnoentities('List'),
+			'prefix'   => '<i class="fas fa-list pictofixedwidth"></i>',
+			'mainmenu' => 'ticket',
+			'leftmenu' => 'digiriskticketlist',
+			'url'      => '/ticket/list.php',
+			'langs'    => 'digiriskdolibarr@digiriskdolibarr',
+			'position' => 101 + $r,
 			'enabled'  => '$conf->digiriskdolibarr->enabled && $conf->ticket->enabled',
 			'perms'    => '$user->rights->ticket->read && $user->rights->digiriskdolibarr->lire',
 			'target'   => '',

--- a/core/tpl/ticket/ticket_action_card_picker.tpl.php
+++ b/core/tpl/ticket/ticket_action_card_picker.tpl.php
@@ -236,6 +236,16 @@ function renderDimKanban($columns, $colTickets, $dim, $allUsers, $allCats, $allS
         </div>
     </div>
 
+    <!-- Quick-create button -->
+    <?php if ($user->hasRight('ticket', 'write')) : ?>
+    <div class="tac-picker-topbar">
+        <button type="button" class="tac-picker-topbar__btn tac-quick-create-open" id="tacQuickCreateBtn">
+            <i class="fas fa-plus"></i> <?= $langs->trans('NewTicket') ?>
+        </button>
+    </div>
+    <?php endif; ?>
+
+
     <!-- Tab navigation -->
     <div class="tac-dim-tabs" id="tacDimTabs">
         <button class="tac-dim-tab active" data-dim="status">
@@ -274,3 +284,108 @@ function renderDimKanban($columns, $colTickets, $dim, $allUsers, $allCats, $allS
     </div>
 
 </div>
+
+<?php if ($user->hasRight('ticket', 'write')) : ?>
+<!-- Quick-create drawer (slide-in from right) -->
+<div class="tac-quick-create" id="tacQuickCreate" aria-hidden="true">
+    <div class="tac-quick-create__overlay tac-quick-create-close"></div>
+    <div class="tac-quick-create__drawer" role="dialog" aria-modal="true" aria-label="<?= dol_escape_htmltag($langs->trans('NewTicket')) ?>">
+        <div class="tac-quick-create__header">
+            <span class="tac-quick-create__title"><i class="fas fa-ticket-alt"></i> <?= $langs->trans('NewTicket') ?></span>
+            <button type="button" class="tac-quick-create__close tac-quick-create-close" aria-label="<?= dol_escape_htmltag($langs->trans('Close')) ?>">
+                <i class="fas fa-times"></i>
+            </button>
+        </div>
+
+        <form class="tac-quick-create__form" id="tacQuickCreateForm" novalidate>
+            <input type="hidden" name="token" value="<?= newToken() ?>">
+
+            <!-- Sujet -->
+            <div class="tac-qc-field tac-qc-field--required">
+                <label class="tac-qc-label" for="tacQcSubject">
+                    <i class="fas fa-heading"></i> <?= $langs->trans('Subject') ?>
+                </label>
+                <input type="text" id="tacQcSubject" name="subject" class="tac-qc-input" required
+                       placeholder="<?= dol_escape_htmltag($langs->trans('TicketSubjectPlaceholder') !== 'TicketSubjectPlaceholder' ? $langs->trans('TicketSubjectPlaceholder') : 'Titre du ticket...') ?>">
+            </div>
+
+            <!-- Type (pleine largeur) -->
+            <div class="tac-qc-field">
+                <label class="tac-qc-label" for="tacQcType">
+                    <i class="fas fa-tag"></i> <?= $langs->trans('Type') ?>
+                </label>
+                <select id="tacQcType" name="type_code" class="tac-qc-select">
+                    <option value=""><?= dol_escape_htmltag($langs->trans('SelectNothing')) ?></option>
+                    <?php foreach ($createFormTypes as $code => $label) : ?>
+                    <option value="<?= dol_escape_htmltag($code) ?>"><?= dol_escape_htmltag($label) ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+
+            <!-- Sévérité + Assigné (2 colonnes) -->
+            <div class="tac-qc-row">
+                <div class="tac-qc-field">
+                    <label class="tac-qc-label" for="tacQcSeverity">
+                        <i class="fas fa-exclamation-triangle"></i> <?= $langs->trans('Severity') ?>
+                    </label>
+                    <select id="tacQcSeverity" name="severity_code" class="tac-qc-select">
+                        <option value=""><?= dol_escape_htmltag($langs->trans('SelectNothing')) ?></option>
+                        <?php foreach ($createFormSeverities as $code => $label) : ?>
+                        <option value="<?= dol_escape_htmltag($code) ?>"><?= dol_escape_htmltag($label) ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="tac-qc-field">
+                    <label class="tac-qc-label" for="tacQcAssignee">
+                        <i class="fas fa-user-check"></i> <?= $langs->trans('AssignedTo') ?>
+                    </label>
+                    <select id="tacQcAssignee" name="fk_user_assign" class="tac-qc-select">
+                        <option value="0"><?= dol_escape_htmltag($langs->trans('Unassigned')) ?></option>
+                        <?php foreach ($createFormUsers as $u) : ?>
+                        <option value="<?= (int) $u['id'] ?>"><?= dol_escape_htmltag($u['fullname']) ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+            </div>
+
+            <!-- Message initial -->
+            <div class="tac-qc-field">
+                <label class="tac-qc-label" for="tacQcMessage">
+                    <i class="fas fa-comment-alt"></i> <?= $langs->trans('TicketInitialMessage') ?>
+                </label>
+                <textarea id="tacQcMessage" name="message" class="tac-qc-textarea"
+                          rows="4" placeholder="<?= dol_escape_htmltag($langs->trans('OptionalDescription')) ?>"></textarea>
+            </div>
+
+            <!-- Pièces jointes -->
+            <div class="tac-qc-field">
+                <label class="tac-qc-label">
+                    <i class="fas fa-paperclip"></i> <?= $langs->trans('QuickCreateAttachments') ?>
+                </label>
+                <div class="tac-qc-dropzone" id="tacQcDropzone" tabindex="0" role="button"
+                     aria-label="<?= dol_escape_htmltag($langs->trans('QuickCreateDropzone')) ?>">
+                    <input type="file" id="tacQcFiles" name="attachments[]" multiple
+                           class="tac-qc-file-input" accept="image/*,.pdf,.doc,.docx,.xls,.xlsx,.odt,.ods,.txt,.zip">
+                    <div class="tac-qc-dropzone__icon"><i class="fas fa-cloud-upload-alt"></i></div>
+                    <div class="tac-qc-dropzone__label"><?= $langs->trans('QuickCreateDropzone') ?></div>
+                    <div class="tac-qc-dropzone__hint"><?= $langs->trans('QuickCreateAttachmentHint') ?></div>
+                </div>
+                <ul class="tac-qc-file-list" id="tacQcFileList"></ul>
+            </div>
+
+            <!-- Toast interne au formulaire -->
+            <div class="tac-qc-toast" id="tacQcToast" aria-live="polite"></div>
+
+            <!-- Actions -->
+            <div class="tac-qc-actions">
+                <button type="button" class="tac-qc-btn tac-qc-btn--secondary tac-quick-create-close">
+                    <?= $langs->trans('Cancel') ?>
+                </button>
+                <button type="submit" class="tac-qc-btn tac-qc-btn--primary" id="tacQcSubmit">
+                    <i class="fas fa-plus-circle"></i> <?= $langs->trans('CreateTicket') ?>
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+<?php endif; ?>

--- a/css/scss/page/_page-ticket-action-card.scss
+++ b/css/scss/page/_page-ticket-action-card.scss
@@ -1950,3 +1950,364 @@ $tac-border:       #e5e7eb;
 
     &.visible { display: inline-block; }
 }
+
+// ---------------------------------------------------------------------------
+// Picker top bar — "Nouveau ticket" button sits above the tabs.
+// ---------------------------------------------------------------------------
+.tac-picker-topbar {
+    display: flex;
+    justify-content: flex-start;
+    margin-bottom: 10px;
+
+    &__btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        padding: 7px 16px;
+        background: $tac-blue;
+        color: #fff;
+        border: none;
+        border-radius: 8px;
+        font-family: inherit;
+        font-size: 0.92em;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background 0.15s ease, box-shadow 0.15s ease;
+
+        &:hover { background: darken($tac-blue, 6%); box-shadow: 0 4px 12px rgba(13,138,255,0.3); }
+
+        i { font-size: 0.9em; }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Quick-create drawer.
+// ---------------------------------------------------------------------------
+.tac-quick-create {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+
+    &.is-open { display: block; }
+
+    &__overlay {
+        position: absolute;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.45);
+        animation: tac-qc-fade-in 0.2s ease;
+        cursor: pointer;
+    }
+
+    &__drawer {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        width: 100%;
+        max-width: 480px;
+        background: #fff;
+        box-shadow: -4px 0 24px rgba(0, 0, 0, 0.15);
+        display: flex;
+        flex-direction: column;
+        animation: tac-qc-slide-in 0.22s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+        overflow: hidden;
+    }
+
+    &__header {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 18px 20px;
+        border-bottom: 1px solid $tac-border;
+        background: $tac-bg;
+        flex: 0 0 auto;
+    }
+
+    &__title {
+        flex: 1 1 auto;
+        font-size: 1.05em;
+        font-weight: 700;
+        color: #1f2937;
+
+        i { color: $tac-blue; margin-right: 6px; }
+    }
+
+    &__close {
+        appearance: none;
+        background: transparent;
+        border: 1px solid $tac-border;
+        border-radius: 6px;
+        width: 32px;
+        height: 32px;
+        cursor: pointer;
+        color: $tac-grey;
+        font-size: 1em;
+        transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+        flex: 0 0 auto;
+
+        &:hover { background: rgba(224,83,83,0.08); color: $tac-red; border-color: $tac-red; }
+    }
+
+    &__form {
+        flex: 1 1 auto;
+        overflow-y: auto;
+        padding: 20px;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+    }
+}
+
+@keyframes tac-qc-fade-in {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+@keyframes tac-qc-slide-in {
+    from { transform: translateX(100%); }
+    to   { transform: translateX(0); }
+}
+
+// ----- Form field primitives -----
+.tac-qc-field {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+
+    &--required .tac-qc-label::after {
+        content: ' *';
+        color: $tac-red;
+    }
+}
+
+.tac-qc-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+
+    @media (max-width: 480px) { grid-template-columns: 1fr; }
+}
+
+.tac-qc-label {
+    font-size: 0.76em;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: $tac-grey;
+
+    i { color: $tac-blue; margin-right: 4px; }
+}
+
+.tac-qc-input,
+.tac-qc-select,
+.tac-qc-textarea {
+    width: 100%;
+    padding: 8px 10px;
+    border: 1px solid $tac-border;
+    border-radius: 7px;
+    background: #fff;
+    font-family: inherit;
+    font-size: 0.93em;
+    color: #1f2937;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+
+    &:focus {
+        outline: none;
+        border-color: $tac-blue;
+        box-shadow: 0 0 0 3px rgba(13, 138, 255, 0.15);
+    }
+
+    &:invalid:not(:placeholder-shown) {
+        border-color: $tac-red;
+    }
+}
+
+.tac-qc-textarea {
+    resize: vertical;
+    min-height: 90px;
+}
+
+.tac-qc-toast {
+    padding: 10px 12px;
+    border-radius: 7px;
+    font-size: 0.9em;
+
+    &:empty { display: none; }
+
+    &.is-error {
+        background: rgba(224, 83, 83, 0.1);
+        border: 1px solid rgba(224, 83, 83, 0.4);
+        color: darken($tac-red, 10%);
+    }
+
+    &.is-success {
+        background: rgba(34, 191, 78, 0.1);
+        border: 1px solid rgba(34, 191, 78, 0.4);
+        color: darken($tac-green, 16%);
+    }
+}
+
+.tac-qc-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    margin-top: 4px;
+    padding-top: 12px;
+    border-top: 1px solid $tac-border;
+    flex: 0 0 auto;
+}
+
+.tac-qc-btn {
+    appearance: none;
+    border: 1px solid $tac-border;
+    border-radius: 8px;
+    padding: 9px 20px;
+    font-family: inherit;
+    font-size: 0.93em;
+    font-weight: 600;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    transition: background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+
+    i { font-size: 0.95em; }
+
+    &--secondary {
+        background: #fff;
+        color: $tac-grey;
+        &:hover { background: rgba(0,0,0,0.04); border-color: darken($tac-border, 10%); }
+    }
+
+    &--primary {
+        background: $tac-blue;
+        color: #fff;
+        border-color: $tac-blue;
+
+        &:hover { background: darken($tac-blue, 6%); box-shadow: 0 4px 12px rgba(13,138,255,0.3); }
+
+        &[disabled] {
+            opacity: 0.55;
+            cursor: not-allowed;
+            &:hover { background: $tac-blue; box-shadow: none; }
+        }
+
+        // Loading spinner
+        &.is-loading {
+            position: relative;
+            color: transparent;
+            pointer-events: none;
+
+            &::after {
+                content: '';
+                position: absolute;
+                top: 50%;
+                left: 50%;
+                width: 16px;
+                height: 16px;
+                margin: -8px 0 0 -8px;
+                border: 2px solid rgba(255, 255, 255, 0.35);
+                border-top-color: #fff;
+                border-radius: 50%;
+                animation: tac-spin 0.65s linear infinite;
+            }
+        }
+    }
+}
+
+// ----- Dropzone pièces jointes -----
+.tac-qc-dropzone {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 20px 16px;
+    border: 2px dashed $tac-border;
+    border-radius: 10px;
+    background: $tac-bg;
+    text-align: center;
+    cursor: pointer;
+    transition: border-color 0.15s ease, background 0.15s ease;
+
+    &:hover,
+    &:focus { border-color: $tac-blue; background: rgba(13,138,255,0.04); outline: none; }
+
+    &.is-dragover {
+        border-color: $tac-blue;
+        background: rgba(13,138,255,0.08);
+
+        .tac-qc-dropzone__label { color: $tac-blue; font-weight: 600; }
+    }
+
+    &__icon {
+        font-size: 1.8em;
+        color: rgba(13,138,255,0.45);
+        line-height: 1;
+    }
+
+    &__label {
+        font-size: 0.88em;
+        color: $tac-grey;
+        transition: color 0.15s ease;
+    }
+
+    &__hint {
+        font-size: 0.75em;
+        color: lighten($tac-grey, 15%);
+    }
+}
+
+// The real <input type="file"> is invisible but covers the whole dropzone.
+.tac-qc-file-input {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0;
+    cursor: pointer;
+}
+
+// File list below the dropzone.
+.tac-qc-file-list {
+    list-style: none;
+    padding: 0;
+    margin: 6px 0 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+
+    &:empty { display: none; }
+
+    li {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 5px 8px;
+        background: #fff;
+        border: 1px solid $tac-border;
+        border-radius: 6px;
+        font-size: 0.85em;
+        color: #1f2937;
+
+        i { color: $tac-grey; flex: 0 0 auto; }
+
+        span { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+        button {
+            appearance: none;
+            background: transparent;
+            border: none;
+            color: $tac-grey;
+            cursor: pointer;
+            padding: 2px 4px;
+            border-radius: 4px;
+            font-size: 0.9em;
+            flex: 0 0 auto;
+
+            &:hover { color: $tac-red; background: rgba(224,83,83,0.08); }
+        }
+    }
+}

--- a/js/modules/ticket_action_card.js
+++ b/js/modules/ticket_action_card.js
@@ -1679,6 +1679,7 @@ window.digiriskdolibarr.ticketPickerKanban.init = function() {
     window.digiriskdolibarr.ticketPickerKanban.event();
     window.digiriskdolibarr.ticketPickerKanban.initSortable();
     window.digiriskdolibarr.ticketPickerKanban.initSettings();
+    window.digiriskdolibarr.ticketPickerKanban.initQuickCreate();
 
     // Restore the last active tab from localStorage.
     var savedDim = localStorage.getItem('tacPickerActiveDim');
@@ -2274,5 +2275,187 @@ window.digiriskdolibarr.ticketPickerKanban.initSettings = function() {
         $gVal.text(val + 'px');
         $board.css('gap', val + 'px');
         localStorage.setItem('tacPickerKanbanColGap', val);
+    });
+};
+
+// ---------------------------------------------------------------------------
+// Quick-create ticket drawer
+// ---------------------------------------------------------------------------
+
+/**
+ * Open the quick-create drawer and focus the subject field.
+ *
+ * @return {void}
+ */
+window.digiriskdolibarr.ticketPickerKanban.openQuickCreate = function() {
+    var $drawer = $('#tacQuickCreate');
+    if (!$drawer.length) {
+        return;
+    }
+    $drawer.addClass('is-open').attr('aria-hidden', 'false');
+    $('body').css('overflow', 'hidden');
+    // Reset the form and file list each time it opens.
+    $('#tacQuickCreateForm')[0].reset();
+    $('#tacQcFileList').empty();
+    $('#tacQcDropzone').removeClass('is-dragover');
+    $('#tacQcToast').removeClass('is-error is-success').text('');
+    $('#tacQcSubmit').removeClass('is-loading').prop('disabled', false);
+    setTimeout(function() { $('#tacQcSubject').trigger('focus'); }, 220);
+};
+
+/**
+ * Close the quick-create drawer.
+ *
+ * @return {void}
+ */
+window.digiriskdolibarr.ticketPickerKanban.closeQuickCreate = function() {
+    $('#tacQuickCreate').removeClass('is-open').attr('aria-hidden', 'true');
+    $('body').css('overflow', '');
+};
+
+/**
+ * Submit the quick-create form via AJAX (multipart/form-data for file uploads).
+ *
+ * @param {Event} e  Form submit event
+ * @return {void}
+ */
+window.digiriskdolibarr.ticketPickerKanban.submitQuickCreate = function(e) {
+    e.preventDefault();
+
+    var $form   = $('#tacQuickCreateForm');
+    var $submit = $('#tacQcSubmit');
+    var $toast  = $('#tacQcToast');
+
+    var subject = $.trim($('#tacQcSubject').val());
+    if (!subject) {
+        $toast.removeClass('is-success').addClass('is-error').text('Le sujet est obligatoire.');
+        $('#tacQcSubject').trigger('focus');
+        return;
+    }
+
+    var token = window.saturne.toolbox.getToken();
+    var sep   = window.saturne.toolbox.getQuerySeparator(document.URL);
+
+    // Use FormData so that file inputs are included in the request.
+    var fd = new FormData($form[0]);
+
+    $submit.addClass('is-loading').prop('disabled', true);
+    $toast.removeClass('is-error is-success').text('');
+
+    $.ajax({
+        url: document.URL + sep + 'action=createTicket&token=' + token,
+        type: 'POST',
+        dataType: 'json',
+        data: fd,
+        processData: false,
+        contentType: false,
+        success: function(response) {
+            $submit.removeClass('is-loading').prop('disabled', false);
+            if (response.success) {
+                window.location.href = response.url;
+            } else {
+                $toast.removeClass('is-success').addClass('is-error')
+                      .text(response.error || 'Une erreur est survenue.');
+            }
+        },
+        error: function() {
+            $submit.removeClass('is-loading').prop('disabled', false);
+            $toast.removeClass('is-success').addClass('is-error')
+                  .text('Erreur réseau. Veuillez réessayer.');
+        }
+    });
+};
+
+/**
+ * Render the selected files list below the dropzone.
+ *
+ * @param {FileList} files
+ * @return {void}
+ */
+window.digiriskdolibarr.ticketPickerKanban.renderFileList = function(files) {
+    var $list = $('#tacQcFileList');
+    $list.empty();
+    if (!files || !files.length) {
+        return;
+    }
+    $.each(files, function(i, file) {
+        var icon = 'fa-file';
+        if (/image\//i.test(file.type))           { icon = 'fa-file-image'; }
+        else if (/pdf/i.test(file.type))          { icon = 'fa-file-pdf'; }
+        else if (/word|doc/i.test(file.type))     { icon = 'fa-file-word'; }
+        else if (/excel|sheet|xls/i.test(file.type)) { icon = 'fa-file-excel'; }
+        else if (/zip|archive/i.test(file.type)) { icon = 'fa-file-archive'; }
+
+        var size = file.size < 1024 * 1024
+            ? Math.round(file.size / 1024) + ' Ko'
+            : (file.size / (1024 * 1024)).toFixed(1) + ' Mo';
+
+        $list.append(
+            '<li>'
+            + '<i class="fas ' + icon + '"></i>'
+            + '<span title="' + $('<span>').text(file.name).html() + '">' + $('<span>').text(file.name).html() + '</span>'
+            + '<small style="color:#9ca3af;flex:0 0 auto">' + size + '</small>'
+            + '</li>'
+        );
+    });
+};
+
+/**
+ * Wire quick-create drawer events (called from ticketPickerKanban.init).
+ *
+ * @return {void}
+ */
+window.digiriskdolibarr.ticketPickerKanban.initQuickCreate = function() {
+    $(document).on('click', '.tac-quick-create-open', window.digiriskdolibarr.ticketPickerKanban.openQuickCreate);
+    $(document).on('click', '.tac-quick-create-close', window.digiriskdolibarr.ticketPickerKanban.closeQuickCreate);
+    $(document).on('keydown', function(e) {
+        if (e.key === 'Escape' && $('#tacQuickCreate').hasClass('is-open')) {
+            window.digiriskdolibarr.ticketPickerKanban.closeQuickCreate();
+        }
+    });
+    $(document).on('submit', '#tacQuickCreateForm', window.digiriskdolibarr.ticketPickerKanban.submitQuickCreate);
+
+    // File input change → update list.
+    $(document).on('change', '#tacQcFiles', function() {
+        window.digiriskdolibarr.ticketPickerKanban.renderFileList(this.files);
+    });
+
+    // Drag-and-drop on the dropzone.
+    $(document).on('dragover dragenter', '#tacQcDropzone', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        $(this).addClass('is-dragover');
+    });
+    $(document).on('dragleave dragend drop', '#tacQcDropzone', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        $(this).removeClass('is-dragover');
+    });
+    $(document).on('drop', '#tacQcDropzone', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        var dt    = e.originalEvent.dataTransfer;
+        var files = dt && dt.files;
+        if (!files || !files.length) {
+            return;
+        }
+        // Assign dropped files to the real input via DataTransfer.
+        try {
+            var input = document.getElementById('tacQcFiles');
+            var transfer = new DataTransfer();
+            $.each(files, function(i, f) { transfer.items.add(f); });
+            input.files = transfer.files;
+            window.digiriskdolibarr.ticketPickerKanban.renderFileList(input.files);
+        } catch (err) {
+            // DataTransfer API not available (old browser) — silently skip preview.
+        }
+    });
+
+    // Keyboard activation of the dropzone (Enter/Space → click the hidden input).
+    $(document).on('keydown', '#tacQcDropzone', function(e) {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            $(this).find('#tacQcFiles').trigger('click');
+        }
     });
 };

--- a/langs/fr_FR/digiriskdolibarr.lang
+++ b/langs/fr_FR/digiriskdolibarr.lang
@@ -1842,3 +1842,16 @@ TicketKanbanLogDeadlineDesc            = Créer un événement lorsque la date l
 TicketKanbanClosedLimit                = Limite tickets fermés
 TicketKanbanClosedLimitDesc            = Nombre maximum de tickets fermés/annulés affichés dans le kanban (0 = illimité)
 
+# Drawer de création rapide de ticket
+SelectNothing                          = — Sélectionner —
+QuickCreateTicket                      = Créer rapidement un ticket
+TicketSubjectPlaceholder               = Titre du ticket...
+TicketInitialMessage                   = Message initial
+OptionalDescription                    = Description (optionnel)...
+Unassigned                             = Non assigné
+QuickCreateAttachments                 = Pièces jointes
+QuickCreateDropzone                    = Glisser-déposer ou cliquer pour sélectionner
+QuickCreateDropzoneActive              = Déposez ici…
+QuickCreateAttachmentHint              = Formats acceptés : images, PDF, docs. Max 10 Mo par fichier.
+QuickCreateTicketSuccess               = Ticket %s créé avec succès.
+

--- a/view/ticket/ticket_action_card.php
+++ b/view/ticket/ticket_action_card.php
@@ -372,6 +372,73 @@ if ($action == 'updateTicketSubject' && !empty(GETPOSTINT('ticket_id'))) {
     exit;
 }
 
+// AJAX: quick-create a ticket from the picker drawer
+if ($action == 'createTicket' && $permissionToWrite) {
+    header('Content-Type: application/json');
+
+    $newTicket                       = new Ticket($db);
+    $newTicket->subject              = GETPOST('subject', 'alphanohtml');
+    $newTicket->type_code            = GETPOST('type_code', 'alpha');
+    $newTicket->severity_code        = GETPOST('severity_code', 'alpha');
+    $newTicket->message              = GETPOST('message', 'restricthtml');
+    $newTicket->fk_user_create       = $user->id;
+    $newTicket->email_from           = $user->email;
+    $newTicket->origin_email         = null;
+    $newTicket->notify_tiers_at_create = 0;
+
+    $newTicket->type_label     = $langs->getLabelFromKey($db, $newTicket->type_code, 'c_ticket_type', 'code', 'label');
+    $newTicket->severity_label = $langs->getLabelFromKey($db, $newTicket->severity_code, 'c_ticket_severity', 'code', 'label');
+
+    // Generate the next ticket reference (required by Ticket::verify() before create).
+    $newTicket->ref = $newTicket->getDefaultRef();
+
+    $fkAssign = GETPOSTINT('fk_user_assign');
+    if ($fkAssign > 0) {
+        $newTicket->fk_user_assign = $fkAssign;
+        $newTicket->status         = Ticket::STATUS_ASSIGNED;
+    }
+
+    $newId = $newTicket->create($user, 1);
+    if ($newId > 0) {
+        // Move uploaded attachments into the ticket directory.
+        $uploadedNames = !empty($_FILES['attachments']['name']) ? (array) $_FILES['attachments']['name'] : [];
+        $uploadedTmps  = !empty($_FILES['attachments']['tmp_name']) ? (array) $_FILES['attachments']['tmp_name'] : [];
+        $uploadedErrs  = !empty($_FILES['attachments']['error']) ? (array) $_FILES['attachments']['error'] : [];
+
+        if (!empty($uploadedNames) && $uploadedNames[0] !== '') {
+            require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
+
+            $destDir = $conf->ticket->dir_output . '/' . dol_sanitizeFileName($newTicket->ref);
+            if (!dol_is_dir($destDir)) {
+                dol_mkdir($destDir);
+            }
+
+            foreach ($uploadedNames as $i => $rawName) {
+                if (!empty($uploadedErrs[$i]) || empty($rawName) || empty($uploadedTmps[$i])) {
+                    continue;
+                }
+                $safeName = dol_sanitizeFileName($rawName);
+                $destFile = $destDir . '/' . $safeName;
+                if (file_exists($destFile)) {
+                    $pi       = pathinfo($safeName);
+                    $destFile = $destDir . '/' . $pi['filename'] . '-' . dol_print_date(dol_now(), 'dayhourlog') . '.' . ($pi['extension'] ?? 'bin');
+                }
+                dol_move_uploaded_file($uploadedTmps[$i], $destFile, 1, 0, $uploadedErrs[$i]);
+            }
+        }
+
+        $detailUrl = dol_buildpath('/custom/digiriskdolibarr/view/ticket/ticket_action_card.php', 1) . '?id=' . $newId;
+        print json_encode(['success' => 1, 'id' => $newId, 'ref' => $newTicket->ref, 'url' => $detailUrl]);
+    } else {
+        $errMsg = $newTicket->error ?: implode(', ', $newTicket->errors ?: []);
+        dol_syslog('ticket_action_card.php createTicket: create failed - ' . $errMsg, LOG_ERR);
+        http_response_code(500);
+        print json_encode(['success' => 0, 'error' => $errMsg ?: 'Ticket creation failed']);
+    }
+    $db->close();
+    exit;
+}
+
 /*
  * View
  */
@@ -771,6 +838,50 @@ if ($object->id <= 0) {
             $pickerStatusTickets[$sts][] = $t;
         }
     }
+}
+
+// Quick-create drawer data — always loaded so the drawer is available on both views.
+$createFormTypes      = [];
+$createFormSeverities = [];
+$createFormUsers      = $pickerAllUsers; // already populated when no ticket is selected
+
+if ($object->id > 0) {
+    // On the detail view the picker arrays are empty — re-fetch users.
+    $sqlU = 'SELECT rowid, firstname, lastname FROM ' . MAIN_DB_PREFIX . 'user'
+        . ' WHERE statut = 1 AND entity IN (' . getEntity('user') . ') ORDER BY lastname, firstname';
+    $resU = $db->query($sqlU);
+    if ($resU) {
+        while ($u = $db->fetch_object($resU)) {
+            $createFormUsers[] = [
+                'id'       => (int) $u->rowid,
+                'fullname' => trim($u->firstname . ' ' . $u->lastname),
+            ];
+        }
+        $db->free($resU);
+    }
+}
+
+$sqlCft = 'SELECT code, label FROM ' . MAIN_DB_PREFIX . 'c_ticket_type WHERE active = 1 AND entity IN (' . getEntity('c_ticket_type') . ') ORDER BY label';
+$resCft = $db->query($sqlCft);
+if ($resCft) {
+    while ($r = $db->fetch_object($resCft)) {
+        $transKey = 'TicketTypeShort' . $r->code;
+        $lbl      = $langs->trans($transKey);
+        $createFormTypes[$r->code] = ($lbl === $transKey) ? $r->label : $lbl;
+    }
+    $db->free($resCft);
+}
+
+
+$sqlCfs = 'SELECT code, label FROM ' . MAIN_DB_PREFIX . 'c_ticket_severity WHERE active = 1 AND entity IN (' . getEntity('c_ticket_severity') . ') ORDER BY code';
+$resCfs = $db->query($sqlCfs);
+if ($resCfs) {
+    while ($r = $db->fetch_object($resCfs)) {
+        $transKey = 'TicketSeverityShort' . $r->code;
+        $lbl      = $langs->trans($transKey);
+        $createFormSeverities[$r->code] = ($lbl === $transKey) ? $r->label : $lbl;
+    }
+    $db->free($resCfs);
 }
 
 // Page entry point — kanban picker if no ticket loaded, otherwise the tile card.


### PR DESCRIPTION
## Résumé

- Ajout d'un drawer "Nouveau ticket" accessible depuis le kanban picker (bouton en haut à gauche)
- Champs disponibles : sujet (requis), type, sévérité, assigné, message, pièces jointes (drag-and-drop)
- Création via AJAX (FormData multipart), redirection instantanée vers la fiche ticket
- Suppression du trigger TICKET_CREATE lors de la création rapide (notrigger=1) pour éviter les erreurs mail
- Menu renommé "Kanban" + entrée "Liste" ajoutée dans modDigiriskDolibarr
- Champ "Groupe" retiré du drawer
- Traductions fr_FR des nouvelles clés

Closes #4443

## Plan de test

- [ ] Ouvrir le kanban, cliquer sur "Nouveau ticket"
- [ ] Vérifier que le drawer s'ouvre correctement
- [ ] Créer un ticket avec sujet uniquement → redirection instantanée vers la fiche
- [ ] Créer un ticket avec type, sévérité, assigné et message
- [ ] Joindre un fichier (drag-and-drop et sélection classique) → vérifier la présence dans le répertoire du ticket
- [ ] Vérifier que le menu gauche affiche bien "Kanban" et "Liste"
- [ ] Vérifier l'absence d'erreur PHP dans les logs lors de la création

🤖 Generated with [Claude Code](https://claude.com/claude-code)
