### PR TITLE
#4763 [ODT] fix: remove extra depth hyphens in element label

### DIFF
--- a/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/modules_digiriskdolibarrdocument.php
+++ b/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/modules_digiriskdolibarrdocument.php
@@ -87,7 +87,7 @@ abstract class ModeleODTDigiriskDolibarrDocument extends SaturneDocumentModel
                     continue; // Skip if digirisk element not found (case of GP/UT fiche with spécific id)
                 }
 
-                $depthHyphens                     = str_repeat('- ', $digiriskElement['depth']);
+                $depthHyphens                     = str_repeat('  ', $digiriskElement['depth']);
                 $tmpArray['digiriskElementLabel'] = $depthHyphens . 'S' . $digiriskElement['object']->entity . ' - ' . $digiriskElement['object']->ref . ' - ' . $digiriskElement['object']->label;
 
                 $tmpArray['picto']                  = DOL_DOCUMENT_ROOT . '/custom/digiriskdolibarr/img/categorieDangers/' . $risk->getDangerCategory($risk, $risk->type) . '.png';


### PR DESCRIPTION
## Changements
- Remplacement de str_repeat dans la generation du label element GP/UT dans les documents ODT
- Les tirets de profondeur (- - S1 - WU3 - ...) sont remplaces par des espaces, evitant la confusion visuelle avec les separateurs du label
- Avant : `- - S1 - WU3 - Accrochage - Decrochage` / Apres : `    S1 - WU3 - Accrochage - Decrochage`

## Fichiers modifies
- core/modules/digiriskdolibarr/digiriskdolibarrdocuments/modules_digiriskdolibarrdocument.php

## Issue
#4763