### PR TITLE
[SCSS] fix: phantom horizontal scrollbar sur les pages panneau GP/UT

### DIFF
--- a/css/digiriskdolibarr.min.css
+++ b/css/digiriskdolibarr.min.css
@@ -163,6 +163,13 @@ body:has(.page-ut-gp-list) {
   overflow-x: auto;
 }
 
+/* The infobox (Document unique, etc.) does not shrink below its flex content and
+   overshoots #id-right by ~15px, which is enough to trigger the overflow-x:auto
+   scrollbar above for nothing. Cap it to the content width so no phantom scrollbar appears. */
+.page-ut-gp-list #id-right .wpeo-infobox-container {
+  max-width: 100%;
+}
+
 /** UT / GP Navigation */
 .page-ut-gp-list .side-nav {
   position: absolute;

--- a/css/scss/page/_page-ut-gp-list.scss
+++ b/css/scss/page/_page-ut-gp-list.scss
@@ -26,6 +26,13 @@ body:has(.page-ut-gp-list) {
   overflow-x: auto;
 }
 
+/* The infobox (Document unique, etc.) does not shrink below its flex content and
+   overshoots #id-right by ~15px, which is enough to trigger the overflow-x:auto
+   scrollbar above for nothing. Cap it to the content width so no phantom scrollbar appears. */
+.page-ut-gp-list #id-right .wpeo-infobox-container {
+  max-width: 100%;
+}
+
 
 /** UT / GP Navigation */
 .page-ut-gp-list .side-nav {


### PR DESCRIPTION
## Problème

Sur les pages avec le panneau d'arborescence GP/UT (`.page-ut-gp-list` — ex. fiche Document unique / risques), une **scrollbar horizontale** apparaît en bas de la zone de contenu `#id-right` alors qu'il n'y a rien à scroller.

## Cause (diagnostiquée en live)

Lecture du DOM réel : `#id-right` déborde de **15px** (scrollWidth 1352 vs clientWidth 1337). Un seul élément en cause : le bloc infobox `.wpeo-infobox-container` (flex) ne se réduit pas sous la largeur de son contenu et dépasse de ~15px (la largeur d'une scrollbar). La règle `​.page-ut-gp-list #id-right { overflow-x: auto }` (ajoutée en #4814 pour contenir les **tables larges**) affiche alors une scrollbar pour ces 15px.

## Fix

```scss
.page-ut-gp-list #id-right .wpeo-infobox-container { max-width: 100%; }
```

L'infobox passe de 1008px à 993px (tient dans la zone de contenu), le débordement passe de **15px → 0** et la scrollbar disparaît. `overflow-x: auto` est **conservé** pour le scroll des vraies tables larges.

## Validation

Testé **en live** (Chrome headless, loggé) sur `digiriskstandard_card.php?risk_type=risk` :
- avant : 2 scrollbars (verticale du panneau + horizontale fantôme)
- après : 1 seule (la verticale du panneau, voulue) — horizontale supprimée, aucune régression visuelle.

`css/digiriskdolibarr.min.css` recompilé (module sans CI de build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)