### PR TITLE
#4875 [Ticket] fix: only send ticket creation email for public interface submissions

### DIFF
--- a/core/triggers/interface_99_modDigiriskdolibarr_DigiriskdolibarrTriggers.class.php
+++ b/core/triggers/interface_99_modDigiriskdolibarr_DigiriskdolibarrTriggers.class.php
@@ -401,7 +401,10 @@ class InterfaceDigiriskdolibarrTriggers extends DolibarrTriggers
 				break;
 
 			case 'TICKET_CREATE' :
-				if (getDolGlobalInt('DIGIRISKDOLIBARR_SEND_EMAIL_ON_TICKET_SUBMIT')) {
+				// Only send this notification for tickets submitted through the DigiRisk public interface.
+				// TICKET_CREATE is fired by Dolibarr core on every ticket creation (back-office, API, ...),
+				// but the email content below is built solely from public-interface extrafields.
+				if (getDolGlobalInt('DIGIRISKDOLIBARR_SEND_EMAIL_ON_TICKET_SUBMIT') && !empty($object->context['digiriskdolibarrpublicinterface'])) {
 					// envoi du mail avec les infos de l'objet aux adresses mail configurées
 					// envoi du mail avec une trad puis avec un model
 

--- a/public/ticket/create_ticket.php
+++ b/public/ticket/create_ticket.php
@@ -286,6 +286,8 @@ if (empty($resHook)) {
             }
         }
         if (empty($error)) {
+            // Flag the object so the TICKET_CREATE trigger knows this ticket comes from the DigiRisk public interface
+            $object->context['digiriskdolibarrpublicinterface'] = 1;
             $result = $object->create($user);
             $object->fetch($result);
             $track_id = $object->track_id;


### PR DESCRIPTION
## Fixes #4875

### Problème

Le mail de création de ticket (réglage `DIGIRISKDOLIBARR_SEND_EMAIL_ON_TICKET_SUBMIT`) était envoyé à **chaque** création de ticket, quelle que soit son origine, alors qu'il est destiné aux tickets soumis via l'interface publique DigiRisk.

`TICKET_CREATE` est déclenché par le cœur de Dolibarr pour toute création de ticket (back-office, API, ...), mais le contenu du mail est construit uniquement à partir de champs propres à l'interface publique (`options_digiriskdolibarr_ticket_service`, `_lastname`, `_firstname`, `_date`, `$object->message`) → mail parasite au contenu incohérent hors interface publique.

### Correction

- `public/ticket/create_ticket.php` : pose du drapeau `$object->context['digiriskdolibarrpublicinterface'] = 1` juste avant `$object->create()`.
- `core/triggers/...DigiriskdolibarrTriggers.class.php` : le bloc `TICKET_CREATE` ne construit/envoie le mail que si ce drapeau est présent (en plus du global).

Les emails de catégorie (`TICKET_PUBLIC_INTERFACE_CREATE`) ne sont pas impactés.

### Tests
- [x] `php -l` OK sur les 2 fichiers
- [ ] Ticket créé depuis le back-office → aucun mail
- [ ] Ticket créé depuis l'interface publique → mail envoyé

🤖 Generated with [Claude Code](https://claude.com/claude-code)
