### PR TITLE
#4814 [Risk] feat: compteurs de cotation dans le bandeau risque + bouton import en icône

### DIFF
--- a/class/actions_digiriskdolibarr.class.php
+++ b/class/actions_digiriskdolibarr.class.php
@@ -1141,7 +1141,9 @@ class ActionsDigiriskdolibarr
         $out = '<div class="banner-risk-badges">';
         foreach ($cotations as $scale => $info) {
             $count = (int) ($counts[$scale] ?? 0);
-            $out  .= '<span class="banner-risk-badge ' . $info['class'] . ($count ? '' : ' empty') . '"><span class="brb-count">' . $count . '</span>' . dol_escape_htmltag($langs->trans($info['label'])) . '</span>';
+            // Short label to keep the badge compact in the banner (e.g. "Risque inacceptable" -> "Inacceptable")
+            $label = dol_ucfirst(preg_replace('/^risque\s+/i', '', $langs->trans($info['label'])));
+            $out  .= '<span class="banner-risk-badge ' . $info['class'] . ($count ? '' : ' empty') . '"><span class="brb-count">' . $count . '</span>' . dol_escape_htmltag($label) . '</span>';
         }
         $out .= '</div>';
 

--- a/class/actions_digiriskdolibarr.class.php
+++ b/class/actions_digiriskdolibarr.class.php
@@ -1101,6 +1101,55 @@ class ActionsDigiriskdolibarr
         return 0; // or return 1 to replace standard code
     }
 
+    /**
+     * Overloading the moreHtmlStatus function : on the risk page, replace the banner status by the risk cotation counts (black/red/orange/grey) of the current element.
+     *
+     * @param  array        $parameters Hook metadatas (context, morehtmlstatus, etc...).
+     * @param  CommonObject $object     Current object.
+     * @return int                      0 to keep the standard status, 1 to replace it.
+     */
+    public function moreHtmlStatus(array $parameters, $object): int
+    {
+        if (strpos($parameters['context'], 'riskcard') === false || !is_a($object, 'DigiriskElement')) {
+            return 0;
+        }
+
+        global $langs;
+
+        require_once __DIR__ . '/riskanalysis/risk.class.php';
+
+        $riskType = GETPOST('risk_type', 'aZ09');
+        if (empty($riskType)) {
+            $riskType = 'risk';
+        }
+
+        // Count only this element's risks of the current type (lightweight filtered fetch)
+        $risk      = new Risk($this->db);
+        $riskInfos = $risk->loadRiskInfos([
+            'filter'     => ' AND t.fk_element = ' . (int) $object->id,
+            'filterRisk' => ' AND t.type = \'' . $this->db->escape($riskType) . '\''
+        ]);
+        $counts = $riskInfos['current']['riskByRiskAssessmentCotations'][$object->id] ?? [];
+
+        // Cotation scale: 4 = black, 3 = red, 2 = orange, 1 = grey
+        $cotations = [
+            4 => ['class' => 'black',  'label' => 'BlackRisk'],
+            3 => ['class' => 'red',    'label' => 'RedRisk'],
+            2 => ['class' => 'orange', 'label' => 'OrangeRisk'],
+            1 => ['class' => 'grey',   'label' => 'GreyRisk'],
+        ];
+        $out = '<div class="banner-risk-badges">';
+        foreach ($cotations as $scale => $info) {
+            $count = (int) ($counts[$scale] ?? 0);
+            $out  .= '<span class="banner-risk-badge ' . $info['class'] . ($count ? '' : ' empty') . '"><span class="brb-count">' . $count . '</span>' . dol_escape_htmltag($langs->trans($info['label'])) . '</span>';
+        }
+        $out .= '</div>';
+
+        $this->resprints = $out;
+
+        return 1;
+    }
+
 	/**
 	 *  Overloading the saturneAttendantsBackToCard function : replacing the parent's function with the one below.
 	 *

--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
@@ -598,6 +598,13 @@ $massactionbutton = $form->selectMassAction('', $arrayofmassactions);
         $newcardbutton .= '<i class="fas fa-brain button-icon"></i><i class="fas fa-plus-circle button-add animated"></i>';
         $newcardbutton .= '	<input type="hidden" class="modal-options" data-modal-to-open="psychosocial_risk_add" data-from-id="'. $object->id .'" data-from-type="digiriskelement" data-from-subtype="photo" data-from-subdir="photos"/>';
         $newcardbutton .= '</div>';
+
+        // Bouton importer des risques partagés : icône seule + texte en tooltip, à côté des boutons d'ajout (id conservé pour déclencher la popup de confirmation)
+        if (!empty($conf->global->DIGIRISKDOLIBARR_SHOW_SHARED_RISKS)) {
+            $newcardbutton .= '<div class="import-shared-risks wpeo-button button-square-40 button-secondary wpeo-tooltip-event" id="actionButtonImportSharedRisks" style="margin-left: 10px;" aria-label="' . $langs->trans('ImportShared' . ucfirst($riskType) . 's') . '" value="' . $object->id . '">';
+            $newcardbutton .= '<i class="fas fa-file-import button-icon"></i>';
+            $newcardbutton .= '</div>';
+        }
     } else {
         $newcardbutton = '<div class="wpeo-button button-square-40 button-grey wpeo-tooltip-event" aria-label="' . $langs->trans('PermissionDenied') . '" data-direction="left" value="' . $object->id . '"><i class="fas fa-exclamation-triangle button-icon"></i><i class="fas fa-plus-circle button-add animated"></i></div>';
 

--- a/css/digiriskdolibarr.min.css
+++ b/css/digiriskdolibarr.min.css
@@ -149,6 +149,11 @@
   margin-right: 0 !important;
 }
 
+/* On GP/UT panel pages, the full-bleed layout (margin-left: -40px) + wide content (modals, list tables already scrollable in their .div-table-responsive) can exceed the viewport when the left menu is expanded. Clip the residual horizontal overflow so the page never gets a horizontal scrollbar. */
+body:has(.page-ut-gp-list) {
+  overflow-x: hidden;
+}
+
 /** Screen */
 .page-ut-gp-list #id-right {
   padding-left: 300px;

--- a/css/digiriskdolibarr.min.css
+++ b/css/digiriskdolibarr.min.css
@@ -5198,17 +5198,19 @@ textarea.action-textarea:not(:last-child) {
   flex-direction: column;
   align-items: flex-start;
   gap: 4px;
+  max-width: 100%;
   font-size: 12px;
 }
 .banner-risk-badges .banner-risk-badge {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: 6px;
-  white-space: nowrap;
+  max-width: 100%;
   color: #333;
   font-weight: 600;
 }
 .banner-risk-badges .banner-risk-badge .brb-count {
+  flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/css/digiriskdolibarr.min.css
+++ b/css/digiriskdolibarr.min.css
@@ -154,6 +154,8 @@
   padding-left: 300px;
   width: 100%;
   display: block;
+  /* Contain wide content (Dolibarr list tables) so it scrolls inside the content area instead of overflowing the whole page, especially when the left menu is expanded */
+  overflow-x: auto;
 }
 
 /** UT / GP Navigation */

--- a/css/digiriskdolibarr.min.css
+++ b/css/digiriskdolibarr.min.css
@@ -5190,6 +5190,50 @@ textarea.action-textarea:not(:last-child) {
   background: rgba(224, 83, 83, 0.08);
 }
 
+/** Risk page banner: cotation counts replacing the native status (moreHtmlStatus hook) */
+.banner-risk-badges {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  font-size: 12px;
+}
+.banner-risk-badges .banner-risk-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+  color: #333;
+  font-weight: 600;
+}
+.banner-risk-badges .banner-risk-badge .brb-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 6px;
+  border-radius: 5px;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 800;
+}
+.banner-risk-badges .banner-risk-badge.black .brb-count {
+  background: #2b2b2b;
+}
+.banner-risk-badges .banner-risk-badge.red .brb-count {
+  background: #e05353;
+}
+.banner-risk-badges .banner-risk-badge.orange .brb-count {
+  background: #e9ad4f;
+}
+.banner-risk-badges .banner-risk-badge.grey .brb-count {
+  background: #b0b0b0;
+}
+.banner-risk-badges .banner-risk-badge.empty {
+  opacity: 0.5;
+}
+
 /** Cell header */
 .table-cell-header {
   display: flex;

--- a/css/scss/page/_page-element-risk.scss
+++ b/css/scss/page/_page-element-risk.scss
@@ -1,0 +1,39 @@
+/** Risk page banner: cotation counts replacing the native status (moreHtmlStatus hook) */
+.banner-risk-badges {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  font-size: 12px;
+
+  .banner-risk-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    white-space: nowrap;
+    color: #333;
+    font-weight: 600;
+
+    .brb-count {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 22px;
+      height: 22px;
+      padding: 0 6px;
+      border-radius: 5px;
+      color: #fff;
+      font-size: 13px;
+      font-weight: 800;
+    }
+
+    &.black .brb-count  { background: #2b2b2b; }
+    &.red .brb-count    { background: #e05353; }
+    &.orange .brb-count { background: #e9ad4f; }
+    &.grey .brb-count   { background: #b0b0b0; }
+
+    &.empty {
+      opacity: 0.5;
+    }
+  }
+}

--- a/css/scss/page/_page-element-risk.scss
+++ b/css/scss/page/_page-element-risk.scss
@@ -4,17 +4,19 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 4px;
+  max-width: 100%;
   font-size: 12px;
 
   .banner-risk-badge {
-    display: inline-flex;
+    display: flex;
     align-items: center;
     gap: 6px;
-    white-space: nowrap;
+    max-width: 100%;
     color: #333;
     font-weight: 600;
 
     .brb-count {
+      flex: 0 0 auto;
       display: inline-flex;
       align-items: center;
       justify-content: center;

--- a/css/scss/page/_page-ut-gp-list.scss
+++ b/css/scss/page/_page-ut-gp-list.scss
@@ -17,6 +17,8 @@
   padding-left: 300px;
   width: 100%;
   display: block;
+  /* Contain wide content (Dolibarr list tables) so it scrolls inside the content area instead of overflowing the whole page, especially when the left menu is expanded */
+  overflow-x: auto;
 }
 
 

--- a/css/scss/page/_page-ut-gp-list.scss
+++ b/css/scss/page/_page-ut-gp-list.scss
@@ -12,6 +12,11 @@
   }
 }
 
+/* On GP/UT panel pages, the full-bleed layout (margin-left: -40px) + wide content (modals, list tables already scrollable in their .div-table-responsive) can exceed the viewport when the left menu is expanded. Clip the residual horizontal overflow so the page never gets a horizontal scrollbar. */
+body:has(.page-ut-gp-list) {
+  overflow-x: hidden;
+}
+
 /** Screen */
 .page-ut-gp-list #id-right {
   padding-left: 300px;

--- a/css/scss/page/_page.scss
+++ b/css/scss/page/_page.scss
@@ -5,3 +5,4 @@
 @import "digiai";
 @import "page-actionplan";
 @import "page-ticket-action-card";
+@import "page-element-risk";

--- a/view/digiriskelement/digiriskelement_risk.php
+++ b/view/digiriskelement/digiriskelement_risk.php
@@ -372,10 +372,8 @@ if ($object->id > 0) {
     saturne_banner_tab($object,'ref','none', 0, 'ref', 'ref', $morehtmlref, true, $moreParams);
 
 	// Buttons for actions
+	// The "import shared risks" action moved next to the "add risk" buttons (icon + tooltip) in the risk list view
 	print '<div class="tabsAction" >';
-	if ($permissiontoadd && !empty($conf->global->DIGIRISKDOLIBARR_SHOW_SHARED_RISKS)) {
-		print '<span class="butAction" id="actionButtonImportSharedRisks" title="" href="' . $_SERVER["PHP_SELF"] . '?id=' . $object->id . '&risk_type=' . $riskType . '&action=import_shared_risks' . '">' . $langs->trans('ImportShared' . ucfirst($riskType) . 's') . '</span>';
-	}
 	print '</div>';
 
 	if ($conf->global->DIGIRISKDOLIBARR_SHOW_RISKS == 1) {

--- a/view/digiriskelement/digiriskelement_risk.php
+++ b/view/digiriskelement/digiriskelement_risk.php
@@ -228,7 +228,9 @@ $form    = new Form($db);
 $title   = $langs->trans(ucfirst($riskType) . 's');
 $helpUrl = 'FR:Module_Digirisk#.C3.89valuation_des_Risques';
 
-digirisk_header($title, $helpUrl);
+// classforhorizontalscrolloftabs constrains #id-right width so the wide risk list table
+// scrolls inside its own .div-table-responsive instead of widening the whole page
+digirisk_header($title, $helpUrl, [], [], '', 'classforhorizontalscrolloftabs');
 
 if ($conf->browser->layout == 'phone') {
     $onPhone = 1;


### PR DESCRIPTION
Closes #4814

## Résumé

Sur la page d'un risque, le bandeau affiche désormais les **compteurs de cotation** de l'élément (à la place du statut « Validé »), et le bouton « Importer des risques partagés » devient une **icône + tooltip** à côté des boutons d'ajout.

## Changements

### Bandeau — compteurs de cotation à la place du statut
- Hook **`moreHtmlStatus`** ajouté dans `class/actions_digiriskdolibarr.class.php` : `showrefnav` (cœur Dolibarr) l'expose et, en retournant `1`, on **remplace** le contenu du statut.
- Gardé sur le contexte `riskcard` (uniquement la page risque), objet `DigiriskElement`.
- Compteurs via `Risk::loadRiskInfos()` **filtré sur l'élément courant et le `risk_type`** (fetch léger). Échelle : gris 0-47, orange 48-50, rouge 51-79, noir 80-100.
- Badges empilés en colonne (puce colorée + libellé) — nouveau partial `css/scss/page/_page-element-risk.scss` importé dans `_page.scss`.

### Bouton « Importer des risques partagés » en icône
- Déplacé de la barre `.tabsAction` (`view/digiriskelement/digiriskelement_risk.php`) vers le `$newcardbutton` de `core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php`, à côté des boutons d'ajout.
- `wpeo-button` icône seule (`fa-file-import`) + `wpeo-tooltip-event` (texte en tooltip via `aria-label`).
- **Id `actionButtonImportSharedRisks` conservé** → la popup de confirmation (`digiriskformconfirm`) se déclenche toujours au clic. Même condition d'affichage (`DIGIRISKDOLIBARR_SHOW_SHARED_RISKS` + droit d'ajout).

## Notes

- Aucune modification de saturne ni du cœur Dolibarr.
- Assets `.min` recompilés à la main (pas de CI de build sur Digirisk).

## Tests

- Vider le cache (Ctrl+Shift+R) — Dolibarr versionne le CSS par version de module.
- Page risque : le bandeau montre les 4 compteurs (noir/rouge/orange/gris) de l'élément ; le bouton import (icône) ouvre bien la popup de confirmation d'import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
