### PR TITLE
#4780 [ProjectCreationAction] fix: undefined property warnings on BACKWARD_COMPATIBILITY constants

### DIFF
--- a/core/tpl/digiriskdolibarr_projectcreation_action.tpl.php
+++ b/core/tpl/digiriskdolibarr_projectcreation_action.tpl.php
@@ -122,7 +122,7 @@ $numberingModules  = ['project' => $conf->global->PROJECT_ADDON];
 list ($projectRef) = saturne_require_objects_mod($numberingModules, $moduleNameLowerCase);
 
 //Check projet
-if ($conf->global->DIGIRISKDOLIBARR_DU_PROJECT > 0 && $conf->global->DIGIRISKDOLIBARR_DU_PROJECT_BACKWARD_COMPATIBILITY == 0) {
+if ($conf->global->DIGIRISKDOLIBARR_DU_PROJECT > 0 && empty($conf->global->DIGIRISKDOLIBARR_DU_PROJECT_BACKWARD_COMPATIBILITY)) {
 	$project->fetch($conf->global->DIGIRISKDOLIBARR_DU_PROJECT);
 	//Backward compatibility
 	if ($project->title == $langs->trans('RiskAssessmentDocument')) {
@@ -178,7 +178,7 @@ if ( $conf->global->DIGIRISKDOLIBARR_DU_PROJECT == 0 || $project->statut == 2 ) 
 	header("Location: " . $_SERVER['PHP_SELF']);
 }
 
-if ($conf->global->DIGIRISKDOLIBARR_PREVENTIONPLAN_PROJECT > 0 && $conf->global->DIGIRISKDOLIBARR_PREVENTIONPLAN_PROJECT_BACKWARD_COMPATIBILITY == 0 ) {
+if ($conf->global->DIGIRISKDOLIBARR_PREVENTIONPLAN_PROJECT > 0 && empty($conf->global->DIGIRISKDOLIBARR_PREVENTIONPLAN_PROJECT_BACKWARD_COMPATIBILITY)) {
 	$project->fetch($conf->global->DIGIRISKDOLIBARR_PREVENTIONPLAN_PROJECT);
 	//Backward compatibility
 	if ($project->title == $langs->trans('PreventionPlan')) {


### PR DESCRIPTION
## Description

Two PHP 8+ warnings in `digiriskdolibarr_projectcreation_action.tpl.php` on backward compatibility checks.

## Warnings

```
Warning: Undefined property: stdClass::$DIGIRISKDOLIBARR_DU_PROJECT_BACKWARD_COMPATIBILITY
in core/tpl/digiriskdolibarr_projectcreation_action.tpl.php on line 125

Warning: Undefined property: stdClass::$DIGIRISKDOLIBARR_PREVENTIONPLAN_PROJECT_BACKWARD_COMPATIBILITY
in core/tpl/digiriskdolibarr_projectcreation_action.tpl.php on line 181
```

## Root cause

Lines 125 and 181 use a direct `== 0` comparison on `$conf->global` properties:

```php
if ($conf->global->DIGIRISKDOLIBARR_DU_PROJECT > 0 && $conf->global->DIGIRISKDOLIBARR_DU_PROJECT_BACKWARD_COMPATIBILITY == 0) {
if ($conf->global->DIGIRISKDOLIBARR_PREVENTIONPLAN_PROJECT > 0 && $conf->global->DIGIRISKDOLIBARR_PREVENTIONPLAN_PROJECT_BACKWARD_COMPATIBILITY == 0) {
```

These constants are not yet defined in `$conf->global` on a fresh install. PHP 8+ raises a Warning when accessing a non-existent dynamic property on `stdClass`.

## Fix

Replace `== 0` comparisons with `empty()` which is safe for undefined properties and semantically equivalent:

```php
if ($conf->global->DIGIRISKDOLIBARR_DU_PROJECT > 0 && empty($conf->global->DIGIRISKDOLIBARR_DU_PROJECT_BACKWARD_COMPATIBILITY)) {
if ($conf->global->DIGIRISKDOLIBARR_PREVENTIONPLAN_PROJECT > 0 && empty($conf->global->DIGIRISKDOLIBARR_PREVENTIONPLAN_PROJECT_BACKWARD_COMPATIBILITY)) {
```

## Impact

No functional impact — `empty(0)` and `0 == 0` are equivalent.
