### PR TITLE
fix: prevent fatal error in printCommonFooter when ticket_service option is null

### DIFF
--- a/class/actions_digiriskdolibarr.class.php
+++ b/class/actions_digiriskdolibarr.class.php
@@ -241,15 +241,17 @@ class ActionsDigiriskdolibarr
                 </script>
                 <?php
 
-                $digiriskelement    = new DigiriskElement($db);
-                $res = $digiriskelement->fetch($object->array_options['options_digiriskdolibarr_ticket_service']);
-                if ($res > 0) {
-                    $outDigiriskElement = $digiriskelement->getNomUrl(1, 'blank', 0, '', -1, 1);
-                    ?>
-                    <script>
-                        jQuery('td[id*="digiriskdolibarr_ticket_service"]').html('<?= $outDigiriskElement ?>');
-                    </script>
-                    <?php
+                if (!empty($object->array_options['options_digiriskdolibarr_ticket_service'])) {
+                    $digiriskelement    = new DigiriskElement($db);
+                    $res = $digiriskelement->fetch((int)$object->array_options['options_digiriskdolibarr_ticket_service']);
+                    if ($res > 0) {
+                        $outDigiriskElement = $digiriskelement->getNomUrl(1, 'blank', 0, '', -1, 1);
+                        ?>
+                        <script>
+                            jQuery('td[id*="digiriskdolibarr_ticket_service"]').html('<?= $outDigiriskElement ?>');
+                        </script>
+                        <?php
+                    }
                 }
 
                 // Collect ticket category IDs including their ancestors (getListForItem returns the full hierarchy)


### PR DESCRIPTION
There is a PHP fatal error in \ctions_digiriskdolibarr.class.php\ in the \printCommonFooter\ hook when the ticket service option is not set. This crashes the page rendering and prevents the footer from loading. The fix wraps the fetch call in an \!empty()\ condition.