### PR TITLE
UI #4869: Suppression des separateurs parasites et alignement de l'en-tete de la modale risque

### DIFF
--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
@@ -733,7 +733,7 @@ $massactionbutton = $form->selectMassAction('', $arrayofmassactions);
                                 </div>
                             </div>
                         </div>
-                        <hr style="margin: 15px 0; border: 0; border-top: 1px solid rgba(0, 0, 0, 0.2);">
+
                         <div class="risk-evaluation-content-wrapper">
                             <div class="risk-evaluation-content">
                                 <div class="cotation-container">
@@ -809,7 +809,6 @@ $massactionbutton = $form->selectMassAction('', $arrayofmassactions);
                             </div>
                         </div>
                     <?php if ($conf->global->DIGIRISKDOLIBARR_TASK_MANAGEMENT) : ?>
-                        <hr>
                         <div class="riskassessment-task">
                             <div style="display: flex; align-items: center; margin-bottom: 5px;">
                                 <span class="section-title" style="margin-bottom: 0; margin-right: 15px; white-space: nowrap;"><?php echo $langs->trans('Task'); ?></span>

--- a/core/tpl/riskanalysis/riskassessment/digiriskdolibarr_riskassessment_view_edit_modal.tpl.php
+++ b/core/tpl/riskanalysis/riskassessment/digiriskdolibarr_riskassessment_view_edit_modal.tpl.php
@@ -80,7 +80,7 @@
                             </div>
                         </div>
 					</div>
-                    <hr style="margin: 15px 0; border: 0; border-top: 1px solid rgba(0, 0, 0, 0.2);">
+
                     <div class="risk-evaluation-content-wrapper">
                         <div class="risk-evaluation-content">
                             <div class="cotation-container">

--- a/css/digiriskdolibarr.min.css
+++ b/css/digiriskdolibarr.min.css
@@ -5918,6 +5918,13 @@ td > .risk-evaluation-list-content .risk-evaluation-container:not(.advanced, .st
   box-shadow: none;
 }
 
+.wpeo-modal[class*=modal-risk] .modal-container .modal-header {
+  align-items: center;
+}
+.wpeo-modal[class*=modal-risk] .modal-container .modal-header .wpeo-button {
+  margin-bottom: 0;
+}
+
 .wpeo-modal[class*=modal-risk] .modal-container .title {
   display: block;
   font-weight: 600;
@@ -5968,7 +5975,6 @@ td > .risk-evaluation-list-content .risk-evaluation-container:not(.advanced, .st
 .wpeo-modal[class*=modal-risk] .modal-container .risk-evaluation-container {
   padding-bottom: 1em;
   margin-bottom: 1em;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.2);
 }
 .wpeo-modal[class*=modal-risk] .modal-container .risk-evaluation-container .risk-evaluation-header {
   margin-bottom: 1em;
@@ -6005,6 +6011,12 @@ td > .risk-evaluation-list-content .risk-evaluation-container:not(.advanced, .st
 }
 .wpeo-modal[class*=modal-risk] .modal-container .risk-evaluation-container.advanced .risk-evaluation-photo {
   margin-right: 1em;
+}
+
+.wpeo-modal[class*=modal-risk] .modal-container .riskassessment-task {
+  padding-top: 1em;
+  margin-top: 1em;
+  border-top: 1px solid rgba(0, 0, 0, 0.2);
 }
 
 /** Listing */

--- a/css/scss/modal/_risk.scss
+++ b/css/scss/modal/_risk.scss
@@ -1,3 +1,11 @@
+.wpeo-modal[class*="modal-risk"] .modal-container .modal-header {
+  align-items: center;
+
+  .wpeo-button {
+    margin-bottom: 0;
+  }
+}
+
 .wpeo-modal[class*="modal-risk"] .modal-container {
   .title {
     display: block;
@@ -54,7 +62,6 @@
 .wpeo-modal[class*="modal-risk"] .modal-container .risk-evaluation-container {
   padding-bottom: 1em;
   margin-bottom: 1em;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.2);
 
   .risk-evaluation-header {
     margin-bottom: 1em;
@@ -103,6 +110,12 @@
       margin-right: 1em;
     }
   }
+}
+
+.wpeo-modal[class*="modal-risk"] .modal-container .riskassessment-task {
+  padding-top: 1em;
+  margin-top: 1em;
+  border-top: 1px solid rgba(0, 0, 0, 0.2);
 }
 
 /** Listing */


### PR DESCRIPTION
## Modifications

- Suppression du <hr> parasite entre l'en-tete d'evaluation (boutons + photos) et les cotations dans la modale d'ajout de risque
- Suppression du meme <hr> dans la modale d'edition de risque
- Repositionnement du separateur : desormais via order-top sur .riskassessment-task pour qu'il apparaisse juste au-dessus de la section Tache
- Alignement vertical (lign-items: center) du titre et du bouton dans l'en-tete de la modale
- Recompilation des fichiers CSS minifies