### PR TITLE
[DigiriskElement] fix: undefined array key customsql

### DIFF
--- a/class/digiriskelement.class.php
+++ b/class/digiriskelement.class.php
@@ -264,7 +264,7 @@ class DigiriskElement extends SaturneObject
     {
         global $conf, $form, $langs;
 
-        if (dol_strlen($filter['customsql'])) {
+        if (isset($filter['customsql']) && dol_strlen($filter['customsql'])) {
             $filter['customsql'] .= ' AND t.rowid != ' . ($this->id ?? 0);
         }
 


### PR DESCRIPTION
Fixes undefined array key 'customsql' warning in DigiriskElement::selectDigiriskElementList()