### PR TITLE
#4910 [Dolistore] fix: use dol_include_once instead of DOL_DOCUMENT_ROOT custom path

### DIFF
--- a/core/ajax/ticket_action_card.php
+++ b/core/ajax/ticket_action_card.php
@@ -718,8 +718,8 @@ switch ($action) {
                 // $addLabel=1 (last arg) appends " - <label>" to the ref so users see "GP1 - Siège Evarisk".
                 $display = '';
                 $newId = (int) $valueToStore;
-                if ($newId > 0 && file_exists(DOL_DOCUMENT_ROOT . '/custom/digiriskdolibarr/class/digiriskelement.class.php')) {
-                    require_once DOL_DOCUMENT_ROOT . '/custom/digiriskdolibarr/class/digiriskelement.class.php';
+                if ($newId > 0) {
+                    dol_include_once('/digiriskdolibarr/class/digiriskelement.class.php');
                     $de = new DigiriskElement($db);
                     if ($de->fetch($newId) > 0) {
                         $display = $de->getNomUrl(1, '', 0, '', -1, 1);

--- a/core/tpl/ticket/ticket_action_card_view.tpl.php
+++ b/core/tpl/ticket/ticket_action_card_view.tpl.php
@@ -785,22 +785,20 @@ if (!in_array($severityKey, ['low', 'normal', 'high', 'blocking'], true)) {
                     $firstServiceId = (int) (is_string($serviceId) ? strtok((string) $serviceId, ',') : $serviceId);
                     $serviceDisplay = '';
                     $serviceOptions = [['id' => 0, 'label' => '— ' . $langs->transnoentities('NoneSelected') . ' —']];
-                    if (file_exists(DOL_DOCUMENT_ROOT . '/custom/digiriskdolibarr/class/digiriskelement.class.php')) {
-                        require_once DOL_DOCUMENT_ROOT . '/custom/digiriskdolibarr/class/digiriskelement.class.php';
-                        $de = new DigiriskElement($db);
-                        if ($firstServiceId > 0 && $de->fetch($firstServiceId) > 0) {
-                            // 6th arg ($addLabel=1) appends " - <label>" after the ref.
-                            $serviceDisplay = $de->getNomUrl(1, '', 0, '', -1, 1);
-                        }
-                        $allElements = $de->fetchAll('ASC', 't.ref', 0, 0, ['customsql' => 't.status > 0 AND t.entity IN (' . getEntity('digiriskdolibarr_digiriskelement') . ')']);
-                        if (is_array($allElements)) {
-                            foreach ($allElements as $el) {
-                                $label = trim(($el->ref ? $el->ref . ' — ' : '') . ($el->label ?? ''));
-                                if ($label === '') {
-                                    $label = '#' . (int) $el->id;
-                                }
-                                $serviceOptions[] = ['id' => (int) $el->id, 'label' => $label];
+                    dol_include_once('/digiriskdolibarr/class/digiriskelement.class.php');
+                    $de = new DigiriskElement($db);
+                    if ($firstServiceId > 0 && $de->fetch($firstServiceId) > 0) {
+                        // 6th arg ($addLabel=1) appends " - <label>" after the ref.
+                        $serviceDisplay = $de->getNomUrl(1, '', 0, '', -1, 1);
+                    }
+                    $allElements = $de->fetchAll('ASC', 't.ref', 0, 0, ['customsql' => 't.status > 0 AND t.entity IN (' . getEntity('digiriskdolibarr_digiriskelement') . ')']);
+                    if (is_array($allElements)) {
+                        foreach ($allElements as $el) {
+                            $label = trim(($el->ref ? $el->ref . ' — ' : '') . ($el->label ?? ''));
+                            if ($label === '') {
+                                $label = '#' . (int) $el->id;
                             }
+                            $serviceOptions[] = ['id' => (int) $el->id, 'label' => $label];
                         }
                     }
                     $renderField('options_digiriskdolibarr_ticket_service', 'select', 'GP/UT',

--- a/view/digiriskelement/digiriskelement_digiai.php
+++ b/view/digiriskelement/digiriskelement_digiai.php
@@ -254,8 +254,9 @@ if ($object->id > 0) {
     $moduleNameLowerCase = 'digiriskdolibarr';
     $moduleName = 'DigiriskDolibarr';
     $moduleNameUpperCase = 'DIGIRISKDOLIBARR';
-    if (file_exists(DOL_DOCUMENT_ROOT . '/custom/saturne/core/tpl/medias/medias_gallery_modal.tpl.php')) {
-        include DOL_DOCUMENT_ROOT . '/custom/saturne/core/tpl/medias/medias_gallery_modal.tpl.php';
+    $mediasGalleryModalPath = dol_buildpath('/saturne/core/tpl/medias/medias_gallery_modal.tpl.php');
+    if (file_exists($mediasGalleryModalPath)) {
+        include $mediasGalleryModalPath;
     }
 
     ?>

--- a/view/ticket/ticket_card.php
+++ b/view/ticket/ticket_card.php
@@ -681,13 +681,11 @@ $regCondition = (string) ($extra['digiriskdolibarr_condition_message'] ?? '');
 $regServiceRaw  = $extra['digiriskdolibarr_ticket_service'] ?? '';
 $firstServiceId = (int) (is_string($regServiceRaw) ? strtok($regServiceRaw, ',') : $regServiceRaw);
 $regService     = '';
-if (file_exists(DOL_DOCUMENT_ROOT . '/custom/digiriskdolibarr/class/digiriskelement.class.php')) {
-    require_once DOL_DOCUMENT_ROOT . '/custom/digiriskdolibarr/class/digiriskelement.class.php';
-    if ($firstServiceId > 0) {
-        $digiriskElement = new DigiriskElement($db);
-        if ($digiriskElement->fetch($firstServiceId) > 0) {
-            $regService = $digiriskElement->getNomUrl(1, '', 0, '', -1, 1);
-        }
+dol_include_once('/digiriskdolibarr/class/digiriskelement.class.php');
+if ($firstServiceId > 0) {
+    $digiriskElement = new DigiriskElement($db);
+    if ($digiriskElement->fetch($firstServiceId) > 0) {
+        $regService = $digiriskElement->getNomUrl(1, '', 0, '', -1, 1);
     }
 }
 
@@ -714,18 +712,16 @@ $drPicto = img_picto('', 'digiriskdolibarr_color@digiriskdolibarr', 'class="pict
 
 // Fetch all GP/UT options for select
 $serviceOptions = ['' => '']; // Empty option
-if (file_exists(DOL_DOCUMENT_ROOT . '/custom/digiriskdolibarr/class/digiriskelement.class.php')) {
-    require_once DOL_DOCUMENT_ROOT . '/custom/digiriskdolibarr/class/digiriskelement.class.php';
-    $digiriskElementTmp = new DigiriskElement($db);
-    $elementList = $digiriskElementTmp->fetchDigiriskElementFlat(0);
-    if (is_array($elementList)) {
-        foreach ($elementList as $el) {
-            $obj = $el['object'] ?? null;
-            if ($obj && isset($obj->id)) {
-                $depth = (int)($el['depth'] ?? 0);
-                $indent = str_repeat('&nbsp;&nbsp;&nbsp;&nbsp;', $depth);
-                $serviceOptions[$obj->id] = $indent . dol_escape_htmltag($obj->ref . ' - ' . $obj->label);
-            }
+dol_include_once('/digiriskdolibarr/class/digiriskelement.class.php');
+$digiriskElementTmp = new DigiriskElement($db);
+$elementList = $digiriskElementTmp->fetchDigiriskElementFlat(0);
+if (is_array($elementList)) {
+    foreach ($elementList as $el) {
+        $obj = $el['object'] ?? null;
+        if ($obj && isset($obj->id)) {
+            $depth = (int)($el['depth'] ?? 0);
+            $indent = str_repeat('&nbsp;&nbsp;&nbsp;&nbsp;', $depth);
+            $serviceOptions[$obj->id] = $indent . dol_escape_htmltag($obj->ref . ' - ' . $obj->label);
         }
     }
 }
@@ -773,13 +769,11 @@ print '</tbody></table>';
 
 // ---- Accidents linked to this ticket ----
 $linkedAccidents = [];
-if (file_exists(DOL_DOCUMENT_ROOT . '/custom/digiriskdolibarr/class/accident.class.php')) {
-    require_once DOL_DOCUMENT_ROOT . '/custom/digiriskdolibarr/class/accident.class.php';
-    $accident = new Accident($db);
-    $fetched  = $accident->fetchAll('', '', 0, 0, ['customsql' => 't.fk_ticket = ' . (int) $object->id]);
-    if (is_array($fetched)) {
-        $linkedAccidents = $fetched;
-    }
+dol_include_once('/digiriskdolibarr/class/accident.class.php');
+$accident = new Accident($db);
+$fetched  = $accident->fetchAll('', '', 0, 0, ['customsql' => 't.fk_ticket = ' . (int) $object->id]);
+if (is_array($fetched)) {
+    $linkedAccidents = $fetched;
 }
 print '<table class="border centpercent tableforfield"><tbody>';
 print '<tr class="liste_titre trforfield"><td><div class="dtc-head">' . img_picto('', 'digiriskdolibarr_color@digiriskdolibarr', 'class="pictoModule"') . ' ' . $langs->trans('Accidents') . '</div></td></tr>';


### PR DESCRIPTION
## Contexte

La soumission de `module_digiriskdolibarr-23.1.0.zip` sur le Dolistore est refusée par le validateur :

> L'appel de votre classe de module ne doit pas se faire avec DOL_DOCUMENT_ROOT, le fichier "ticket_action_card.php" du module "digiriskdolibarr" est erroné, vous devez corriger la ligne ci-dessous avec "dol_include_once".

Le validateur ne signale que le premier fichier rencontré, mais `develop` en contient **6 occurrences dans 4 fichiers** : corriger uniquement celui du message aurait fait échouer la soumission suivante.

## Changements

- `core/ajax/ticket_action_card.php`, `core/tpl/ticket/ticket_action_card_view.tpl.php`, `view/ticket/ticket_card.php` : remplacement des `require_once DOL_DOCUMENT_ROOT . '/custom/digiriskdolibarr/class/...'` par `dol_include_once('/digiriskdolibarr/class/...')`.
- `view/digiriskelement/digiriskelement_digiai.php` : résolution du chemin du template Saturne via `dol_buildpath()`.

## Pourquoi les gardes `file_exists` disparaissent aussi

Chaque `require_once` était protégé par un `file_exists(DOL_DOCUMENT_ROOT . '/custom/...')` qui testait **le même chemin erroné**. Sur une installation hors `custom/`, le garde renvoyait `false` et désactivait silencieusement la fonctionnalité (GP/UT vide, accidents liés absents, galerie manquante) sans aucune erreur.

Corriger seulement les `require_once` aurait satisfait le validateur en laissant ce bug en place. Les gardes sont donc supprimés pour les classes du module — elles sont toujours présentes par construction, et `dol_include_once()` gère déjà l'absence de fichier.

**Exception :** le garde de la galerie Saturne est **conservé** — Saturne est un module tiers réellement optionnel. Seule la résolution du chemin change, via `dol_buildpath()`, ce qui préserve la sémantique `include` d'origine (et non `include_once`).

## Fichiers modifiés

- `core/ajax/ticket_action_card.php`
- `core/tpl/ticket/ticket_action_card_view.tpl.php`
- `view/digiriskelement/digiriskelement_digiai.php`
- `view/ticket/ticket_card.php`

## Vérifications effectuées

- [x] Aucun `require`/`include` avec `DOL_DOCUMENT_ROOT . '/custom/'` ne subsiste dans le module
- [x] `php -l` OK sur les 4 fichiers

## Reste à valider fonctionnellement

- [ ] Fiche ticket : GP/UT et accidents liés s'affichent
- [ ] Fiche action ticket : select GP/UT peuplé + édition inline (AJAX) OK
- [ ] DigiAI : la galerie de médias s'ouvre
- [ ] Package accepté par le Dolistore

## À noter (hors périmètre)

`core/tpl/ticket/ticket_action_card_view.tpl.php:56` appelle `dol_buildpath('/custom/digiriskdolibarr/core/ajax/...', 1)` avec un préfixe `/custom/` en trop — `dol_buildpath()` l'ajoute déjà. Ça fonctionne par accident en installation standard et le validateur ne le détecte pas, donc laissé tel quel pour ne pas élargir le périmètre avant la soumission.

## Issue

Closes #4910
