### PR TITLE
#4794 [DigiriskElement] fix: undefined variable morehtmlref and allRisks

### DIFF
--- a/class/digiriskelement.class.php
+++ b/class/digiriskelement.class.php
@@ -549,6 +549,7 @@ class DigiriskElement extends SaturneObject
         // ParentElement
         $parent_element = new self($db);
         $result         = $parent_element->fetch($this->fk_parent);
+        $morehtmlref    = '';
         if ($result > 0) {
             $morehtmlref .= $langs->trans("Description") . ' : ' . $this->description;
             $morehtmlref .= '<br>' . $langs->trans("ParentElement") . ' : ' . $parent_element->getNomUrl(1, 'blank', 1);

--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
@@ -1,4 +1,5 @@
 <?php
+$allRisks             = $allRisks ?? 0;
 $selectedfields_label = 'risklist_selectedfields';
 // Selection of new fields
 require __DIR__ . '/../../../../class/actions_changeselectedfields.php';


### PR DESCRIPTION
Fixes #4794

- Init `\ = ''` before first `.=` in `getBannerTabContent()`  
- Add `\ = \ ?? 0` at top of `digiriskdolibarr_risklist_view.tpl.php`