### PR TITLE
[Amélioration] #4443 - IHM ticket registre

### DIFF
--- a/css/scss/page/_page-ticket-card.scss
+++ b/css/scss/page/_page-ticket-card.scss
@@ -1,0 +1,242 @@
+// Ticket card (issue #4443) — light, modern restyle layered over the native
+// Dolibarr ticket card. Fully scoped to .digirisk-ticket-card so it never leaks
+// to other pages. Self-contained variables (no dependency on global colors).
+
+$dtc-radius:      12px;
+$dtc-shadow:      0 1px 3px rgba(17, 24, 39, 0.06), 0 1px 2px rgba(17, 24, 39, 0.04);
+$dtc-shadow-hov:  0 6px 18px rgba(17, 24, 39, 0.10);
+$dtc-blue:        #2b6cb0;
+$dtc-grey:        #6b7280;
+$dtc-bg:          #f6f8fb;
+$dtc-border:      #e5e7eb;
+$dtc-hairline:    #f1f3f5;
+$dtc-title:       #111827;
+
+.digirisk-ticket-card {
+
+    // ---- Two-column layout with a real gap (override native float) ----
+    .fichecenter {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        align-items: flex-start;
+        margin-top: 8px;
+    }
+    .fichecenter > .fichehalfleft,
+    .fichecenter > .fichehalfright {
+        float: none;
+        width: auto;
+        flex: 1 1 380px;
+        min-width: 0;
+    }
+    .underbanner { display: none; } // decorative native separator, not needed here
+
+    // ---- Section cards (tableforfield) ----
+    table.tableforfield {
+        background: #fff;
+        border: 1px solid $dtc-border;
+        border-radius: $dtc-radius;
+        box-shadow: $dtc-shadow;
+        border-collapse: separate;
+        border-spacing: 0;
+        // No overflow:hidden here — it would clip the tag dropdown that overflows the card.
+        // Rounded top corners are handled directly on the header cell below.
+        margin: 0 0 10px 0;
+        transition: box-shadow .18s ease;
+
+        &:hover { box-shadow: $dtc-shadow-hov; }
+
+        // Section header row — the TD stays a table-cell so colspan and the
+        // full-width background are preserved; an inner flex wrapper (.dtc-head)
+        // handles vertical centering and the left title / right edit layout.
+        tr.liste_titre > td {
+            background: $dtc-bg;
+            border-top-left-radius: $dtc-radius;
+            border-top-right-radius: $dtc-radius;
+            border-bottom: 1px solid $dtc-border;
+            padding: 0;
+            vertical-align: middle;
+
+            > .dtc-head {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+                padding: 7px 12px;
+                font-weight: 700;
+                font-size: 0.92em;
+                letter-spacing: .01em;
+                color: $dtc-title;
+
+                img { vertical-align: middle; }
+                img.pictoModule { height: 20px; width: auto; }
+
+                .dtc-head-edit {
+                    margin-left: auto;
+                    display: inline-flex;
+                    align-items: center;
+                    gap: 6px;
+                    font-weight: 400;
+                    flex: 0 0 auto;
+                }
+
+                // Inline (on-the-fly) editable subject, shown on the same line as the label
+                .dtc-head-label { flex: 0 0 auto; }
+                .dtc-subject {
+                    flex: 1 1 auto;
+                    min-width: 0;
+                    font-weight: 400;
+                }
+                .dtc-subject-value {
+                    cursor: text;
+                    padding: 1px 5px;
+                    border-radius: 5px;
+                    transition: background .15s ease;
+                }
+                .dtc-subject:hover .dtc-subject-value { background: rgba(43, 108, 176, .10); }
+                .dtc-subject-input {
+                    width: 100%;
+                    box-sizing: border-box;
+                    font: inherit;
+                    font-weight: 400;
+                    padding: 3px 7px;
+                    border: 1px solid $dtc-blue;
+                    border-radius: 6px;
+                    outline: none;
+                }
+            }
+        }
+
+        // Body cells — vertical-align middle so labels line up with their values
+        // (avatars / pictos are taller than the label text).
+        > tbody > tr > td {
+            padding: 5px 12px;
+            border-top: 1px solid $dtc-hairline;
+            vertical-align: middle;
+            line-height: 1.35;
+        }
+        > tbody > tr.liste_titre + tr > td,
+        > tbody > tr:first-child > td { border-top: 0; }
+
+        // Field labels
+        td.titlefield,
+        td.titlefieldmiddle {
+            color: $dtc-grey;
+            font-weight: 500;
+        }
+
+        // Nested helper tables (label + edit pencil) stay transparent
+        table.nobordernopadding,
+        table.nobordernopadding > tbody > tr > td {
+            background: none;
+            border: 0;
+            padding: 0;
+            box-shadow: none;
+        }
+        table.nobordernopadding td.none,
+        table.nobordernopadding td.nowrap { color: $dtc-grey; font-weight: 500; }
+    }
+
+    // Edit pencils: discreet, highlight on hover
+    a.editfielda {
+        color: $dtc-grey;
+        opacity: .5;
+        transition: opacity .15s ease, color .15s ease;
+        &:hover { opacity: 1; color: $dtc-blue; }
+    }
+
+    // ---- Linked tasks table ----
+    table.noborder {
+        background: #fff;
+        border: 1px solid $dtc-border;
+        border-radius: $dtc-radius;
+        box-shadow: $dtc-shadow;
+        border-collapse: separate;
+        border-spacing: 0;
+        overflow: hidden;
+        margin: 0 0 18px 0;
+
+        tr.liste_titre th {
+            background: $dtc-bg;
+            border-bottom: 1px solid $dtc-border;
+            padding: 6px 10px;
+            font-size: 0.78em;
+            text-transform: uppercase;
+            letter-spacing: .04em;
+            color: $dtc-grey;
+        }
+        td {
+            padding: 5px 10px;
+            border-top: 1px solid $dtc-hairline;
+        }
+        tr:hover td { background: #fafbfc; }
+    }
+
+    // ---- Classification tags ----
+    // Uses the exact kanban tag markup (kanban-card-tags / kanban-tag / kanban-add-tag-btn /
+    // kanban-tag-dropdown / kanban-tag-option), so styling comes from the global kanban rules
+    // in _page-actionplan.scss — identical look to the ticket kanban.
+    // Cap the dropdown height and scroll instead of growing sky-high with many categories.
+    .kanban-tag-dropdown {
+        max-height: 240px;
+        overflow-y: auto;
+    }
+
+    // ---- Inline edit (assignee / progress) — click the value, no pencil ----
+    .dtc-assignee-editor { display: inline-block; }
+    .dtc-editable {
+        cursor: pointer;
+        border-radius: 5px;
+        padding: 1px 5px;
+        transition: background .15s ease;
+
+        &:hover { background: rgba(43, 108, 176, .10); }
+    }
+    .dtc-progress-value {
+        display: inline-block;
+        min-width: 1.4em;
+        text-align: center;
+
+        &[contenteditable]:focus {
+            outline: none;
+            background: #fff;
+            box-shadow: 0 0 0 2px rgba(43, 108, 176, .35);
+            border-radius: 5px;
+        }
+    }
+
+    // ---- Status action buttons (native .butAction.butStatus) → pills ----
+    .navBarForStatus .butAction.butStatus {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        margin: 3px 0 3px 6px;
+        padding: 5px 12px;
+        border: 1px solid $dtc-border;
+        border-radius: 999px;
+        background: #fff;
+        color: $dtc-title;
+        font-weight: 600;
+        box-shadow: $dtc-shadow;
+        text-transform: none;
+        transition: transform .15s ease, box-shadow .15s ease, background .15s ease, color .15s ease, border-color .15s ease;
+
+        &:hover {
+            transform: translateY(-1px);
+            box-shadow: $dtc-shadow-hov;
+            background: $dtc-blue;
+            color: #fff;
+            border-color: $dtc-blue;
+        }
+    }
+
+    // Keep list bullets tidy inside the Accidents section
+    ul.nomargin { margin: 0; padding-left: 18px; }
+}
+
+// ---- Responsive: stack the two columns ----
+@media (max-width: 900px) {
+    .digirisk-ticket-card .fichecenter > .fichehalfleft,
+    .digirisk-ticket-card .fichecenter > .fichehalfright {
+        flex: 1 1 100%;
+    }
+}

--- a/css/scss/page/_page.scss
+++ b/css/scss/page/_page.scss
@@ -5,4 +5,5 @@
 @import "digiai";
 @import "page-actionplan";
 @import "page-ticket-action-card";
+@import "page-ticket-card";
 @import "page-element-risk";

--- a/js/modules/ticket.js
+++ b/js/modules/ticket.js
@@ -85,6 +85,22 @@ window.digiriskdolibarr.ticket.event = function() {
   $(document).on( 'keyup', '#email', window.digiriskdolibarr.ticket.checkValidEmail);
   $(document).on( 'keyup', '#options_digiriskdolibarr_ticket_phone', window.digiriskdolibarr.ticket.checkValidPhone);
 
+  // Ticket card (issue #4443) — inline (on-the-fly) editing
+  $(document).on( 'click',   '.digirisk-ticket-card .dtc-subject-value', window.digiriskdolibarr.ticket.editSubjectInline);
+  $(document).on( 'keydown', '.digirisk-ticket-card .dtc-subject-input', window.digiriskdolibarr.ticket.subjectInputKeydown);
+  $(document).on( 'blur',    '.digirisk-ticket-card .dtc-subject-input', window.digiriskdolibarr.ticket.saveSubjectInline);
+  $(document).on( 'click',   '.digirisk-ticket-card .kanban-add-tag-btn', window.digiriskdolibarr.ticket.toggleTagDropdown);
+  $(document).on( 'click',   '.digirisk-ticket-card .kanban-tag-option', window.digiriskdolibarr.ticket.addCategoryInline);
+  $(document).on( 'click',   '.digirisk-ticket-card .kanban-tag-remove', window.digiriskdolibarr.ticket.removeCategoryInline);
+  $(document).on( 'click',   '.digirisk-ticket-card .kanban-tag-dropdown', function(event) { event.stopPropagation(); });
+  $(document).on( 'click',   window.digiriskdolibarr.ticket.closeTagDropdowns);
+  $(document).on( 'click',   '.digirisk-ticket-card .dtc-assignee-value', window.digiriskdolibarr.ticket.editAssigneeInline);
+  $(document).on( 'change',  '.digirisk-ticket-card .dtc-assignee-select', window.digiriskdolibarr.ticket.saveAssigneeInline);
+  $(document).on( 'blur',    '.digirisk-ticket-card .dtc-assignee-select', window.digiriskdolibarr.ticket.closeAssigneeInline);
+  $(document).on( 'focus',   '.digirisk-ticket-card .dtc-progress-value[contenteditable]', window.digiriskdolibarr.ticket.progressFocus);
+  $(document).on( 'keydown', '.digirisk-ticket-card .dtc-progress-value[contenteditable]', window.digiriskdolibarr.ticket.progressKeydown);
+  $(document).on( 'blur',    '.digirisk-ticket-card .dtc-progress-value[contenteditable]', window.digiriskdolibarr.ticket.saveProgressInline);
+
   $(document).on( 'change', '.param-table input, .param-table select, .param-table textarea', window.digiriskdolibarr.ticket.handleParamChange);
   // CKEDITOR is only loaded on pages with a rich-text editor. Guard the global
   // so this handler never throws "CKEDITOR is not defined" — an uncaught error
@@ -352,4 +368,341 @@ window.digiriskdolibarr.ticket.handleParamChange = function() {
 	}
 	var $btn = $('.' + $table.data('btn'));
 	$btn.prop('disabled', false);
+};
+
+/**
+ * Ticket card (#4443) — start inline edit of the subject.
+ *
+ * @since   23.0.0
+ * @version 23.0.0
+ *
+ * @param  {Object} event Click event.
+ * @return {void}
+ */
+window.digiriskdolibarr.ticket.editSubjectInline = function(event) {
+  event.preventDefault();
+  var $wrap = $(this).closest('.dtc-head').find('.dtc-subject');
+  if (!$wrap.length || $wrap.find('.dtc-subject-input').length) {
+    return;
+  }
+  var current = String($wrap.attr('data-value') || '');
+  var $input  = $('<input type="text" class="dtc-subject-input" />').val(current);
+  $wrap.html($input);
+  $input.trigger('focus').trigger('select');
+};
+
+/**
+ * Ticket card (#4443) — Enter saves, Escape cancels the subject edit.
+ *
+ * @since   23.0.0
+ * @version 23.0.0
+ *
+ * @param  {Object} event Keydown event.
+ * @return {void}
+ */
+window.digiriskdolibarr.ticket.subjectInputKeydown = function(event) {
+  if (event.key === 'Enter' || event.keyCode === 13) {
+    event.preventDefault();
+    $(this).trigger('blur');
+  } else if (event.key === 'Escape' || event.keyCode === 27) {
+    var $wrap = $(this).closest('.dtc-subject');
+    $(this).data('done', true);
+    window.digiriskdolibarr.ticket.renderSubject($wrap, String($wrap.attr('data-value') || ''));
+  }
+};
+
+/**
+ * Ticket card (#4443) — save the subject on the fly (AJAX), no page reload.
+ *
+ * @since   23.0.0
+ * @version 23.0.0
+ *
+ * @return {void}
+ */
+window.digiriskdolibarr.ticket.saveSubjectInline = function() {
+  var $input = $(this);
+  var $wrap  = $input.closest('.dtc-subject');
+  if ($input.data('done')) {
+    return;
+  }
+  $input.data('done', true);
+  var newValue = $input.val().trim();
+  var oldValue = String($wrap.attr('data-value') || '');
+  if (newValue === '' || newValue === oldValue) {
+    window.digiriskdolibarr.ticket.renderSubject($wrap, oldValue);
+    return;
+  }
+  var token = window.saturne.toolbox.getToken();
+  var sep   = window.saturne.toolbox.getQuerySeparator(document.URL);
+  $.ajax({
+    url: document.URL + sep + 'action=setsubject_ajax&token=' + token,
+    type: 'POST',
+    data: { subject: newValue },
+    dataType: 'json',
+    success: function(resp) {
+      var saved = (resp && resp.subject != null) ? resp.subject : newValue;
+      $wrap.attr('data-value', saved);
+      window.digiriskdolibarr.ticket.renderSubject($wrap, saved);
+    },
+    error: function() {
+      window.digiriskdolibarr.ticket.renderSubject($wrap, oldValue);
+    }
+  });
+};
+
+/**
+ * Ticket card (#4443) — render the subject value span.
+ *
+ * @since   23.0.0
+ * @version 23.0.0
+ *
+ * @param  {jQuery} $wrap Subject wrapper.
+ * @param  {string} value Subject value.
+ * @return {void}
+ */
+window.digiriskdolibarr.ticket.renderSubject = function($wrap, value) {
+  var text = (value && value.length) ? $('<div>').text(value).html() : '';
+  $wrap.html('<span class="dtc-subject-value">' + text + '</span>');
+};
+
+/**
+ * Ticket card (#4443) — toggle the "add tag" dropdown (same UX as the ticket kanban).
+ *
+ * @since   23.0.0
+ * @version 23.0.0
+ *
+ * @param  {Object} event Click event.
+ * @return {void}
+ */
+window.digiriskdolibarr.ticket.toggleTagDropdown = function(event) {
+  event.preventDefault();
+  event.stopPropagation();
+  var $dropdown = $(this).siblings('.kanban-tag-dropdown');
+  $('.digirisk-ticket-card .kanban-tag-dropdown').not($dropdown).removeClass('visible');
+  $dropdown.toggleClass('visible');
+};
+
+/**
+ * Ticket card (#4443) — close any open tag dropdown (outside click).
+ *
+ * @since   23.0.0
+ * @version 23.0.0
+ *
+ * @return {void}
+ */
+window.digiriskdolibarr.ticket.closeTagDropdowns = function() {
+  $('.digirisk-ticket-card .kanban-tag-dropdown.visible').removeClass('visible');
+};
+
+/**
+ * Ticket card (#4443) — add a category on the fly (same endpoint/behaviour as the kanban).
+ *
+ * @since   23.0.0
+ * @version 23.0.0
+ *
+ * @param  {Object} event Click event.
+ * @return {void}
+ */
+window.digiriskdolibarr.ticket.addCategoryInline = function(event) {
+  event.stopPropagation();
+  var $opt = $(this);
+  if ($opt.hasClass('assigned')) {
+    return;
+  }
+  var $dropdown = $opt.closest('.kanban-tag-dropdown');
+  var $tagsRow  = $opt.closest('.kanban-card-tags');
+  var catId     = $opt.data('value');
+  $dropdown.removeClass('visible');
+  $.ajax({
+    url: $tagsRow.data('tag-url') + '?action=addTicketCategory&ticket_id=' + $tagsRow.data('ticket-id') + '&cat_id=' + catId + '&token=' + window.saturne.toolbox.getToken(),
+    type: 'POST',
+    dataType: 'json',
+    success: function(response) {
+      if (!response || !response.success) {
+        return;
+      }
+      var bgColor = response.color ? '#' + response.color : '#8c8c8c';
+      var $tag = $('<span class="kanban-tag" data-cat-id="' + response.id + '" style="background:' + bgColor + '">'
+        + $('<div>').text(response.label).html()
+        + '<span class="kanban-tag-remove" title="&times;">&times;</span></span>');
+      $tagsRow.find('.kanban-tag-dropdown-wrapper').before($tag);
+      $opt.addClass('assigned').append('<i class="fas fa-check" style="margin-left:auto;font-size:9px;color:#28a745"></i>');
+    }
+  });
+};
+
+/**
+ * Ticket card (#4443) — remove a category on the fly (same endpoint/behaviour as the kanban).
+ *
+ * @since   23.0.0
+ * @version 23.0.0
+ *
+ * @param  {Object} event Click event.
+ * @return {void}
+ */
+window.digiriskdolibarr.ticket.removeCategoryInline = function(event) {
+  event.stopPropagation();
+  var $tag     = $(this).closest('.kanban-tag');
+  var $tagsRow = $tag.closest('.kanban-card-tags');
+  var catId    = $tag.data('cat-id');
+  $tag.css('opacity', '0.4');
+  $.ajax({
+    url: $tagsRow.data('tag-url') + '?action=removeTicketCategory&ticket_id=' + $tagsRow.data('ticket-id') + '&cat_id=' + catId + '&token=' + window.saturne.toolbox.getToken(),
+    type: 'POST',
+    dataType: 'json',
+    success: function(response) {
+      if (!response || !response.success) {
+        $tag.css('opacity', '1');
+        return;
+      }
+      $tag.slideUp(150, function() {
+        $(this).remove();
+        $tagsRow.find('.kanban-tag-option[data-value="' + catId + '"]').removeClass('assigned').find('.fa-check').remove();
+      });
+    },
+    error: function() {
+      $tag.css('opacity', '1');
+    }
+  });
+};
+
+/**
+ * Ticket card (#4443) — reveal the assignee select for on-the-fly editing.
+ *
+ * @since   23.0.0
+ * @version 23.0.0
+ *
+ * @param  {Object} event Click event.
+ * @return {void}
+ */
+window.digiriskdolibarr.ticket.editAssigneeInline = function(event) {
+  event.preventDefault();
+  var $cell = $(this).closest('.dtc-assignee');
+  if ($cell.find('.dtc-assignee-editor').is(':visible')) {
+    return;
+  }
+  $cell.find('.dtc-assignee-value').hide();
+  $cell.find('.dtc-assignee-editor').show();
+  $cell.find('.dtc-assignee-select').trigger('focus');
+};
+
+/**
+ * Ticket card (#4443) — save the assignee on the fly (same endpoint as the kanban).
+ *
+ * @since   23.0.0
+ * @version 23.0.0
+ *
+ * @return {void}
+ */
+window.digiriskdolibarr.ticket.saveAssigneeInline = function() {
+  var $sel   = $(this);
+  var $cell  = $sel.closest('.dtc-assignee');
+  var userId = parseInt($sel.val(), 10) || 0;
+  $.ajax({
+    url: $cell.data('assign-url') + '?action=setassignee_ajax&id=' + $cell.data('ticket-id') + '&user_id=' + userId + '&token=' + window.saturne.toolbox.getToken(),
+    type: 'POST',
+    dataType: 'json',
+    success: function(resp) {
+      if (resp && resp.nomurl) {
+        $cell.find('.dtc-assignee-value').html(resp.nomurl).show();
+      } else {
+        $cell.find('.dtc-assignee-value').show();
+      }
+      $cell.find('.dtc-assignee-editor').hide();
+    },
+    error: function() {
+      $cell.find('.dtc-assignee-value').show();
+      $cell.find('.dtc-assignee-editor').hide();
+    }
+  });
+};
+
+/**
+ * Ticket card (#4443) — close the assignee editor on blur (no selection made).
+ *
+ * @since   23.0.0
+ * @version 23.0.0
+ *
+ * @return {void}
+ */
+window.digiriskdolibarr.ticket.closeAssigneeInline = function() {
+  var $cell = $(this).closest('.dtc-assignee');
+  window.setTimeout(function() {
+    if ($cell.find('.dtc-assignee-editor').is(':visible')) {
+      $cell.find('.dtc-assignee-editor').hide();
+      $cell.find('.dtc-assignee-value').show();
+    }
+  }, 200);
+};
+
+/**
+ * Ticket card (#4443) — select the whole progress value when it gains focus.
+ *
+ * @since   23.0.0
+ * @version 23.0.0
+ *
+ * @return {void}
+ */
+window.digiriskdolibarr.ticket.progressFocus = function() {
+  var el = this;
+  window.setTimeout(function() {
+    var range = document.createRange();
+    range.selectNodeContents(el);
+    var sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+  }, 0);
+};
+
+/**
+ * Ticket card (#4443) — Enter validates the progress (triggers blur), no line break.
+ *
+ * @since   23.0.0
+ * @version 23.0.0
+ *
+ * @param  {Object} event Keydown event.
+ * @return {void}
+ */
+window.digiriskdolibarr.ticket.progressKeydown = function(event) {
+  if (event.key === 'Enter' || event.keyCode === 13) {
+    event.preventDefault();
+    $(this).trigger('blur');
+  }
+};
+
+/**
+ * Ticket card (#4443) — save the progress on the fly from the contenteditable value.
+ *
+ * @since   23.0.0
+ * @version 23.0.0
+ *
+ * @return {void}
+ */
+window.digiriskdolibarr.ticket.saveProgressInline = function() {
+  var $val     = $(this);
+  var $cell    = $val.closest('.dtc-progress');
+  var oldValue = parseInt($cell.attr('data-value'), 10) || 0;
+  var newValue = parseInt(($val.text() || '').replace(/[^0-9]/g, ''), 10);
+  if (isNaN(newValue)) {
+    newValue = oldValue;
+  }
+  newValue = Math.max(0, Math.min(100, newValue));
+  $val.text(newValue);
+  if (newValue === oldValue) {
+    return;
+  }
+  $.ajax({
+    url: $cell.data('progress-url') + '?action=setprogress_ajax&id=' + $cell.data('ticket-id') + '&token=' + window.saturne.toolbox.getToken(),
+    type: 'POST',
+    data: { progress: newValue },
+    dataType: 'json',
+    success: function(resp) {
+      var val = (resp && resp.progress != null) ? resp.progress : newValue;
+      $cell.attr('data-value', val);
+      $val.text(val);
+    },
+    error: function() {
+      $val.text(oldValue);
+    }
+  });
 };

--- a/langs/fr_FR/digiriskdolibarr.lang
+++ b/langs/fr_FR/digiriskdolibarr.lang
@@ -831,6 +831,7 @@ auditreportdocument.odt = Rapport d'audit
 # Data - Donnée
 GroupmentDocument                        = Fiche de Groupement
 Groupmentdocument                        = Fiche de Groupement
+DocumentModelStandardPDF                 = Modèle PDF standard
 GroupmentDocumentGenerated               = Génération de fiche de Groupement
 groupmentdocument.odt                    = Fiche de Groupement
 groupmentdocument_custom.odt             = Fiche de Groupement personnalisée
@@ -1785,6 +1786,8 @@ TicketActionAssignedOtherDone        = Ticket assigné
 TicketActionCloseConfirm             = Confirmer la clôture
 TicketActionCancelConfirm            = Confirmer l'annulation
 TicketActionCardRegistresSection      = Informations registres
+TicketMessageTitle                    = Titre du message
+TicketResponsibleAndProgress          = Responsable et avancement
 TicketActionCardClassificationSection = Classification
 TicketActionCardDatesSection          = Dates clés
 TicketActionCardIdentificationSection = Identification

--- a/lib/digiriskdolibarr_ticket.lib.php
+++ b/lib/digiriskdolibarr_ticket.lib.php
@@ -64,6 +64,33 @@ function createTicketCategory($label, $description, $color, $visible, $type, $fk
 }
 
 /**
+ * Prepare ticket card header — issue #4443.
+ *
+ * Reuses the native Dolibarr ticket tabs (so the Digirisk hook tabs stay) but rewrites
+ * the main "Ticket" tab so it points back to the Digirisk custom card
+ * (view/ticket/ticket_card.php) instead of the native /ticket/card.php. This keeps
+ * navigation inside the custom UI instead of falling back to native Dolibarr.
+ *
+ * @param  Ticket $object Ticket object
+ * @return array          Array of tabs
+ */
+function digiriskdolibarr_ticket_prepare_head(Ticket $object): array
+{
+    require_once DOL_DOCUMENT_ROOT . '/core/lib/ticket.lib.php';
+
+    $head          = ticket_prepare_head($object);
+    $customCardUrl = dol_buildpath('/custom/digiriskdolibarr/view/ticket/ticket_card.php', 1) . '?id=' . (int) $object->id;
+
+    foreach ($head as $key => $tab) {
+        if (isset($tab[2]) && $tab[2] === 'tabTicket') {
+            $head[$key][0] = $customCardUrl;
+        }
+    }
+
+    return $head;
+}
+
+/**
  * Prepare ticket statistics pages header
  *
  * @return array $head   Array of tabs

--- a/view/ticket/ticket_action_card.php
+++ b/view/ticket/ticket_action_card.php
@@ -427,7 +427,7 @@ if ($action == 'createTicket' && $permissionToWrite) {
             }
         }
 
-        $detailUrl = dol_buildpath('/custom/digiriskdolibarr/view/ticket/ticket_action_card.php', 1) . '?id=' . $newId;
+        $detailUrl = dol_buildpath('/custom/digiriskdolibarr/view/ticket/ticket_card.php', 1) . '?id=' . $newId;
         print json_encode(['success' => 1, 'id' => $newId, 'ref' => $newTicket->ref, 'url' => $detailUrl]);
     } else {
         $errMsg = $newTicket->error ?: implode(', ', $newTicket->errors ?: []);
@@ -559,7 +559,7 @@ if ($object->id <= 0) {
                 }
             }
 
-            $detailUrl = dol_buildpath('/custom/digiriskdolibarr/view/ticket/ticket_action_card.php', 1) . '?id=' . (int) $row->rowid;
+            $detailUrl = dol_buildpath('/custom/digiriskdolibarr/view/ticket/ticket_card.php', 1) . '?id=' . (int) $row->rowid;
 
             $sevCode  = strtoupper((string) ($row->severity_code ?: ''));
             $sevTrans = $sevCode !== '' ? $langs->trans('TicketSeverityShort' . $sevCode) : '';
@@ -612,7 +612,7 @@ if ($object->id <= 0) {
                     }
                 }
 
-                $detailUrl = dol_buildpath('/custom/digiriskdolibarr/view/ticket/ticket_action_card.php', 1) . '?id=' . (int) $row->rowid;
+                $detailUrl = dol_buildpath('/custom/digiriskdolibarr/view/ticket/ticket_card.php', 1) . '?id=' . (int) $row->rowid;
                 $sevCode   = strtoupper((string) ($row->severity_code ?: ''));
                 $sevTrans  = $sevCode !== '' ? $langs->trans('TicketSeverityShort' . $sevCode) : '';
                 if ($sevTrans === 'TicketSeverityShort' . $sevCode) {

--- a/view/ticket/ticket_card.php
+++ b/view/ticket/ticket_card.php
@@ -1,0 +1,542 @@
+<?php
+/* Copyright (C) 2026 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+/**
+ * \file    view/ticket/ticket_card.php
+ * \ingroup digiriskdolibarr
+ * \brief   Ticket card with native Dolibarr layout — Issue #4443.
+ */
+
+// Force-load CKEditor so the rich-text editor is available for the initial message.
+if (!defined('FORCE_CKEDITOR')) {
+    define('FORCE_CKEDITOR', 1);
+}
+
+// Load Digirisk (and Dolibarr) environment — from custom/digiriskdolibarr/view/ticket/
+if (file_exists('../digiriskdolibarr.main.inc.php')) {
+    require_once __DIR__ . '/../digiriskdolibarr.main.inc.php';
+} elseif (file_exists('../../digiriskdolibarr.main.inc.php')) {
+    require_once __DIR__ . '/../../digiriskdolibarr.main.inc.php';
+} else {
+    die('Include of digiriskdolibarr main fails');
+}
+
+require_once DOL_DOCUMENT_ROOT . '/ticket/class/ticket.class.php';
+require_once DOL_DOCUMENT_ROOT . '/ticket/class/actions_ticket.class.php';
+require_once DOL_DOCUMENT_ROOT . '/core/lib/ticket.lib.php';
+require_once __DIR__ . '/../../lib/digiriskdolibarr_ticket.lib.php';
+require_once DOL_DOCUMENT_ROOT . '/user/class/user.class.php';
+require_once DOL_DOCUMENT_ROOT . '/projet/class/project.class.php';
+require_once DOL_DOCUMENT_ROOT . '/core/class/html.form.class.php';
+require_once DOL_DOCUMENT_ROOT . '/core/class/html.formprojet.class.php';
+require_once DOL_DOCUMENT_ROOT . '/categories/class/categorie.class.php';
+require_once DOL_DOCUMENT_ROOT . '/comm/action/class/actioncomm.class.php';
+
+global $conf, $db, $hookmanager, $langs, $moduleNameLowerCase, $user;
+
+saturne_load_langs(['ticket', 'companies', 'projects', 'categories']);
+
+$id      = GETPOSTINT('id');
+$trackId = GETPOST('track_id', 'alpha');
+$action  = GETPOST('action', 'aZ09');
+
+$now = dol_now();
+
+$object = new Ticket($db);
+if ($id > 0 || !empty($trackId)) {
+    $object->fetch($id, '', $trackId);
+    if ($object->id > 0) {
+        $object->fetch_optionals();
+    }
+}
+
+// Security
+if (!$user->hasRight('ticket', 'read')) {
+    accessforbidden();
+}
+
+$permissionToWrite = $user->hasRight('ticket', 'write') && !$user->socid;
+$url_page_current  = dol_buildpath('/custom/digiriskdolibarr/view/ticket/ticket_card.php', 1);
+// Kanban AJAX endpoint (reused for on-the-fly tags & assignee — same server behaviour, incl. kanban event logging).
+$kanbanAjaxUrl     = dol_buildpath('/custom/digiriskdolibarr/view/ticket/ticket_action_card.php', 1);
+
+/*
+ * Actions
+ */
+
+// AJAX: inline (on-the-fly) subject save
+if ($action === 'setsubject_ajax' && $permissionToWrite) {
+    $newSubject      = GETPOST('subject', 'alphanohtml');
+    $object->fetch($id);
+    $oldSubject      = $object->subject;
+    $object->subject = $newSubject;
+    if ($object->update($user) > 0 && trim($newSubject) !== trim($oldSubject)) {
+        $actioncomm = new ActionComm($db);
+        $actioncomm->type_code   = 'AC_OTH_AUTO';
+        $actioncomm->code        = 'AC_TICKET_MODIFY';
+        $actioncomm->label       = $langs->trans('Subject') . ' : ' . $oldSubject . ' -> ' . $newSubject;
+        $actioncomm->fk_element  = $object->id;
+        $actioncomm->elementtype = 'ticket';
+        $actioncomm->datep       = dol_now();
+        $actioncomm->userownerid = $user->id;
+        $actioncomm->percentage  = -1;
+        $actioncomm->create($user);
+    }
+    header('Content-Type: application/json');
+    print json_encode(['success' => 1, 'subject' => $object->subject]);
+    exit;
+}
+
+// AJAX: inline (on-the-fly) assignee save — returns getNomUrl so the display stays a proper user link
+if ($action === 'setassignee_ajax' && $permissionToWrite) {
+    $newUserId = GETPOSTINT('user_id');
+    $object->fetch($id);
+    $object->fk_user_assign = $newUserId;
+    $object->update($user);
+    if ($newUserId > 0) {
+        $assignee = new User($db);
+        $assignee->fetch($newUserId);
+        $nomUrl = $assignee->getNomUrl(-1);
+    } else {
+        $nomUrl = '<span class="opacitymedium">' . $langs->trans('NotAssigned') . '</span>';
+    }
+    header('Content-Type: application/json');
+    print json_encode(['success' => 1, 'nomurl' => $nomUrl]);
+    exit;
+}
+
+// AJAX: inline (on-the-fly) progress save
+if ($action === 'setprogress_ajax' && $permissionToWrite) {
+    $newProgress = GETPOSTINT('progress');
+    if ($newProgress < 0) {
+        $newProgress = 0;
+    }
+    if ($newProgress > 100) {
+        $newProgress = 100;
+    }
+    $object->fetch($id);
+    $object->progress = $newProgress;
+    $object->update($user);
+    header('Content-Type: application/json');
+    print json_encode(['success' => 1, 'progress' => (int) $object->progress]);
+    exit;
+}
+
+// Action: classify (set project — native form_project posts action=classin)
+if ($action === 'classin' && $permissionToWrite) {
+    $object->fetch($id);
+    $object->setProject(GETPOSTINT('projectid'));
+    header('Location: ' . $url_page_current . '?id=' . $object->id);
+    exit;
+}
+
+// Action: set initial message
+if ($action === 'setmessage' && $permissionToWrite) {
+    if (GETPOST('cancel', 'alpha')) {
+        header('Location: ' . $url_page_current . '?id=' . $id);
+        exit;
+    } else {
+        $object->fetch($id);
+        $object->message = GETPOST('message', 'restricthtml');
+        $object->update($user);
+        header('Location: ' . $url_page_current . '?id=' . $object->id);
+        exit;
+    }
+}
+
+// Action: mark ticket as read
+if ($action === 'set_read' && $permissionToWrite) {
+    $object->fetch(0, '', GETPOST('track_id', 'alpha'));
+    if ($object->markAsRead($user) > 0) {
+        setEventMessages($langs->trans('TicketMarkedAsRead'), null, 'mesgs');
+    } else {
+        setEventMessages($object->error, $object->errors, 'errors');
+    }
+    header('Location: ' . $url_page_current . '?track_id=' . urlencode($object->track_id));
+    exit;
+}
+
+// Action: change ticket status (native status navbar buttons)
+if ($action === 'confirm_set_status' && $permissionToWrite && !GETPOST('cancel')) {
+    $object->fetch(GETPOSTINT('id'), GETPOST('track_id', 'alpha'));
+    $newStatus = GETPOSTINT('new_status');
+    if ($object->setStatut($newStatus, null, '', 'TICKET_MODIFY')) {
+        header('Location: ' . $url_page_current . '?track_id=' . urlencode($object->track_id));
+        exit;
+    }
+    setEventMessages($object->error, $object->errors, 'errors');
+}
+
+/*
+ * View
+ */
+
+if ($object->id <= 0) {
+    saturne_header(0, '', $langs->trans('Ticket'), '');
+    print '<div class="error">' . $langs->trans('ErrorRecordNotFound') . '</div>';
+    llxFooter();
+    $db->close();
+    exit;
+}
+
+// Load thirdparty if linked
+if ($object->socid > 0) {
+    $object->fetch_thirdparty();
+}
+
+$form     = new Form($db);
+$userstat = new User($db);
+
+$title   = $langs->trans('Ticket') . ' ' . $object->ref;
+$helpUrl = 'FR:Module_Digirisk';
+saturne_header(0, '', $title, $helpUrl);
+
+print '<div class="digirisk-ticket-card">';
+
+// Ticket tabs — same as native (incl. Digirisk hook tabs) but the "Ticket" tab returns
+// to this custom card instead of the native /ticket/card.php.
+$head = digiriskdolibarr_ticket_prepare_head($object);
+print dol_get_fiche_head($head, 'tabTicket', $langs->trans('Ticket'), -1, 'ticket');
+
+// ---- Build morehtmlref (native Dolibarr banner style) ----
+$morehtmlref = '<div class="refidno">';
+
+// Tracking id
+$morehtmlref .= '<span class="opacitymedium">' . $langs->trans('TicketTrackId') . ' : </span>' . dolPrintLabel($object->track_id);
+
+// Author
+if ($object->fk_user_create > 0) {
+    $morehtmlref .= '<br>';
+    $fuser = new User($db);
+    $fuser->fetch($object->fk_user_create);
+    $morehtmlref .= $fuser->getNomUrl(-1);
+}
+
+// Thirdparty
+if (isModEnabled('societe')) {
+    $morehtmlref .= '<br>';
+    $morehtmlref .= img_picto($langs->trans('ThirdParty'), 'company', 'class="pictofixedwidth"');
+    if ($object->socid > 0 && is_object($object->thirdparty)) {
+        $morehtmlref .= $object->thirdparty->getNomUrl(1);
+    } else {
+        $morehtmlref .= '<span class="opacitymedium">' . $langs->trans('NoThirdParty') . '</span>';
+    }
+}
+
+// Project
+if (isModEnabled('project')) {
+    $morehtmlref .= '<br>';
+    $object->fetchProject();
+    $morehtmlref .= img_picto($langs->trans('Project'), 'project', 'class="pictofixedwidth"');
+    if ($permissionToWrite) {
+        if ($action != 'classify') {
+            $morehtmlref .= '<a class="editfielda" href="' . $url_page_current . '?action=classify&token=' . newToken() . '&id=' . $object->id . '">' . img_edit($langs->transnoentitiesnoconv('SetProject')) . '</a> ';
+        }
+        $morehtmlref .= $form->form_project($url_page_current . '?id=' . $object->id, $object->socid, (string) $object->fk_project, ($action == 'classify' ? 'projectid' : 'none'), 0, 0, 0, 1, '', 'maxwidth300');
+    } elseif (!empty($object->fk_project) && is_object($object->project)) {
+        $morehtmlref .= $object->project->getNomUrl(1);
+    }
+}
+
+$morehtmlref .= '</div>';
+
+$linkback = '<a href="' . dol_buildpath('/custom/digiriskdolibarr/view/ticket/ticket_action_card.php', 1) . '"><strong>' . $langs->trans('BackToList') . '</strong></a>';
+
+dol_banner_tab($object, 'ref', $linkback, ($user->socid ? 0 : 1), 'ref', 'ref', $morehtmlref);
+
+print '<div class="fichecenter">';
+
+/*
+ * Left column
+ */
+print '<div class="fichehalfleft">';
+print '<div class="underbanner clearboth"></div>';
+
+// ---- Titre du message (label + subject on the same line, inline on-the-fly edit) ----
+$subjectRaw = (string) ($object->subject ?? '');
+print '<table class="border centpercent tableforfield"><tbody>';
+print '<tr class="liste_titre trforfield"><td colspan="2"><div class="dtc-head">';
+print '<span class="dtc-head-label">' . $langs->trans('TicketMessageTitle') . '</span>';
+print '<span class="dtc-subject" data-value="' . dol_escape_htmltag($subjectRaw) . '">';
+if ($subjectRaw !== '') {
+    print '<span class="dtc-subject-value">' . dolPrintLabel($subjectRaw) . '</span>';
+} else {
+    print '<span class="dtc-subject-value opacitymedium">' . $langs->trans('NoSubject') . '</span>';
+}
+print '</span>';
+print '</div></td></tr>';
+print '</tbody></table>';
+
+// ---- Message initial (editable rich text) ----
+print '<form method="POST" action="' . dol_escape_htmltag($url_page_current . '?id=' . $object->id) . '">';
+print '<input type="hidden" name="token" value="' . newToken() . '">';
+print '<input type="hidden" name="action" value="setmessage">';
+print '<input type="hidden" name="id" value="' . (int) $object->id . '">';
+print '<table class="border centpercent tableforfield"><tbody>';
+print '<tr class="liste_titre trforfield"><td colspan="2"><div class="dtc-head">';
+print $langs->trans('TicketInitialMessage');
+print '<span class="dtc-head-edit">';
+if ($permissionToWrite && $action === 'editmessage') {
+    print '<input type="submit" class="button button-edit smallpaddingimp" value="' . $langs->trans('Modify') . '"> ';
+    print '<input type="submit" class="button button-cancel smallpaddingimp" name="cancel" value="' . $langs->trans('Cancel') . '">';
+} elseif ($permissionToWrite) {
+    print '<a class="editfielda" href="' . dol_escape_htmltag($url_page_current . '?id=' . $object->id . '&action=editmessage&token=' . newToken()) . '">' . img_edit($langs->trans('Modify'), 0) . '</a>';
+}
+print '</span>';
+print '</div></td></tr>';
+print '<tr><td colspan="2">';
+if ($action === 'editmessage' && $permissionToWrite) {
+    require_once DOL_DOCUMENT_ROOT . '/core/class/doleditor.class.php';
+    $doleditor = new DolEditor('message', $object->message, '', 120, 'dolibarr_details', 'In', false, true, getDolGlobalString('FCKEDITOR_ENABLE_TICKET'), ROWS_9, '95%');
+    $doleditor->Create();
+} else {
+    print !empty($object->message) ? dol_htmlentitiesbr($object->message) : '<span class="opacitymedium">' . $langs->trans('None') . '</span>';
+}
+print '</td></tr>';
+print '</tbody></table>';
+print '</form>';
+
+// ---- Informations registres (Digirisk ticket extrafields) ----
+$extra = [];
+foreach (($object->array_options ?? []) as $rawKey => $val) {
+    $cleanKey = (strpos($rawKey, 'options_') === 0) ? substr($rawKey, strlen('options_')) : $rawKey;
+    $extra[$cleanKey] = $val;
+}
+
+$regLastname  = (string) ($extra['digiriskdolibarr_ticket_lastname'] ?? '');
+$regFirstname = (string) ($extra['digiriskdolibarr_ticket_firstname'] ?? '');
+$regPhone     = (string) ($extra['digiriskdolibarr_ticket_phone'] ?? '');
+$regLocation  = (string) ($extra['digiriskdolibarr_ticket_location'] ?? '');
+$regDateRaw   = $extra['digiriskdolibarr_ticket_date'] ?? null;
+$regDate      = !empty($regDateRaw) ? dol_print_date((int) $regDateRaw, 'day', 'tzuser') : '';
+$regCondition = (string) ($extra['digiriskdolibarr_condition_message'] ?? '');
+
+// GP/UT — linked DigiriskElement (chkbxlst stores comma-separated ids; keep the first).
+$regServiceRaw  = $extra['digiriskdolibarr_ticket_service'] ?? '';
+$firstServiceId = (int) (is_string($regServiceRaw) ? strtok($regServiceRaw, ',') : $regServiceRaw);
+$regService     = '';
+if ($firstServiceId > 0 && file_exists(DOL_DOCUMENT_ROOT . '/custom/digiriskdolibarr/class/digiriskelement.class.php')) {
+    require_once DOL_DOCUMENT_ROOT . '/custom/digiriskdolibarr/class/digiriskelement.class.php';
+    $digiriskElement = new DigiriskElement($db);
+    if ($digiriskElement->fetch($firstServiceId) > 0) {
+        $regService = $digiriskElement->getNomUrl(1, '', 0, '', -1, 1);
+    }
+}
+
+// A warning icon flags an unfilled registre field, mirroring the target design.
+$regWarn = static function (string $value) use ($langs): string {
+    return $value === '' ? img_warning($langs->trans('None')) . ' ' : '';
+};
+
+print '<table class="border centpercent tableforfield"><tbody>';
+print '<tr class="liste_titre trforfield"><td colspan="4"><div class="dtc-head">' . img_picto('', 'digiriskdolibarr_color@digiriskdolibarr', 'class="pictoModule"') . ' ' . $langs->trans('TicketActionCardRegistresSection') . '</div></td></tr>';
+
+print '<tr>';
+print '<td class="titlefieldmiddle">' . $regWarn($regLastname) . $langs->trans('LastName') . '</td><td>' . dol_escape_htmltag($regLastname) . '</td>';
+print '<td class="titlefieldmiddle">' . $regWarn($regFirstname) . $langs->trans('FirstName') . '</td><td>' . dol_escape_htmltag($regFirstname) . '</td>';
+print '</tr>';
+
+print '<tr>';
+print '<td class="titlefieldmiddle">' . $regWarn($regPhone) . $langs->trans('Phone') . '</td><td>' . dol_print_phone($regPhone) . '</td>';
+print '<td class="titlefieldmiddle">' . $regWarn($regDate) . $langs->trans('DeclarationDate') . '</td><td>' . $regDate . '</td>';
+print '</tr>';
+
+print '<tr>';
+print '<td class="titlefieldmiddle">' . $regWarn($regService) . $langs->trans('GP/UT') . '</td><td>' . $regService . '</td>';
+print '<td class="titlefieldmiddle">' . $regWarn($regLocation) . $langs->trans('Location') . '</td><td>' . dol_escape_htmltag($regLocation) . '</td>';
+print '</tr>';
+
+print '<tr><td class="titlefieldmiddle">' . $langs->trans('ConditionMessage') . '</td><td colspan="3">' . ($regCondition !== '' ? dolPrintHTML($regCondition) : '<span class="opacitymedium">' . $langs->trans('None') . '</span>') . '</td></tr>';
+
+// "Registre signé": disabled indicator. TODO (#4443 step 2): reflect real SaturneSignature state
+// and add the "Conditions à accepter pour la signature" (ValidateText) + category-scoped
+// "Date de départ anticipé" rows (see actions_digiriskdolibarr.class.php printCommonFooter:324-337 / 291-310).
+print '<tr><td class="titlefieldmiddle">' . $langs->trans('RegisterSigned') . '</td><td colspan="3"><input type="checkbox" disabled></td></tr>';
+
+print '</tbody></table>';
+
+// ---- Accidents linked to this ticket ----
+$linkedAccidents = [];
+if (file_exists(DOL_DOCUMENT_ROOT . '/custom/digiriskdolibarr/class/accident.class.php')) {
+    require_once DOL_DOCUMENT_ROOT . '/custom/digiriskdolibarr/class/accident.class.php';
+    $accident = new Accident($db);
+    $fetched  = $accident->fetchAll('', '', 0, 0, ['customsql' => 't.fk_ticket = ' . (int) $object->id]);
+    if (is_array($fetched)) {
+        $linkedAccidents = $fetched;
+    }
+}
+print '<table class="border centpercent tableforfield"><tbody>';
+print '<tr class="liste_titre trforfield"><td><div class="dtc-head">' . img_picto('', 'digiriskdolibarr_color@digiriskdolibarr', 'class="pictoModule"') . ' ' . $langs->trans('Accidents') . '</div></td></tr>';
+print '<tr><td>';
+if (!empty($linkedAccidents)) {
+    print '<ul class="nomargin">';
+    foreach ($linkedAccidents as $acc) {
+        print '<li>' . $acc->getNomUrl(1) . '</li>';
+    }
+    print '</ul>';
+} else {
+    print '<span class="opacitymedium">' . $langs->trans('AccidentsLinked') . ' : ' . $langs->trans('None') . '</span>';
+}
+print '</td></tr>';
+print '</tbody></table>';
+
+print '</div>'; // fichehalfleft
+
+/*
+ * Right column
+ */
+print '<div class="fichehalfright">';
+print '<div class="underbanner clearboth"></div>';
+
+// ---- Responsable et avancement ----
+print '<table class="border centpercent tableforfield"><tbody>';
+print '<tr class="liste_titre trforfield"><td colspan="2"><div class="dtc-head">' . $langs->trans('TicketResponsibleAndProgress') . '</div></td></tr>';
+
+// Assigned user (inline, on-the-fly editable)
+print '<tr><td class="titlefieldmiddle">' . $langs->trans('AssignedTo') . '</td>';
+print '<td class="dtc-assignee" data-ticket-id="' . (int) $object->id . '" data-assign-url="' . dol_escape_htmltag($url_page_current) . '">';
+print '<span class="dtc-assignee-value' . ($permissionToWrite ? ' dtc-editable' : '') . '">';
+if ($object->fk_user_assign > 0) {
+    $userstat->fetch($object->fk_user_assign);
+    print $userstat->getNomUrl(-1);
+} else {
+    print '<span class="opacitymedium">' . $langs->trans('NotAssigned') . '</span>';
+}
+print '</span>';
+if ($permissionToWrite) {
+    print '<span class="dtc-assignee-editor" style="display:none;">';
+    // forcecombo = 1 → plain <select> (no select2) so the native "change" event fires reliably.
+    print $form->select_dolusers($object->fk_user_assign, 'dtc_assignee_select', 1, null, 0, '', '', '0', 0, 0, '', 0, '', 'dtc-assignee-select maxwidth200', 0, 0, false, 1);
+    print '</span>';
+}
+print '</td></tr>';
+
+// Progression (inline, on-the-fly editable — contenteditable, click to edit)
+print '<tr><td class="titlefieldmiddle">' . $langs->trans('Progression') . '</td>';
+print '<td class="dtc-progress" data-ticket-id="' . (int) $object->id . '" data-progress-url="' . dol_escape_htmltag($url_page_current) . '" data-value="' . (int) $object->progress . '">';
+print '<span class="dtc-progress-value' . ($permissionToWrite ? ' dtc-editable' : '') . '"' . ($permissionToWrite ? ' contenteditable="true"' : '') . '>' . ((int) $object->progress) . '</span> %';
+print '</td></tr>';
+print '</tbody></table>';
+
+// ---- Linked tasks table (STRUCTURE ONLY — data wiring is step 2) ----
+// TODO (#4443 step 2): populate rows from the tasks linked to this ticket.
+//   $task->getTasksArray(null, null, $object->fk_project, 0, 0, '', '-1', '', 0, 0, $extrafields);
+//   then render each row with projectLinesa() (native progress bar / resources).
+//   Refs: projet/tasks.php:956/1216, core/lib/project.lib.php:600,
+//   actions_digiriskdolibarr.class.php:523 (TotalProgress pattern).
+print '<div class="div-table-responsive-no-min">';
+print '<table class="noborder centpercent">';
+print '<tr class="liste_titre">';
+print '<th>' . $langs->trans('RefTask') . '</th>';
+print '<th>' . $langs->trans('Label') . '</th>';
+print '<th class="center">' . $langs->trans('DateStart') . '</th>';
+print '<th class="center">' . $langs->trans('Deadline') . '</th>';
+print '<th class="center">' . $langs->trans('Progress') . '</th>';
+print '<th class="right">' . $langs->trans('Resp') . '</th>';
+print '</tr>';
+print '<tr class="oddeven"><td colspan="6" class="opacitymedium center">' . $langs->trans('NoRecordFound') . '</td></tr>';
+print '</table>';
+print '</div>';
+
+// ---- Classification (categories) + key dates ----
+print '<table class="border centpercent tableforfield"><tbody>';
+print '<tr class="liste_titre trforfield"><td colspan="2"><div class="dtc-head">' . $langs->trans('TicketActionCardClassificationSection') . '</div></td></tr>';
+
+if (isModEnabled('category')) {
+    $catObj           = new Categorie($db);
+    $ticketCategories = $catObj->containing($object->id, Categorie::TYPE_TICKET);
+    if (!is_array($ticketCategories)) {
+        $ticketCategories = [];
+    }
+    $allTicketCategories = $catObj->get_full_arbo(Categorie::TYPE_TICKET);
+    if (!is_array($allTicketCategories)) {
+        $allTicketCategories = [];
+    }
+    $assignedCategoryIds = array_map(static fn($c) => (int) $c->id, $ticketCategories);
+
+    print '<tr><td class="titlefieldmiddle">' . $langs->trans('Categories') . '</td><td>';
+    // Exact same markup as the ticket kanban (core/tpl/ticket/ticket_action_card_picker.tpl.php)
+    // so it inherits the identical kanban tag styling (_page-actionplan.scss).
+    print '<div class="kanban-card-tags" data-ticket-id="' . (int) $object->id . '" data-tag-url="' . dol_escape_htmltag($kanbanAjaxUrl) . '">';
+
+    foreach ($ticketCategories as $cat) {
+        $tagBg = !empty($cat->color) ? '#' . dol_escape_htmltag($cat->color) : '#8c8c8c';
+        print '<span class="kanban-tag" data-cat-id="' . (int) $cat->id . '" style="background:' . $tagBg . '">';
+        print dol_escape_htmltag($cat->label);
+        if ($permissionToWrite) {
+            print '<span class="kanban-tag-remove" title="' . dol_escape_htmltag($langs->trans('Remove')) . '">&times;</span>';
+        }
+        print '</span>';
+    }
+
+    if ($permissionToWrite) {
+        print '<div class="kanban-tag-dropdown-wrapper">';
+        print '<button class="kanban-add-tag-btn" title="' . dol_escape_htmltag($langs->trans('AddCategory')) . '"><i class="fas fa-tag"></i><i class="fas fa-plus" style="font-size:7px;margin-left:1px"></i></button>';
+        print '<div class="kanban-tag-dropdown" data-ticket-id="' . (int) $object->id . '">';
+        foreach ($allTicketCategories as $ac) {
+            $acId = (int) ($ac['rowid'] ?? 0);
+            if ($acId <= 0) {
+                continue;
+            }
+            $isAssigned = in_array($acId, $assignedCategoryIds, true);
+            $dotColor   = !empty($ac['color']) ? '#' . dol_escape_htmltag($ac['color']) : '#8c8c8c';
+            print '<div class="kanban-tag-option' . ($isAssigned ? ' assigned' : '') . '" data-value="' . $acId . '" data-color="' . dol_escape_htmltag((string) ($ac['color'] ?? '')) . '">';
+            print '<span class="kanban-tag-dot" style="background:' . $dotColor . '"></span>';
+            print dol_escape_htmltag($ac['label']);
+            if ($isAssigned) {
+                print '<i class="fas fa-check" style="margin-left:auto;font-size:9px;color:#28a745"></i>';
+            }
+            print '</div>';
+        }
+        print '</div>';
+        print '</div>';
+    }
+
+    print '</div>';
+    print '</td></tr>';
+}
+
+// Creation date + elapsed time
+print '<tr><td class="titlefieldmiddle">' . $langs->trans('DateCreation') . '</td><td>';
+print dol_print_date($object->datec, 'dayhour', 'tzuser');
+print '<span class="opacitymedium"><span class="small"> - ' . $langs->trans('TimeElapsedSince') . ': <b><i>' . convertSecondToTime(roundUpToNextMultiple($now - $object->datec, 60)) . '</i></b></span></span>';
+print '</td></tr>';
+
+// Read date
+print '<tr><td class="titlefieldmiddle">' . $langs->trans('TicketReadOn') . '</td><td>';
+print !empty($object->date_read) ? dol_print_date($object->date_read, 'dayhour', 'tzuser') : '';
+print '</td></tr>';
+
+// Close date
+print '<tr><td class="titlefieldmiddle">' . $langs->trans('TicketCloseOn') . '</td><td>';
+print !empty($object->date_close) ? dol_print_date($object->date_close, 'dayhour', 'tzuser') : '';
+print '</td></tr>';
+
+print '</tbody></table>';
+
+// ---- Status change buttons (native ticket navbar) — above recent events ----
+if ($permissionToWrite && isset($object->status) && $object->status < Ticket::STATUS_CLOSED) {
+    $actionobject = new ActionsTicket($db);
+    $actionobject->viewStatusActions($object);
+}
+
+// ---- Recent events (native Dolibarr widget) ----
+require_once DOL_DOCUMENT_ROOT . '/core/class/html.formactions.class.php';
+$formactions = new FormActions($db);
+$formactions->showactions($object, 'ticket', 0, 1, 'listactions', 5);
+
+print '</div>'; // fichehalfright
+print '</div>'; // fichecenter
+
+print dol_get_fiche_end();
+
+print '</div>'; // digirisk-ticket-card
+
+llxFooter();
+$db->close();


### PR DESCRIPTION
## Description

Refonte complète de l'IHM de la card ticket du registre (#4443) en layout **natif Dolibarr**, avec édition **à la volée**.

## Fonctionnalités

- **Card native** (`view/ticket/ticket_card.php`) : bandeau, colonnes gauche/droite, onglets natifs. Le registre (`ticket_action_card.php`) redirige vers cette card.
- **Édition à la volée** (AJAX, sans rechargement), au **clic sur la valeur** :
  - Titre du message
  - Assigné à (select utilisateurs → renvoie le `getNomUrl`)
  - Progression (`contenteditable`, borné 0–100)
- **Tags / catégories** : **même fonctionnement et design que le kanban des tickets** (markup + CSS `kanban-*` communs, endpoints `addTicketCategory` / `removeTicketCategory`) — chips colorés, bouton « + » → dropdown scrollable.
- **Informations registres** (extrafields Digirisk) + **Accidents liés**, avec le logo Digirisk sur les en-têtes.
- **Responsable et avancement** : assigné + progression + structure du tableau des tâches (données à brancher en étape 2).
- **Classification** (catégories) + dates (création / lu / clôture).
- **Boutons de statut natifs** placés au-dessus des **événements récents** (widget natif `FormActions::showactions()`).
- **En-tête d'onglets custom** (`digiriskdolibarr_ticket_prepare_head`) : l'onglet « Ticket » revient sur la card custom au lieu du natif `/ticket/card.php`.
- Style : cartes arrondies, compactes, titres alignés à gauche et centrés verticalement, dropdown scrollable, responsive.

## Fichiers

- `view/ticket/ticket_card.php` (nouveau)
- `view/ticket/ticket_action_card.php` (redirection du registre)
- `lib/digiriskdolibarr_ticket.lib.php` (en-tête d'onglets custom)
- `js/modules/ticket.js` (édition inline + tags kanban)
- `css/scss/page/_page-ticket-card.scss` (nouveau) + `css/scss/page/_page.scss` (import)
- `langs/fr_FR/digiriskdolibarr.lang` (2 clés : `TicketMessageTitle`, `TicketResponsibleAndProgress`)

> Les fichiers compilés `*.min.css` / `*.min.js` ne sont pas commités (générés par la CI).

## Reste à faire (étape 2)

- Brancher les données du tableau des tâches (« Responsable et avancement ») via `getTasksArray($object->fk_project)` + `projectLinesa()`.

## Issue

Closes #4443
