### PR TITLE
#4894 [Menu] fix: don't expand the tree branch of the URL id on non-element pages

### DIFF
--- a/lib/digiriskdolibarr_function.lib.php
+++ b/lib/digiriskdolibarr_function.lib.php
@@ -249,7 +249,10 @@ function digirisk_header($title = '', $helpUrl = '', $arrayofjs = [], $arrayofcs
 								});
 
 								<?php
-								$idToFetch = GETPOSTINT('id') ?: GETPOSTINT('fromid');
+								// "id" only maps to a digiriskelement on the element/accident pages; on other
+								// pages (e.g. the standard card) it refers to a different object, so don't use it
+								// to expand the tree branch of the element that happens to share that id.
+								$idToFetch = (strpos($_SERVER['PHP_SELF'], 'digiriskelement') !== false || strpos($_SERVER['PHP_SELF'], 'accident') !== false) ? (GETPOSTINT('id') ?: GETPOSTINT('fromid')) : 0;
 								if ($idToFetch > 0) {
 									$object->fetch($idToFetch);
 								}


### PR DESCRIPTION
Closes #4894

## Problème
Le JS inline de `digirisk_header` faisait `$idToFetch = GETPOSTINT('id')` → `fetch()` → `getBranch()` pour déplier la branche de l'élément courant. Sur une page où `id` désigne un autre objet (fiche standard `?id=3`), il dépliait à tort l'élément 3.

## Fix
Ne calculer `$idToFetch` que si `$_SERVER['PHP_SELF']` est une page élément/accident (sinon 0 → pas de fetch, pas de dépliage).

## Résultat mesuré (élément 3 = WU1, parent GP1)
Fiche standard `?id=3` : arbre **replié** (0 nœud toggled), identique à l'arrivée par le menu ✅. Page élément `?id=3` : élément surligné + branche dépliée, préservé ✅. Vérifié Playwright + capture.

> Va avec la PR Saturne Evarisk/Saturne#1447 (les deux sources de la confusion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)