### PR TITLE
#4912 [Ticket] fix: apply date range filter to stats graphs 2 and 3

### DIFF
--- a/class/ticketdashboard.class.php
+++ b/class/ticketdashboard.class.php
@@ -293,10 +293,18 @@ class TicketDashboard extends DigiriskDolibarrDashboard
 
         $mainCategoriesImploded = implode(',', array_column($mainCategories, 'id'));
 
+        // Apply the stats page date range so the category/GP-UT cross-tab graphs honor the same filter as the other graphs
+        $dateStart  = dol_mktime(0, 0, 0, GETPOST('dateStartmonth', 'int'), GETPOST('dateStartday', 'int'), GETPOST('dateStartyear', 'int'));
+        $dateEnd    = dol_mktime(23, 59, 59, GETPOST('dateEndmonth', 'int'), GETPOST('dateEndday', 'int'), GETPOST('dateEndyear', 'int'));
+        $dateFilter = '';
+        if (!empty($dateStart) && !empty($dateEnd)) {
+            $dateFilter = " AND t.datec BETWEEN '" . $this->db->idate($dateStart) . "' AND '" . $this->db->idate($dateEnd) . "'";
+        }
+
         $select      = ', cp.fk_categorie';
         $moreSelects = ['fk_categorie'];
         $join        = ' INNER JOIN ' . MAIN_DB_PREFIX . $this->module . '_digiriskelement AS d ON d.rowid = eft.digiriskdolibarr_ticket_service';
-        $filter      = 't.fk_statut > 0 AND t.entity = ' . $conf->entity . ' AND cp.fk_categorie IN (' . $mainCategoriesImploded  . ') AND d.status = ' . DigiriskElement::STATUS_VALIDATED;
+        $filter      = 't.fk_statut > 0 AND t.entity = ' . $conf->entity . ' AND cp.fk_categorie IN (' . $mainCategoriesImploded  . ') AND d.status = ' . DigiriskElement::STATUS_VALIDATED . $dateFilter;
         $tickets     = saturne_fetch_all_object_type('Ticket', 'ASC', 'eft.digiriskdolibarr_ticket_service', 0, 0, ['customsql' => $filter], 'AND', true, false, true, $join, [], $select, $moreSelects);
         if (!is_array($tickets) || empty($tickets)) {
             return $array;
@@ -317,7 +325,7 @@ class TicketDashboard extends DigiriskDolibarrDashboard
 
         $mainSubCategoriesImploded = implode(',', array_column($mainSubCategories, 'id'));
 
-        $filter  = 't.fk_statut > 0 AND t.entity = ' . $conf->entity . ' AND cp.fk_categorie IN (' . $mainSubCategoriesImploded  . ') AND d.status = ' . DigiriskElement::STATUS_VALIDATED;
+        $filter  = 't.fk_statut > 0 AND t.entity = ' . $conf->entity . ' AND cp.fk_categorie IN (' . $mainSubCategoriesImploded  . ') AND d.status = ' . DigiriskElement::STATUS_VALIDATED . $dateFilter;
         $tickets = saturne_fetch_all_object_type('Ticket', 'ASC', 'eft.digiriskdolibarr_ticket_service', 0, 0, ['customsql' => $filter], 'AND', true, false, true, $join, [], $select, $moreSelects);
         if (!is_array($tickets) || empty($tickets)) {
             return $array;


### PR DESCRIPTION
Closes #4912

### Problème
Sur la page **Statistiques des tickets**, le filtre **Plage de dates** n'était pas appliqué aux graphes 2 et 3 :
- Graphe 2 : *Nombre de tickets par catégorie principale et par GP/UT*
- Graphe 3 : *Nombre de tickets par sous-catégorie principale et par GP/UT*

Ces deux graphes affichaient les tickets de toute la période, quelle que soit la plage sélectionnée. Le graphe 1 (tickets par mois) respectait déjà la plage.

### Cause
Dans `TicketDashboard::load_dashboard()`, les deux requêtes alimentant les crosstabs construisaient un `$filter` neuf sans contrainte de date (ni le `$this->where` porteur de la plage).

### Correctif
Ajout d'une clause `t.datec BETWEEN dateStart AND dateEnd` (cohérente avec le graphe 1 et le filtre de la page) aux deux requêtes des graphes 2 et 3. Aucun changement de comportement quand aucune plage n'est saisie.

### Vérification (Playwright, en faisant varier uniquement la plage)
| Plage | Graphe 2 | Graphe 3 |
|---|---|---|
| aucun filtre | 2 | 2 |
| large 2000-2099 | 2 | 2 |
| année 2024 | 1 | 1 |
| année 2026 | 1 | 1 |
| année 2025 | 0 | 0 |

Les deux tickets catégorisés (un en 2024, un en 2026) sont désormais correctement partitionnés par la plage.

> Note : base `develop` → `Closes #` ne fermera pas l'issue automatiquement, à fermer manuellement au merge.