### PR TITLE
#4778 [ModDigiriskDolibarr] fix: undefined property warnings in init() on PHP 8+

### DIFF
--- a/core/modules/modDigiriskDolibarr.class.php
+++ b/core/modules/modDigiriskDolibarr.class.php
@@ -2127,7 +2127,7 @@ class modDigiriskdolibarr extends DolibarrModules
         addDocumentModel('accidentinvestigationdocument_odt', 'accidentinvestigationdocument', 'ODT templates', 'DIGIRISKDOLIBARR_ACCIDENTINVESTIGATIONDOCUMENT_ADDON_ODT_PATH');
         addDocumentModel('registerdocument_odt', 'registerdocument', 'ODT templates', 'DIGIRISKDOLIBARR_REGISTERDOCUMENT_ADDON_ODT_PATH');
 
-		if ( $conf->global->DIGIRISKDOLIBARR_DIGIRISKELEMENT_TRASH == 0 ) {
+		if (empty($conf->global->DIGIRISKDOLIBARR_DIGIRISKELEMENT_TRASH)) {
 			require_once __DIR__ . '/../../class/digiriskelement/groupment.class.php';
 
 			$trashRef                      = 'GP0';
@@ -2143,7 +2143,7 @@ class modDigiriskdolibarr extends DolibarrModules
 			dolibarr_set_const($this->db, 'DIGIRISKDOLIBARR_DIGIRISKELEMENT_TRASH', $trash_id, 'integer', 0, '', $conf->entity);
 		}
 
-		if ( $conf->global->DIGIRISKDOLIBARR_ACTIVE_STANDARD == 0 ) {
+		if (empty($conf->global->DIGIRISKDOLIBARR_ACTIVE_STANDARD)) {
 			require_once __DIR__ . '/../../class/digiriskstandard.class.php';
 
 			$digiriskstandard                = new DigiriskStandard($this->db);
@@ -2418,7 +2418,7 @@ class modDigiriskdolibarr extends DolibarrModules
         }
 
 		//DigiriskElement favorite medias backward compatibility
-		if ($conf->global->DIGIRISKDOLIBARR_DIGIRISKELEMENT_MEDIAS_BACKWARD_COMPATIBILITY == 0) {
+		if (empty($conf->global->DIGIRISKDOLIBARR_DIGIRISKELEMENT_MEDIAS_BACKWARD_COMPATIBILITY)) {
 			require_once __DIR__ . '/../../class/digiriskelement.class.php';
 
 			$digiriskelement     = new DigiriskElement($this->db);
@@ -2499,7 +2499,7 @@ class modDigiriskdolibarr extends DolibarrModules
             dolibarr_set_const($this->db, 'DIGIRISKDOLIBARR_PROJECT_TAGS_SET', 4, 'integer', 0, '', $conf->entity);
         }
 
-		if ($conf->global->DIGIRISKDOLIBARR_TRIGGERS_UPDATED == 0) {
+		if (empty($conf->global->DIGIRISKDOLIBARR_TRIGGERS_UPDATED)) {
 			require_once DOL_DOCUMENT_ROOT . '/comm/action/class/actioncomm.class.php';
 
 			$actioncomm = new Actioncomm($this->db);


### PR DESCRIPTION
## Description

Multiple PHP 8+ Warnings on undefined properties in `modDigiriskDolibarr::init()`.

## Warnings

```
Warning: Undefined property: stdClass::$DIGIRISKDOLIBARR_DIGIRISKELEMENT_TRASH
in core/modules/modDigiriskDolibarr.class.php on line 2130

Warning: Undefined property: stdClass::$DIGIRISKDOLIBARR_ACTIVE_STANDARD
in core/modules/modDigiriskDolibarr.class.php on line 2146

Warning: Undefined property: stdClass::$DIGIRISKDOLIBARR_DIGIRISKELEMENT_MEDIAS_BACKWARD_COMPATIBILITY
in core/modules/modDigiriskDolibarr.class.php on line 2421

Warning: Undefined property: stdClass::$DIGIRISKDOLIBARR_TRIGGERS_UPDATED
in core/modules/modDigiriskDolibarr.class.php on line 2502
```

## Root cause

In `init()`, several constants are checked with a direct `== 0` comparison:

```php
if ( $conf->global->DIGIRISKDOLIBARR_DIGIRISKELEMENT_TRASH == 0 ) {
if ( $conf->global->DIGIRISKDOLIBARR_ACTIVE_STANDARD == 0 ) {
if ($conf->global->DIGIRISKDOLIBARR_DIGIRISKELEMENT_MEDIAS_BACKWARD_COMPATIBILITY == 0) {
if ($conf->global->DIGIRISKDOLIBARR_TRIGGERS_UPDATED == 0) {
```

These constants do not exist in `$conf->global` before they are set for the first time (fresh install / module activation). PHP 8+ raises a `Warning` when accessing a non-existent dynamic property on `stdClass`.

## Fix

Replace `== 0` comparisons with `empty()` which is safe for undefined properties and semantically equivalent (0, null and '' are all falsy):

```php
if (empty($conf->global->DIGIRISKDOLIBARR_DIGIRISKELEMENT_TRASH)) {
if (empty($conf->global->DIGIRISKDOLIBARR_ACTIVE_STANDARD)) {
if (empty($conf->global->DIGIRISKDOLIBARR_DIGIRISKELEMENT_MEDIAS_BACKWARD_COMPATIBILITY)) {
if (empty($conf->global->DIGIRISKDOLIBARR_TRIGGERS_UPDATED)) {
```

## Impact

No functional impact — `empty(0)` and `0 == 0` are equivalent. Fixes warnings on PHP 8+.
