### PR TITLE
#4707 [Ticket] feat: getNomUrl on public ticket success page when connected

### DIFF
--- a/lib/digiriskdolibarr_function.lib.php
+++ b/lib/digiriskdolibarr_function.lib.php
@@ -559,6 +559,36 @@ function getNomUrlUser(User $object, $withpictoimg = 0, $option = '', $infologin
 }
 
 /**
+ * Return a ticket reference as a clickable getNomUrl link for the public ticket interface.
+ *
+ * The public pages are NOLOGIN, so $user is never loaded from the session. We detect an active
+ * back-office session through $_SESSION['dol_login'] and only render a link when that user is
+ * connected and holds the ticket read permission, otherwise we keep the bold reference.
+ *
+ * @param  Ticket $ticket Ticket object, already fetched
+ * @return string         getNomUrl link if connected with read access, '<b>ref</b>' otherwise
+ */
+function getNomUrlTicketPublic(Ticket $ticket): string
+{
+	global $db;
+
+	$display = '<b>' . $ticket->ref . '</b>';
+	if (!empty($_SESSION['dol_login'])) {
+		$connectedUser = new User($db);
+		if ($connectedUser->fetch(0, $_SESSION['dol_login']) > 0) {
+			// fetch() does not populate rights, so hasRight() would always return 0 without this
+			$connectedUser->loadRights('ticket');
+			if ($connectedUser->hasRight('ticket', 'read')) {
+				// Tooltip disabled: the public interface does not load Dolibarr tooltip CSS/JS
+				$display = $ticket->getNomUrl(1, '', 1);
+			}
+		}
+	}
+
+	return $display;
+}
+
+/**
  *	Show category image
  *
 * @param object	$object

--- a/public/ticket/create_ticket.php
+++ b/public/ticket/create_ticket.php
@@ -361,7 +361,7 @@ if (empty($resHook)) {
                 // Creation OK
                 dol_delete_dir_recursive($ticket_upload_dir . '/ticket/' . $ticketTmpId . '/');
                 $urltogo = $_SERVER['PHP_SELF'] . '/../ticket_success.php?track_id=' . $track_id;
-                setEventMessages($langs->trans("TicketSent", ''), null);
+                setEventMessages($langs->trans('TicketSent') . ' ' . getNomUrlTicketPublic($object), null);
                 header("Location: " . $urltogo);
                 exit;
             }

--- a/public/ticket/ticket_success.php
+++ b/public/ticket/ticket_success.php
@@ -56,6 +56,8 @@ if (file_exists('../../digiriskdolibarr.main.inc.php')) {
 require_once DOL_DOCUMENT_ROOT . '/ticket/class/ticket.class.php';
 require_once DOL_DOCUMENT_ROOT . '/categories/class/categorie.class.php';
 
+require_once __DIR__ . '/../../lib/digiriskdolibarr_function.lib.php';
+
 // Global variables definitions
 global $conf, $db, $hookmanager, $langs;
 
@@ -105,6 +107,9 @@ $substitutionArray = getCommonSubstitutionArray($langs, 0, null, $object);
 complete_substitutions_array($substitutionArray, $langs, $object);
 $ticketSuccessMessage = make_substitutions($successMessage, $substitutionArray);
 
+// Clickable link for connected back-office users only (public page, $user is not loaded here)
+$ticketRefDisplay = getNomUrlTicketPublic($object);
+
 /*
  * View
  */
@@ -126,7 +131,7 @@ if (!getDolGlobalInt('DIGIRISKDOLIBARR_TICKET_ENABLE_PUBLIC_INTERFACE')) {
     <div class="public-card__header">
         <div class="header-information center">
             <div class="left"><a href="<?php echo dol_buildpath('/custom/digiriskdolibarr/public/ticket/create_ticket.php?entity=' . $conf->entity, 1); ?>" class="information-back"><i class="fas fa-sm fa-chevron-left paddingright"></i><?php echo $langs->trans('Back'); ?></a></div>
-            <div class="information-title"><?php echo $langs->trans('TicketSuccess') . ' <b>' . $object->ref . '</b>'; ?></div>
+            <div class="information-title"><?php echo $langs->trans('TicketSuccess') . ' ' . $ticketRefDisplay; ?></div>
             <span class="wpeo-notice notice-info left" style="margin-left: 16%; width: 70%">
                 <span class="notice-content">
                     <span class="notice-subtitle"><?php echo $langs->transnoentities($ticketSuccessMessage); ?></span>


### PR DESCRIPTION
## Contexte

Issue #4707 : sur l'interface publique des tickets (pages `NOLOGIN`), la référence du ticket s'affichait en **texte brut** sur la page de succès et était **absente** du message d'événement « Ticket envoyé ». On souhaite qu'elle devienne un **lien cliquable** (`getNomUrl`) vers la fiche ticket — **uniquement si l'utilisateur est connecté** au back-office (annotation « Lien si connectée » de l'issue).

## Problème technique

Les pages publiques étant `NOLOGIN`, `$user` n'est jamais chargé depuis la session. Il faut détecter une session back-office active via `$_SESSION['dol_login']`. Surtout, `User::fetch()` **ne peuple pas** les droits : sans `loadRights()`, `hasRight('ticket', 'read')` renvoie toujours `0` (cf. `user.class.php`), d'où l'absence de lien même en étant connecté.

## Changements

- **`lib/digiriskdolibarr_function.lib.php`** : nouveau helper `getNomUrlTicketPublic(Ticket $ticket)` (cohérent avec la famille `getNomUrl*` existante). Détecte la session, charge les droits, renvoie le lien `getNomUrl(1, '', 1)` (tooltip désactivé, non chargé en public) si `ticket/read`, sinon `<b>ref</b>`.
- **`public/ticket/ticket_success.php`** : le titre utilise le helper (+ `require_once` de la lib).
- **`public/ticket/create_ticket.php`** : le `setEventMessages('TicketSent')` affiche aussi le lien via le helper.

## Tests

- Connecté (droit *Lire les tickets*) → référence cliquable dans le titre **et** dans le bandeau « Ticket envoyé ».
- Non connecté → référence en gras, sans lien, dans les deux cas.
- `php -l` OK sur les 3 fichiers.

Closes #4707

🤖 Generated with [Claude Code](https://claude.com/claude-code)