### PR TITLE
#4784 [Risk] fix: undefined array key nbRiskByCotations in getRisksByCotation() on fresh install

### DIFF
--- a/class/riskanalysis/risk.class.php
+++ b/class/riskanalysis/risk.class.php
@@ -965,7 +965,7 @@ class Risk extends SaturneObject
         $array['dataset']    = 1;
         $array['labels']     = $this->cotations;
 
-        $array['data'] = $riskByDangerCategoriesAndRiskAssessments['nbRiskByCotations'];
+        $array['data'] = $riskByDangerCategoriesAndRiskAssessments['nbRiskByCotations'] ?? [];
 
         return $array;
     }


### PR DESCRIPTION
## Description

PHP 8+ `Undefined array key` warning in `Risk::getRisksByCotation()` on fresh install with no risks.

## Warning

```
Warning: Undefined array key "nbRiskByCotations"
in class/riskanalysis/risk.class.php on line 968
```

## Root cause

Line 968 in `getRisksByCotation()`:

```php
$array['data'] = $riskByDangerCategoriesAndRiskAssessments['nbRiskByCotations'];
```

When no risks exist (fresh install or empty database), `getRiskByDangerCategoriesAndRiskAssessments()` returns an empty array `[]` — the key `nbRiskByCotations` is then absent, triggering the warning.

## Fix

Add null coalescing operator to default to an empty array:

```php
$array['data'] = $riskByDangerCategoriesAndRiskAssessments['nbRiskByCotations'] ?? [];
```

## Impact

No functional impact — an empty data array results in an empty pie chart, which is the correct behaviour when no risks exist.
