### PR TITLE
#4807 [PreventionPlan] fix: cast id with GETPOSTINT to avoid fetch() TypeError on PHP 8

### DIFF
--- a/view/preventionplan/preventionplan_card.php
+++ b/view/preventionplan/preventionplan_card.php
@@ -57,7 +57,7 @@ global $conf, $db, $hookmanager, $langs, $moduleNameLowerCase, $user;
 saturne_load_langs(['other', 'mails']);
 
 // Get parameters
-$id                  = GETPOST('id', 'int');
+$id                  = GETPOSTINT('id');
 $lineid              = GETPOST('lineid', 'int');
 $ref                 = GETPOST('ref', 'alpha');
 $action              = GETPOST('action', 'aZ09');


### PR DESCRIPTION
Closes #4807

## Problème

Ouvrir la fiche plan de prévention sans paramètre `id` provoque une erreur fatale sous PHP 8 :

```
Uncaught TypeError: Argument 1 passed to SaturneObject::fetch() must be of the type int, string given,
called in .../preventionplan_card.php on line 89 — SaturneObject->fetch('')
```

## Cause

`$id = GETPOST('id', 'int')` renvoie une chaîne vide `''` quand `id` est absent, passée ensuite à `SaturneObject::fetch(int $id)` → `TypeError`.

## Correctif

`GETPOST('id', 'int')` → `GETPOSTINT('id')`, qui renvoie toujours un `int` (0 si absent). Aligné sur les fiches sœurs (`accident_card.php`, `digiriskelement_card.php`) et les conventions Saturne. Corrige du même coup les `fetch($id)` en aval du fichier.

## Test

- `php -l` OK
- `fetch(0)` est inoffensif (renvoie 0 / non trouvé, sans erreur)

> Note hors-scope : `view/firepermit/firepermit_card.php:59` présente le même pattern `GETPOST('id', 'int')` → `fetch($id)` (bug jumeau latent). À traiter dans une issue dédiée.
