### PR TITLE
#4892 [Risk] rework: banner element display (parent getNomUrl + label, description icon)

### DIFF
--- a/class/digiriskelement.class.php
+++ b/class/digiriskelement.class.php
@@ -565,11 +565,11 @@ class DigiriskElement extends SaturneObject
         $result         = $parent_element->fetch($this->fk_parent);
         $morehtmlref    = '';
         if ($result > 0) {
-            $morehtmlref .= $langs->trans("Description") . ' : ' . $this->description;
+            $morehtmlref .= '<i class="fas fa-comment-dots" title="' . dol_escape_htmltag($langs->trans("Description")) . '"></i> ' . $this->description;
             $morehtmlref .= '<br>' . $parent_element->getNomUrl(1, 'blank', 1, '', -1, 1);
         } else {
             $digiriskstandard->fetch($conf->global->DIGIRISKDOLIBARR_ACTIVE_STANDARD);
-            $morehtmlref .= $langs->trans("Description") . ' : ' . $this->description;
+            $morehtmlref .= '<i class="fas fa-comment-dots" title="' . dol_escape_htmltag($langs->trans("Description")) . '"></i> ' . $this->description;
             $morehtmlref .= '<br>' . $digiriskstandard->getNomUrl(1, 'blank', 1, '', -1, 1);
         }
         $morehtmlref .= '<br>';

--- a/class/digiriskelement.class.php
+++ b/class/digiriskelement.class.php
@@ -566,11 +566,11 @@ class DigiriskElement extends SaturneObject
         $morehtmlref    = '';
         if ($result > 0) {
             $morehtmlref .= $langs->trans("Description") . ' : ' . $this->description;
-            $morehtmlref .= '<br>' . $langs->trans("ParentElement") . ' : ' . $parent_element->getNomUrl(1, 'blank', 1);
+            $morehtmlref .= '<br>' . $parent_element->getNomUrl(1, 'blank', 1, '', -1, 1);
         } else {
             $digiriskstandard->fetch($conf->global->DIGIRISKDOLIBARR_ACTIVE_STANDARD);
             $morehtmlref .= $langs->trans("Description") . ' : ' . $this->description;
-            $morehtmlref .= '<br>' . $langs->trans("ParentElement") . ' : ' . $digiriskstandard->getNomUrl(1, 'blank', 1);
+            $morehtmlref .= '<br>' . $digiriskstandard->getNomUrl(1, 'blank', 1, '', -1, 1);
         }
         $morehtmlref .= '<br>';
         $this->fetch($this->id);


### PR DESCRIPTION
Closes #4892

## Changement
Bandeau fiche élément (`DigiriskElement::getBannerTabContent`) : suppression du texte « Élément parent : » et affichage du parent via `getNomUrl(1, 'blank', 1, '', -1, 1)` (param `addLabel` activé).

**Avant** : `Élément parent : 🔧 GP1`
**Après** : `🔧 GP1 - Siège Evarisk` (picto + ref + label, cliquable)

Appliqué aux deux branches (parent réel / standard racine). Vérifié visuellement (Playwright).

🤖 Generated with [Claude Code](https://claude.com/claude-code)