### PR TITLE
#4853 [PAPRIPACT] fix: guard risk fetch on corrective actions without linked risk

### DIFF
--- a/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/projectdocument/pdf_papripact_a3_paysage_projectdocument.modules.php
+++ b/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/projectdocument/pdf_papripact_a3_paysage_projectdocument.modules.php
@@ -403,11 +403,17 @@ class pdf_papripact_a3_paysage_projectdocument
 				$objectDoc = array();
 				for ($i = 0; $i < $nblines; $i++) {
                     $object->lines[$i]->fetch_optionals();
-                    $risk->fetch($object->lines[$i]->array_options['options_fk_risk']);
-					$lastEvaluation = $riskassessment->fetchFromParent($risk->id, 1);
-					if ($lastEvaluation > 0 && !empty($lastEvaluation) && is_array($lastEvaluation)) {
-						$lastEvaluation = array_shift($lastEvaluation);
-					}
+                    // A corrective action is not necessarily linked to a risk: reset and guard the fetch to avoid a fatal on a null fk_risk
+                    $risk           = new Risk($this->db);
+                    $fkRisk         = (int) ($object->lines[$i]->array_options['options_fk_risk'] ?? 0);
+                    $lastEvaluation = null;
+                    if ($fkRisk > 0) {
+                        $risk->fetch($fkRisk);
+                        $lastEvaluation = $riskassessment->fetchFromParent($risk->id, 1);
+                        if ($lastEvaluation > 0 && !empty($lastEvaluation) && is_array($lastEvaluation)) {
+                            $lastEvaluation = array_shift($lastEvaluation);
+                        }
+                    }
 
                     $users          = $object->lines[$i]->liste_contact(-1, 'internal');
                     $userExecutives = [];
@@ -417,7 +423,7 @@ class pdf_papripact_a3_paysage_projectdocument
                         }
                     };
 
-                    $risk->category = $risk->getDangerCategoryName($risk);
+                    $risk->category = $fkRisk > 0 ? $risk->getDangerCategoryName($risk) : '';
 
 					$tmpArray = array("cotation" => empty($lastEvaluation->cotation) ? 0 : $lastEvaluation->cotation);
 					$tmpArray += array("task_ref" => $object->lines[$i]->ref);


### PR DESCRIPTION
## Problème

La génération du PAPRIPACT (modèle `papripact_a3_paysage_projectdocument`) plantait avec une erreur fatale :

```
TypeError: Argument 1 passed to SaturneObject::fetch() must be of the type int, null given
```

En cause : le document parcourt toutes les actions correctives du projet Document Unique et charge le risque lié via le champ complémentaire `options_fk_risk`. Lorsqu'une action corrective n'est rattachée à aucun risque, `options_fk_risk` vaut `null`, et `SaturneObject::fetch()` étant désormais typé strictement `int`, l'appel `fetch(null)` lève un `TypeError` qui interrompt toute la génération.

## Changements

- Cast de `options_fk_risk` en `int` (0 si absent) et exécution du `fetch()` uniquement quand un risque est réellement lié.
- Ré-instanciation de l'objet `Risk` à chaque itération pour qu'une action sans risque n'hérite pas des données du risque de l'itération précédente.
- Catégorie de danger laissée vide (au lieu de `-1`) pour les actions correctives sans risque.

Les actions correctives sans risque apparaissent désormais dans le PAPRIPACT avec les colonnes risque / cotation / catégorie vides, au lieu de faire échouer la génération.

## Fichiers modifiés

- `core/modules/digiriskdolibarr/digiriskdolibarrdocuments/projectdocument/pdf_papripact_a3_paysage_projectdocument.modules.php`

## Issue

#4853
