### PR TITLE
#4888 [Risk] rework: use saturne_select_users for executive pickers

### DIFF
--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
@@ -835,7 +835,7 @@ $massactionbutton = $form->selectMassAction('', $arrayofmassactions);
                                     <div style="display: flex; align-items: center; gap: 5px; height: 30px;">
                                         <i class="fas fa-user-tie fa-fw" style="color: #888;"></i>
                                         <div style="flex-grow: 1; min-width: 0;">
-                                            <?php print $form->select_dolusers(0, 'executive_id', $langs->trans('Responsible'), null, 0, '', 0, '', 0, 'widthcentpercent', '', 0, '', 'executiveSelect'); ?>
+                                            <?php print saturne_select_users('executive_id', 0, $langs->trans('Responsible'), 'executiveSelect widthcentpercent'); ?>
                                         </div>
                                     </div>
                                 </div>

--- a/core/tpl/riskanalysis/riskassessmenttask/digiriskdolibarr_riskassessment_task_view.tpl.php
+++ b/core/tpl/riskanalysis/riskassessmenttask/digiriskdolibarr_riskassessment_task_view.tpl.php
@@ -174,7 +174,7 @@ if (!empty($related_tasks) && is_array($related_tasks)) {
                                 <div>
                                     <div class="flex flex-row items-center justify-center">
                                         <i class="fas fa-user-tie 100" style="margin-right: 1em;"></i>
-                                        <?php print $form->select_dolusers(0, 'executive_id', 1, null, 0, '', 0, '', 0, 'minwidth200', '', 0, '', 'executiveSelect'); ?>
+                                        <?php print saturne_select_users('executive_id', 0, 1, 'executiveSelect minwidth200'); ?>
                                     </div>
                                 </div>
                             </div>
@@ -385,7 +385,7 @@ if (!empty($related_tasks) && is_array($related_tasks)) {
 										}
 									}
 								}
-								print $form->select_dolusers($currentExecutiveId, 'executive_id_edit' . $related_task->id, 1, null, 0, '', 0, '', 0, 'minwidth200', '', 0, '', 'executiveSelectEdit');
+								print saturne_select_users('executive_id_edit' . $related_task->id, $currentExecutiveId, 1, 'executiveSelectEdit minwidth200');
 								?>
 							</div>
 						</div>


### PR DESCRIPTION
Closes #4888

## Problème
Les 3 sélecteurs d'exécutant de la liste des risques (modale ajout risque, ajout tâche, édition tâche) appelaient chacun `select_dolusers()` → la même requête « tous les utilisateurs » exécutée **18× par page** (17 doublons, reliquat du profilage #4886).

## Solution
Utiliser le helper mutualisé **`saturne_select_users()`** (liste mise en cache par requête) à la place de `select_dolusers()`, en conservant **nom + classes** (`executive_id`, `executiveSelect`, `executiveSelectEdit`) → `risk.js` et `task.js` fonctionnent sans modification.

## Résultat mesuré
- Requête `select_dolusers` : **18 → 1**.
- Page liste des risques : **245 → 226** requêtes, doublons **37 → 19**.
- Cumul depuis le profilage initial : **419 → 226 requêtes (−46 %), 260 → 19 doublons (−93 %)**.

## Vérification (Playwright)
Sélecteur d'exécutant : **63 utilisateurs**, combo select2 actif, présélection correcte (modale édition), rendu pleine largeur — aucune régression. Capture modale « ajouter une tâche » OK.

## ⚠️ Dépendance
Nécessite la PR Saturne **Evarisk/Saturne#1441** (`saturne_select_users`) **fusionnée d'abord**, sinon fonction indéfinie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)