### PR TITLE
#4844 [Module] fix: parse error fatal `!empty(...) = 0` sur la ligne 889

### DIFF
--- a/core/modules/modDigiriskDolibarr.class.php
+++ b/core/modules/modDigiriskDolibarr.class.php
@@ -886,7 +886,7 @@ class modDigiriskdolibarr extends DolibarrModules
 
 		if (!isModEnabled('digiriskdolibarr')) {
 			$conf->digiriskdolibarr          = new stdClass();
-			!empty($conf->digiriskdolibarr->enabled) = 0;
+			$conf->digiriskdolibarr->enabled = 0;
 		}
 
 		// Array to add new pages in new tabs


### PR DESCRIPTION
Closes #4844

## Problème

`develop` est actuellement **cassé** : le module ne se charge plus du tout.

```
Parse error: syntax error, unexpected token "=" in .../core/modules/modDigiriskDolibarr.class.php on line 889
```

## Cause

Le commit `4e6fd4e9` (*fix undefined property stdClass::enabled warnings in PHP 8.2*) a fait un rechercher-remplacer `$conf->digiriskdolibarr->enabled` → `!empty($conf->digiriskdolibarr->enabled)` sur **tout** le fichier, y compris la ligne d'**affectation**, ce qui donne du PHP invalide :

```php
!empty($conf->digiriskdolibarr->enabled) = 0;   // on ne peut pas affecter au résultat de !empty()
```

## Correction

Restauration de l'affectation simple (1 ligne) :

```php
$conf->digiriskdolibarr->enabled = 0;
```

Les `!empty()` sur les contextes de **lecture** (`tabcond`, chaînes `enabled` du menu) sont corrects et restent inchangés. Aucun warning PHP 8.2 sur cette ligne (écriture sur un `stdClass` fraîchement instancié).

## Vérification

`php -l` (PHP 8.3) sur le fichier corrigé : **No syntax errors detected**.