### PR TITLE
[Kanban] fix: align init() guard selector to .kanban-board

### DIFF
--- a/js/modules/actionplan_kanban.js
+++ b/js/modules/actionplan_kanban.js
@@ -9,7 +9,7 @@ window.digiriskdolibarr.actionplanKanban = {};
  * Init — auto-called by saturne.js on document.ready
  */
 window.digiriskdolibarr.actionplanKanban.init = function() {
-    if (!$('.actionplan-kanban-board').length) {
+    if (!$('.kanban-board').length) {
         return;
     }
     window.digiriskdolibarr.actionplanKanban.event();


### PR DESCRIPTION
## Probleme
Sur la vue plan d'action en kanban (actionplan_list.php?view=kanban), aucune interaction JS : pas de drag & drop, pas d'edition inline, pas de popover settings.

## Cause
init() de js/modules/actionplan_kanban.js testait .actionplan-kanban-board, classe absente du markup. Le TPL rend le conteneur avec class=kanban-board. init() faisait donc return immediatement, sans brancher events/sortable/settings.

## Correction
Aligne le selecteur de init() sur .kanban-board (coherent avec le reste du module). Le .min.js est regenere par la CI sur develop.