### PR TITLE
#4899 [Risk] feat: show the element banner ref as a badge like the GP/UT tree

### DIFF
--- a/css/digiriskdolibarr.min.css
+++ b/css/digiriskdolibarr.min.css
@@ -6898,3 +6898,20 @@ tr.liste_titre th.liste_titre:not(.maxwidthsearch), tr.liste_titre td.liste_titr
     padding-left: 0px;
   }
 }
+.arearef[class*="banner-element-"] .banner-ref-sep {
+  display: none;
+}
+.arearef[class*="banner-element-"] .refid > span.valignmiddle:first-child {
+  display: inline-block;
+  padding: 4px 8px;
+  margin-right: 12px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: #fff;
+  background: #263c5c;
+}
+.arearef.banner-element-workunit .refid > span.valignmiddle:first-child {
+  background: #0d8aff;
+}

--- a/css/scss/page/_page-element-risk.scss
+++ b/css/scss/page/_page-element-risk.scss
@@ -39,3 +39,28 @@
     }
   }
 }
+
+/** Element banner: render the ref as a badge (same look as the GP/UT tree), colored by element type.
+    Scoped to the banner-element-* class (added by saturne_banner_tab only for elements with a subtype),
+    so it never affects other modules' banners. */
+.arearef[class*="banner-element-"] {
+  .banner-ref-sep {
+    display: none; /* the badge uses its own right margin instead of a " - " separator */
+  }
+
+  .refid > span.valignmiddle:first-child {
+    display: inline-block;
+    padding: 4px 8px;
+    margin-right: 12px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: #fff;
+    background: #263c5c; /* default / groupment */
+  }
+}
+
+.arearef.banner-element-workunit .refid > span.valignmiddle:first-child {
+  background: #0d8aff;
+}


### PR DESCRIPTION
Closes #4899

## Changement
La ref du bandeau élément s'affiche en **badge coloré par type** (groupment `#263C5C`, workunit `#0d8aff`), label à côté sans le `- `, **même design que l'arbre GP/UT**.

SCSS scopé sur `.arearef[class*="banner-element-"]` (classe ajoutée par `saturne_banner_tab`, cf. Evarisk/Saturne#1451) → n'affecte aucun autre module. `digiriskdolibarr.min.css` compilé/committé (pas de CI d'assets sur ce repo).

## Vérification (Playwright)
WU1 → badge **bleu** (`rgb(13,138,255)`), GP1 → badge **foncé** (`rgb(38,60,92)`), label à côté. Capture OK.

> Va avec Evarisk/Saturne#1451 (expose la classe de type + le séparateur). Ordre de merge indifférent (dégradation propre).

🤖 Generated with [Claude Code](https://claude.com/claude-code)