### PR TITLE
#4863 [TicketDocument] Fix: Undefined variable allCategories in pdf_ticketdocument

### DIFF
--- a/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/ticketdocument/pdf_ticketdocument.modules.php
+++ b/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/ticketdocument/pdf_ticketdocument.modules.php
@@ -446,6 +446,7 @@
             $userTmp->fetch($object->fk_user_assign);
             $digiriskElement->fetch($object->array_options['options_digiriskdolibarr_ticket_service']);
             $categories = $category->containing($object->id, Categorie::TYPE_TICKET);
+            $allCategories = '';
             if (!empty($categories)) {
                 $index = 0;
                 foreach ($categories as $cat) {


### PR DESCRIPTION
## Description
Lors de la generation du PDF ticket, un warning PHP apparait :

`	xt
Warning: Undefined variable \ in pdf_ticketdocument.modules.php on line 542
`

## Cause
`\` n'est construite que dans le bloc `if (!empty(\))` (ligne 449). Si aucune categorie n'est liee au ticket, la variable est undefined quand elle est passee a `getTicketPdfTables()` ligne 542.

## Correction
Initialisation `\ = '';` avant le bloc `if` (ligne 449).

## Fichier modifie
- `core/modules/digiriskdolibarr/digiriskdolibarrdocuments/ticketdocument/pdf_ticketdocument.modules.php`

Closes #4863