### PR TITLE
#4851 [SCSS] fix: retour à la ligne du nom des GP/UT dans le panneau de navigation

### DIFF
--- a/css/digiriskdolibarr.min.css
+++ b/css/digiriskdolibarr.min.css
@@ -303,9 +303,9 @@ body:has(.page-ut-gp-list) {
   font-size: 13px;
   padding-left: 0;
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 .page-ut-gp-list .side-nav .workunit-list .row-container {
   /* Actions float over the right edge on hover so they never reserve width nor push other elements */

--- a/css/scss/page/_page-ut-gp-list.scss
+++ b/css/scss/page/_page-ut-gp-list.scss
@@ -175,13 +175,14 @@ body:has(.page-ut-gp-list) {
       padding: 3px 6px;
     }
 
+    /* Long GP/UT names wrap onto new lines instead of stretching the row; flex-grow + min-width:0 keep the row within the fixed panel width */
     .title.element-label {
       font-size: 13px;
       padding-left: 0;
       min-width: 0;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
+      white-space: normal;
+      overflow-wrap: anywhere;
+      word-break: break-word;
     }
 
     /* Actions float over the right edge on hover so they never reserve width nor push other elements */


### PR DESCRIPTION
## Contexte
Fixes #4851

Dans le panneau de navigation GP/UT (`.side-nav`) de la page d'évaluation des risques, un nom de GP/UT trop long était tronqué (`…`) et restait sur une seule ligne, rendant le nom illisible.

## Correctif
Règle `.page-ut-gp-list .side-nav .workunit-list .row-container .title.element-label` :
- `white-space: nowrap` → `white-space: normal`
- suppression de `overflow: hidden` + `text-overflow: ellipsis`
- ajout de `overflow-wrap: anywhere` + `word-break: break-word` (gère aussi les mots très longs)

`flex-grow: 1` (hérité) + `min-width: 0` garantissent que la ligne reste dans la largeur fixe du panneau (300px) : le nom revient à la ligne au lieu d'élargir la box.

## Fichiers
- `css/scss/page/_page-ut-gp-list.scss` (source)
- `css/digiriskdolibarr.min.css` (compilé — pas de CI de build sur ce dépôt)

## Test
Vérifié via rendu headless avec le CSS compilé réel et le markup du panneau : largeur du panneau inchangée, le nom long passe sur plusieurs lignes.

| Avant | Après |
|-------|-------|
| Nom tronqué `…` sur une ligne | Nom complet réparti sur plusieurs lignes, box à largeur fixe |

🤖 Generated with [Claude Code](https://claude.com/claude-code)