### PR TITLE
#4809 [FirePermit] fix: cast id with GETPOSTINT to avoid fetch() TypeError on PHP 8

### DIFF
--- a/view/firepermit/firepermit_card.php
+++ b/view/firepermit/firepermit_card.php
@@ -56,7 +56,7 @@ global $conf, $db, $hookmanager, $langs, $user;
 saturne_load_langs(['other', 'mails']);
 
 // Get parameters
-$id                  = GETPOST('id', 'int');
+$id                  = GETPOSTINT('id');
 $lineid              = GETPOST('lineid', 'int');
 $ref                 = GETPOST('ref', 'alpha');
 $action              = GETPOST('action', 'aZ09');


### PR DESCRIPTION
Closes #4809

Bug jumeau de #4807/#4808, sur la fiche permis de feu.

## Problème

Ouvrir `view/firepermit/firepermit_card.php` sans paramètre `id` provoque une erreur fatale sous PHP 8 :

```
Uncaught TypeError: Argument 1 passed to SaturneObject::fetch() must be of the type int, string given,
called in .../firepermit_card.php on line 94 — fetch('')
```

## Cause

`$id = GETPOST('id', 'int')` renvoie une chaîne vide `''` quand `id` est absent, passée ensuite à `SaturneObject::fetch(int $id)`.

## Correctif

`GETPOST('id', 'int')` → `GETPOSTINT('id')` (renvoie toujours un `int`, 0 si absent). Aligné sur les fiches sœurs et les conventions Saturne.

## Test

- `php -l` OK
- `fetch(0)` est inoffensif (renvoie 0 / non trouvé)
