### PR TITLE
#4838 [PreventionPlan] fix: warning property id on int

### DIFF
--- a/view/preventionplan/preventionplan_card.php
+++ b/view/preventionplan/preventionplan_card.php
@@ -623,9 +623,11 @@ if (empty($reshook)) {
 	$triggersendname    = 'PREVENTIONPLAN_SENTBYMAIL';
 	$trackid            = 'preventionplan' . $object->id;
 	$labourInspector    = $digiriskresources->fetchResourcesFromObject('LabourInspector', $object);
-	$labourInspectorId  = $labourInspector->id;
-	$thirdparty->fetch($labourInspectorId);
-	$object->thirdparty = $thirdparty;
+	$labourInspectorId  = is_object($labourInspector) ? $labourInspector->id : 0;
+	if ($labourInspectorId > 0) {
+		$thirdparty->fetch($labourInspectorId);
+		$object->thirdparty = $thirdparty;
+	}
 
 	include DOL_DOCUMENT_ROOT . '/core/actions_sendmails.inc.php';
 }


### PR DESCRIPTION
Fixes #4838. L'avertissement \Attempt to read property id on int\ a été corrigé en vérifiant d'abord que \\\ est un objet valide avant de lire son id, et on s'assure de ne pas faire le \etch()\ inconditionnellement s'il n'y a pas d'inspecteur.