### PR TITLE
#4816 [Risk] fix: php8 undefined array key warnings on risk lists

### DIFF
--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_inheritedrisklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_inheritedrisklist_view.tpl.php
@@ -210,8 +210,8 @@
 
 			foreach ($search as $key => $val) {
 				if ($key == 'status' && $search[$key] == -1) continue;
-				$mode_search = (($evaluation->isInt($evaluation->fields[$key]) || $evaluation->isFloat($evaluation->fields[$key])) ? 1 : 0);
-				if (strpos($evaluation->fields[$key]['type'], 'integer:') === 0) {
+				$mode_search = (($risk->isInt($risk->fields[$key]) || $risk->isFloat($risk->fields[$key])) ? 1 : 0);
+				if (strpos($risk->fields[$key]['type'], 'integer:') === 0) {
 					if ($search[$key] == '-1') $search[$key] = '';
 					$mode_search = 2;
 				}
@@ -344,7 +344,7 @@
 		if ($key == 'status') $cssforfield .= ($cssforfield ? ' ' : '') . 'center';
 		if ( ! empty($arrayfields['r.' . $key]['checked'])) {
 			print '<td class="liste_titre' . ($cssforfield ? ' ' . $cssforfield : '') . '">';
-			if (is_array($val['arrayofkeyval'])) print $form->selectarray('search_' . $key, $val['arrayofkeyval'], $search[$key], $val['notnull'], 0, 0, '', 1, 0, 0, '', 'maxwidth75');
+			if (!empty($val['arrayofkeyval']) && is_array($val['arrayofkeyval'])) print $form->selectarray('search_' . $key, $val['arrayofkeyval'], (isset($search[$key]) ? $search[$key] : ''), $val['notnull'], 0, 0, '', 1, 0, 0, '', 'maxwidth75');
 			elseif (strpos($val['type'], 'integer:') === 0) {
 				print $risk->showInputField($val, $key, $search[$key], '', '', 'search_', 'maxwidth150', 1);
 			} elseif ($key == 'fk_element') {
@@ -374,7 +374,7 @@
 						endif; ?>
 					</ul>
 				</div>
-			<?php } elseif ( ! preg_match('/^(date|timestamp)/', $val['type']) && $key != 'category') print '<input type="text" class="flat maxwidth75" name="search_' . $key . '" value="' . dol_escape_htmltag($search[$key]) . '">';
+			<?php } elseif ( ! preg_match('/^(date|timestamp)/', $val['type']) && $key != 'category') print '<input type="text" class="flat maxwidth75" name="search_' . $key . '" value="' . dol_escape_htmltag(isset($search[$key]) ? $search[$key] : '') . '">';
 			print '</td>';
 		}
 	}

--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
@@ -488,8 +488,8 @@ if ( ! preg_match('/(evaluation)/', $sortfield)) {
 
     foreach ($search as $key => $val) {
         if ($key == 'status' && $search[$key] == -1) continue;
-        $mode_search = (($evaluation->isInt($evaluation->fields[$key]) || $evaluation->isFloat($evaluation->fields[$key])) ? 1 : 0);
-        if (strpos($evaluation->fields[$key]['type'], 'integer:') === 0) {
+        $mode_search = (($risk->isInt($risk->fields[$key]) || $risk->isFloat($risk->fields[$key])) ? 1 : 0);
+        if (strpos($risk->fields[$key]['type'], 'integer:') === 0) {
             if ($search[$key] == '-1') $search[$key] = '';
             $mode_search                             = 2;
         }

--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_sharedrisklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_sharedrisklist_view.tpl.php
@@ -240,8 +240,8 @@ if ( ! preg_match('/(evaluation)/', $sortfield)) {
 
 	foreach ($search as $key => $val) {
 		if ($key == 'status' && $search[$key] == -1) continue;
-		$mode_search = (($evaluation->isInt($evaluation->fields[$key]) || $evaluation->isFloat($evaluation->fields[$key])) ? 1 : 0);
-		if (strpos($evaluation->fields[$key]['type'], 'integer:') === 0) {
+		$mode_search = (($risk->isInt($risk->fields[$key]) || $risk->isFloat($risk->fields[$key])) ? 1 : 0);
+		if (strpos($risk->fields[$key]['type'], 'integer:') === 0) {
 			if ($search[$key] == '-1') $search[$key] = '';
 			$mode_search                             = 2;
 		}

--- a/lib/digiriskdolibarr_function.lib.php
+++ b/lib/digiriskdolibarr_function.lib.php
@@ -2506,7 +2506,7 @@ function digiriskformconfirm($page, $title, $question, $action, $formquestion = 
 					$more .= '</div></div>'."\n";
 				} elseif ($input['type'] == 'checkbox') {
 					$more .= '<div class="tagtr">';
-					$more .= '<div class="tagtd'.(empty($input['tdclass']) ? '' : (' '.$input['tdclass'])).'">'.$input['label'].' </div><div class="tagtd">';
+					$more .= '<div class="tagtd'.(empty($input['tdclass']) ? '' : (' '.$input['tdclass'])).'">'.(empty($input['label']) ? '' : $input['label']).' </div><div class="tagtd">';
 					$more .= '<input type="checkbox" class="flat'.$morecss.'" id="'.dol_escape_htmltag($input['name']).'" name="'.dol_escape_htmltag($input['name']).'"'.$moreattr;
 					if (!is_bool($input['value']) && $input['value'] != 'false' && $input['value'] != '0' && $input['value'] != '') {
 						$more .= ' checked';

--- a/view/digiriskelement/digiriskelement_risk.php
+++ b/view/digiriskelement/digiriskelement_risk.php
@@ -121,7 +121,7 @@ $pagenext = $page + 1;
 $search_all = GETPOST('search_all', 'alphanohtml') ? trim(GETPOST('search_all', 'alphanohtml')) : trim(GETPOST('sall', 'alphanohtml'));
 $search     = array();
 foreach ($risk->fields as $key => $val) {
-	if (GETPOST('search_' . $key, 'alpha') !== '') $search[$key] = GETPOST('search_' . $key, 'alpha');
+	$search[$key] = (GETPOST('search_' . $key, 'alpha') !== '') ? GETPOST('search_' . $key, 'alpha') : '';
 
 	if ($key == 'fk_element' && $contextpage == 'sharedrisk') {
 		$search[$key] = GETPOST('search_' . $key . '_sharedrisk', 'alpha');

--- a/view/digiriskelement/risk_list.php
+++ b/view/digiriskelement/risk_list.php
@@ -126,7 +126,7 @@ $pagenext = $page + 1;
 $search_all = GETPOST('search_all', 'alphanohtml') ? trim(GETPOST('search_all', 'alphanohtml')) : trim(GETPOST('sall', 'alphanohtml'));
 $search     = array();
 foreach ($risk->fields as $key => $val) {
-	if (GETPOST('search_' . $key, 'alpha') !== '') $search[$key] = GETPOST('search_' . $key, 'alpha');
+	$search[$key] = (GETPOST('search_' . $key, 'alpha') !== '') ? GETPOST('search_' . $key, 'alpha') : '';
 	if ($key == 'fk_element' && $contextpage == 'sharedrisk') {
 		$search[$key] = GETPOST('search_' . $key . '_sharedrisk', 'alpha');
 	}


### PR DESCRIPTION
## Changements

Corrections de warnings de compatibilité PHP 8 (`Undefined array key`) sur les pages de liste des risques.

- **Cause racine** : `$search[$key]` n'était initialisé que si un filtre était actif → les templates le lisaient sans garde. Chaque clé de champ est désormais initialisée à `''` par défaut (pattern standard Dolibarr `list.php`).
- **Boucles SQL** : 3 boucles recherchaient la table risk (`natural_search('r.'.$key, ...)`) mais calculaient le mode de recherche depuis `$evaluation->fields[$key]`, qui ne contient pas les clés propres au risque (`category`, `fk_element`, `fk_projet`...). Alignées sur `$risk->fields[$key]`, comme la boucle déjà correcte du même fichier.
- **`arrayofkeyval`** : ajout d'une garde `!empty(...) && is_array(...)`.
- **Checkbox** : la branche `checkbox` de `print_fields` affichait `$input['label']` sans garde (contrairement à la branche `select`) → garde `empty()`.

## Fichiers modifiés

- `view/digiriskelement/digiriskelement_risk.php`
- `view/digiriskelement/risk_list.php`
- `core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php`
- `core/tpl/riskanalysis/risk/digiriskdolibarr_sharedrisklist_view.tpl.php`
- `core/tpl/riskanalysis/risk/digiriskdolibarr_inheritedrisklist_view.tpl.php`
- `lib/digiriskdolibarr_function.lib.php`

## Issue

#4816
