### PR TITLE
#4776 [ModDigiriskDolibarr] fix: undefined property warning on DIGIRISKDOLIBARR_ENVIRONMENT_PROJECT

### DIFF
--- a/core/modules/modDigiriskDolibarr.class.php
+++ b/core/modules/modDigiriskDolibarr.class.php
@@ -1519,7 +1519,7 @@ class modDigiriskdolibarr extends DolibarrModules
             'titre'    => '<i class="fas fa-tasks pictofixedwidth" style="padding-right: 4px;"></i>' . $langs->trans('ActionPlan'),
             'mainmenu' => 'digiriskdolibarr',
             'leftmenu' => 'digiriskenvironmentalactionplan',
-            'url'      => '/projet/tasks.php?id=' . $conf->global->DIGIRISKDOLIBARR_ENVIRONMENT_PROJECT,
+            'url'      => '/projet/tasks.php?id=' . ($conf->global->DIGIRISKDOLIBARR_ENVIRONMENT_PROJECT ?? ''),
             'langs'    => 'digiriskdolibarr@digiriskdolibarr',
             'position' => 100 + $r,
             'enabled'  => '$conf->digiriskdolibarr->enabled && $conf->projet->enabled',


### PR DESCRIPTION
## Description

PHP 8+ Warning on undefined property in `modDigiriskDolibarr` constructor on line 1522.

## Warning

```
Warning: Undefined property: stdClass::$DIGIRISKDOLIBARR_ENVIRONMENT_PROJECT
in core/modules/modDigiriskDolibarr.class.php on line 1522
```

## Root cause

On line 1522, when building the Environment Action Plan menu entry URL:

```php
'url' => '/projet/tasks.php?id=' . $conf->global->DIGIRISKDOLIBARR_ENVIRONMENT_PROJECT,
```

The constant `DIGIRISKDOLIBARR_ENVIRONMENT_PROJECT` does not exist in `$conf->global` on a fresh install before the environment project is configured. PHP 8+ raises a Warning when accessing a non-existent dynamic property on `stdClass`.

## Fix

Use null coalescing operator `??`:

```php
'url' => '/projet/tasks.php?id=' . ($conf->global->DIGIRISKDOLIBARR_ENVIRONMENT_PROJECT ?? ''),
```

## Impact

No functional impact — an unconfigured constant defaults to empty string, which is the expected behaviour.
