### PR TITLE
#4800 [DUER] fix: load active standard of current entity for document generation (multicompany)

### DIFF
--- a/view/digiriskstandard/digiriskstandard_riskassessmentdocument.php
+++ b/view/digiriskstandard/digiriskstandard_riskassessmentdocument.php
@@ -54,7 +54,10 @@ global $conf, $db, $hookmanager, $langs, $user;
 saturne_load_langs();
 
 // Get parameters
-$id        = GETPOSTINT('id');
+// The risk assessment document is a singleton per entity: always load the active standard of the
+// current entity, not a URL id. Otherwise, under multicompany, an id pointing to another entity's
+// standard makes document generation resolve an empty output directory ("Répertoire introuvable").
+$id        = getDolGlobalInt('DIGIRISKDOLIBARR_ACTIVE_STANDARD');
 $action    = GETPOST('action', 'aZ09');
 $subaction = GETPOST('subaction', 'aZ09');
 


### PR DESCRIPTION
Closes #4800

### Contexte
En multicompany, la génération du Document Unique échouait avec « Répertoire introuvable » + « Le fichier n'a pas pu être généré en PDF » dès que l'entité de session ≠ entité du standard chargé.

### Cause
`digiriskstandard_riskassessmentdocument.php` était la seule vue du standard à charger l'objet par l'`id` de l'URL (`actions_fetchobject.inc.php`) au lieu de `DIGIRISKDOLIBARR_ACTIVE_STANDARD` (constante par entité), comme le font `card`, `legaldisplay`, `registerdocument`, `informationssharing`, `risk_list`. Du coup `$object->entity` ne correspondait pas à l'entité courante, et `getMultidirOutput()` renvoyait un répertoire vide (`multidir_output` est mono-entité côté core ; multicompany ne partage pas les répertoires des modules custom).

### Correctif
1 ligne : charger le standard actif de l'entité courante.

```php
$id = getDolGlobalInt('DIGIRISKDOLIBARR_ACTIVE_STANDARD'); // au lieu de GETPOSTINT('id')
```

### Tests
- `php -l` OK.
- Alignement vérifié avec les 5 vues sœurs du standard.
- Comportement multicompany à confirmer sur instance multi-entités (pas d'entité de test en local).

> ⚠️ Base = `develop`, défaut du repo = `main` → `Closes #4800` ne fermera pas l'issue automatiquement, à fermer manuellement au merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)