### PR TITLE
#4836 [PreventionPlan] fix: type error when loading object without id

### DIFF
--- a/view/preventionplan/preventionplan_card.php
+++ b/view/preventionplan/preventionplan_card.php
@@ -58,7 +58,7 @@ saturne_load_langs(['other', 'mails']);
 
 // Get parameters
 $id                  = GETPOSTINT('id');
-$lineid              = GETPOST('lineid', 'int');
+$lineid              = GETPOSTINT('lineid');
 $ref                 = GETPOST('ref', 'alpha');
 $action              = GETPOST('action', 'aZ09');
 $subaction           = GETPOST('subaction', 'aZ09');
@@ -67,7 +67,8 @@ $cancel              = GETPOST('cancel', 'aZ09');
 $contextpage         = GETPOST('contextpage', 'aZ') ? GETPOST('contextpage', 'aZ') : 'preventionplancard'; // To manage different context of search
 $backtopage          = GETPOST('backtopage', 'alpha');
 $backtopageforcancel = GETPOST('backtopageforcancel', 'alpha');
-$fk_parent           = GETPOST('fk_parent', 'int');
+
+$fk_parent           = GETPOSTINT('fk_parent');
 
 // Initialize technical objects
 $object             = new PreventionPlan($db);
@@ -86,7 +87,9 @@ $thirdparty         = new Societe($db);
 $project            = new Project($db);
 
 // Load object
-$object->fetch($id);
+if ($id > 0 || !empty($ref)) {
+	$object->fetch($id, $ref);
+}
 
 $deletedElements = $digiriskelement->getMultiEntityTrashList();
 if (empty($deletedElements)) {


### PR DESCRIPTION
Fixes #4836. Lors de la création d'un plan de prévention, le paramètre id n'est pas défini. L'appel inconditionnel à fetch() causait une TypeError dans SaturneObject. Le correctif utilise GETPOSTINT() et n'appelle fetch() que si l'identifiant (ou la ref) est valide.