### PR TITLE
#4443 [Ticket] Box fichiers joints = widget natif showdocuments (comme la card native)

### DIFF
--- a/view/ticket/ticket_card.php
+++ b/view/ticket/ticket_card.php
@@ -494,24 +494,11 @@ if ($action === 'confirm_set_status' && $permissionToWrite && !GETPOST('cancel')
     setEventMessages($object->error, $object->errors, 'errors');
 }
 
-// Action: ticket attached-files box — upload (sendit) + delete (remove_file) for the native showdocuments widget
-$ticketFilesDir = $conf->ticket->dir_output . '/' . dol_sanitizeFileName($object->ref);
-if (GETPOST('sendit', 'alpha') && $permissionToWrite && getDolGlobalString('MAIN_UPLOAD_DOC')) {
-    require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
-    dol_mkdir($ticketFilesDir);
-    dol_add_file_process($ticketFilesDir, 0, 1, 'userfile');
-    header('Location: ' . $url_page_current . '?id=' . $object->id);
-    exit;
-}
-if ($action === 'remove_file' && $permissionToWrite) {
-    require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
-    $ticketFileToDelete = dol_sanitizeFileName(basename(GETPOST('file', 'alphanohtml')));
-    if ($ticketFileToDelete !== '') {
-        dol_delete_file($ticketFilesDir . '/' . $ticketFileToDelete);
-    }
-    header('Location: ' . $url_page_current . '?id=' . $object->id);
-    exit;
-}
+// Ticket attached-files box — native generate/delete handling for the showdocuments widget (same as the native ticket card).
+$upload_dir         = $conf->ticket->dir_output;
+$permissiontoadd    = $permissionToWrite ? 1 : 0;
+$permissiontodelete = $permissionToWrite ? 1 : 0;
+include DOL_DOCUMENT_ROOT . '/core/actions_builddoc.inc.php';
 
 /*
  * View
@@ -809,20 +796,16 @@ if (!empty($linkedAccidents)) {
 print '</td></tr>';
 print '</tbody></table>';
 
-// ---- Attached files (native Dolibarr documents widget: upload + list + delete + download) ----
+// ---- Attached files box (native Dolibarr showdocuments widget: generate + list + preview + delete), same as the native ticket card ----
 require_once DOL_DOCUMENT_ROOT . '/core/class/html.formfile.class.php';
 $formfileTicket  = new FormFile($db);
 $ticketFilesName = dol_sanitizeFileName($object->ref);
 $ticketFilesDir  = $conf->ticket->dir_output . '/' . $ticketFilesName;
-print '<table class="border centpercent tableforfield"><tbody>';
-print '<tr class="liste_titre trforfield"><td><div class="dtc-head">' . img_picto('', 'object_generic', 'class="pictoModule"') . ' ' . $langs->trans('Files') . '</div></td></tr>';
-print '<tr><td>';
-if ($permissionToWrite) {
-    print $formfileTicket->form_attach_new_file($url_page_current . '?id=' . $object->id, $langs->trans('AddFile'), 0, 0, 1, 40, $object, '', 0, '', 0);
-}
-print $formfileTicket->showdocuments('ticket', $ticketFilesName, $ticketFilesDir, $url_page_current . '?id=' . $object->id, 0, $permissionToWrite ? 1 : 0, '', 1, 0, 0, 28, 0, '', '', '', '');
-print '</td></tr>';
-print '</tbody></table>';
+$genallowed      = $permissionToWrite ? 1 : 0;
+$delallowed      = $permissionToWrite ? 1 : 0;
+print '<div class="dtc-files-box">';
+print $formfileTicket->showdocuments('ticket', $ticketFilesName, $ticketFilesDir, $url_page_current . '?id=' . $object->id, $genallowed, $delallowed, $object->model_pdf, 1, 0, 0, 28, 0, '', '', '', '');
+print '</div>';
 
 print '</div>'; // fichehalfleft
 


### PR DESCRIPTION
Box « Fichiers joints » sur la card ticket = **widget natif Dolibarr `showdocuments`**, identique à la card ticket native :

- « Modèle de document [ODT/PDF templates] GÉNÉRER »
- Liste des fichiers du ticket : aperçu, taille, date, suppression (🗑)
- Stockage `documents/ticket/{ref}` ; génération + suppression via `actions_builddoc.inc.php`
- Colonne gauche, après Accidents

Vérifié (Playwright) : rendu identique à la box native.

Part of #4443

🤖 Generated with [Claude Code](https://claude.com/claude-code)