### PR TITLE
#4781 [Risk] fix: undefined array key warning in getRisksByDangerCategories() on fresh install

### DIFF
--- a/class/riskanalysis/risk.class.php
+++ b/class/riskanalysis/risk.class.php
@@ -1040,7 +1040,7 @@ class Risk extends SaturneObject
 
         foreach ($dangerCategories as $dangerCategory) {
             $array['data'][$dangerCategory['position']][] = $dangerCategory['name'];
-            $array['data'][$dangerCategory['position']][] = $riskByDangerCategoriesAndRiskAssessments[$dangerCategory['name']]['risk'];
+            $array['data'][$dangerCategory['position']][] = $riskByDangerCategoriesAndRiskAssessments[$dangerCategory['name']]['risk'] ?? 0;
         }
 
         return $array;


### PR DESCRIPTION
## Description

PHP 8+ Warning `Undefined array key` in `Risk::getRisksByDangerCategories()` when no risks exist for a danger category.

## Warning

```
Warning: Undefined array key "Risques de chute de plain-pied"
in class/riskanalysis/risk.class.php on line 1043
```

## Root cause

Line 1043 in `getRisksByDangerCategories()`:

```php
$array['data'][$dangerCategory['position']][] = $riskByDangerCategoriesAndRiskAssessments[$dangerCategory['name']]['risk'];
```

The `$riskByDangerCategoriesAndRiskAssessments` array is built from existing risks only. If no risk exists for a given danger category (e.g. on a fresh install), the key `$dangerCategory['name']` is absent, triggering a PHP 8 `Undefined array key` warning.

## Fix

Add null coalescing operator to default to `0` when the key is missing:

```php
$array['data'][$dangerCategory['position']][] = $riskByDangerCategoriesAndRiskAssessments[$dangerCategory['name']]['risk'] ?? 0;
```

## Impact

No functional impact — an absent category defaults to 0 risks, which is the correct value.
