### PR TITLE
#4926 [Task] feat: add mass validate and mass change project actions on task list

### DIFF
--- a/class/actions_digiriskdolibarr.class.php
+++ b/class/actions_digiriskdolibarr.class.php
@@ -1055,6 +1055,212 @@ class ActionsDigiriskdolibarr
     }
 
     /**
+     * Overloading the addMoreMassActions function : replacing the parent's function with the one below
+     *
+     * @param  array $parameters Hook metadata (context, etc...)
+     * @return int               0 < on error, 0 on success, 1 to replace standard code
+     */
+    public function addMoreMassActions(array $parameters): int
+    {
+        global $langs, $user;
+
+        if (preg_match('/tasklist|projecttaskscard/', $parameters['context']) && $user->hasRight('projet', 'creer')) {
+            // Hook runs on a Dolibarr core page, module lang files are not loaded there
+            $langs->load('digiriskdolibarr@digiriskdolibarr');
+
+            $arrayOfMassActions = [
+                'prevalidatetasks'      => '<span class="fas fa-check paddingrightonly"></span>' . $langs->trans('MassValidateTasks'),
+                'prechangeprojecttasks' => '<span class="fas fa-random paddingrightonly"></span>' . $langs->trans('MassChangeTasksProject')
+            ];
+
+            $out = '';
+            foreach ($arrayOfMassActions as $code => $label) {
+                $out .= '<option value="' . $code . '" data-html="' . dol_escape_htmltag($label) . '">' . $label . '</option>';
+            }
+
+            $this->resprints = $out;
+        }
+
+        return 0; // or return 1 to replace standard code
+    }
+
+    /**
+     * Overloading the doPreMassActions function : replacing the parent's function with the one below
+     *
+     * @param  array $parameters Hook metadata (context, massaction, toselect, etc...)
+     * @return int               0 < on error, 0 on success, 1 to replace standard code
+     * @throws Exception
+     */
+    public function doPreMassActions(array $parameters): int
+    {
+        global $form, $langs, $user;
+
+        if (!preg_match('/tasklist|projecttaskscard/', $parameters['context']) || !$user->hasRight('projet', 'creer')) {
+            return 0;
+        }
+
+        $langs->load('digiriskdolibarr@digiriskdolibarr');
+
+        $nbSelected = is_array($parameters['toselect']) ? count($parameters['toselect']) : 0;
+
+        if ($parameters['massaction'] == 'prevalidatetasks') {
+            $this->resprints = $form->formconfirm($_SERVER['PHP_SELF'], $langs->trans('MassValidateTasks'), $langs->trans('ConfirmMassValidateTasksQuestion', $nbSelected), 'digirisk_validate_tasks', null, 'yes', 0, 200, 500, 1);
+        }
+
+        if ($parameters['massaction'] == 'prechangeprojecttasks') {
+            require_once DOL_DOCUMENT_ROOT . '/core/class/html.formprojet.class.php';
+
+            $formProject  = new FormProjets($this->db);
+            $formQuestion = [
+                [
+                    'type'  => 'other',
+                    'name'  => 'digiriskdolibarr_fk_project',
+                    'label' => $langs->trans('Project'),
+                    'value' => $formProject->select_projects(-1, GETPOSTINT('digiriskdolibarr_fk_project'), 'digiriskdolibarr_fk_project', 0, 0, 1, 1, 0, 0, 0, '', 1, 0, 'minwidth300')
+                ]
+            ];
+
+            $this->resprints = $form->formconfirm($_SERVER['PHP_SELF'], $langs->trans('MassChangeTasksProject'), $langs->trans('ConfirmMassChangeTasksProjectQuestion', $nbSelected), 'digirisk_change_project_tasks', $formQuestion, 'yes', 0, 250, 500, 1);
+        }
+
+        return 0; // or return 1 to replace standard code
+    }
+
+    /**
+     * Overloading the doMassActions function : replacing the parent's function with the one below
+     *
+     * @param  array  $parameters Hook metadata (context, toselect, etc...)
+     * @param  object $object     Current object
+     * @param  string $action     Current action
+     * @return int                0 < on error, 0 on success, 1 to replace standard code
+     */
+    public function doMassActions(array $parameters, $object, $action): int
+    {
+        global $langs, $user;
+
+        if (!preg_match('/tasklist|projecttaskscard/', $parameters['context']) || !$user->hasRight('projet', 'creer')) {
+            return 0;
+        }
+
+        if (!in_array($action, ['digirisk_validate_tasks', 'digirisk_change_project_tasks']) || GETPOST('confirm', 'alpha') != 'yes') {
+            return 0;
+        }
+
+        $langs->load('digiriskdolibarr@digiriskdolibarr');
+
+        $taskIds = array_filter(array_map('intval', (array) $parameters['toselect']));
+        if (empty($taskIds)) {
+            $this->errors[] = $langs->trans('ErrorSelectAtLeastOne');
+            return -1;
+        }
+
+        require_once DOL_DOCUMENT_ROOT . '/projet/class/task.class.php';
+
+        if ($action == 'digirisk_validate_tasks') {
+            $nbValidated = 0;
+            foreach ($taskIds as $taskId) {
+                $task = new Task($this->db);
+                // Only a draft task can be validated, same rule as the task card
+                if ($task->fetch($taskId) <= 0 || $task->status != Task::STATUS_DRAFT) {
+                    continue;
+                }
+
+                // An explicit trigger code is needed, triggers parse it and warn on the empty one Dolibarr sends by default
+                if ($task->setStatusCommon($user, Task::STATUS_VALIDATED, 0, 'TASK_VALIDATE') < 0) {
+                    $this->errors[] = $task->errorsToString();
+                    return -1;
+                }
+
+                $nbValidated++;
+            }
+
+            setEventMessages($langs->trans('MassValidateTasksSuccess', $nbValidated, count($taskIds)), []);
+
+            return 0;
+        }
+
+        $projectId = GETPOSTINT('digiriskdolibarr_fk_project');
+        if ($projectId <= 0) {
+            $this->errors[] = $langs->trans('ErrorFieldRequired', $langs->transnoentities('Project'));
+            return -1;
+        }
+
+        require_once DOL_DOCUMENT_ROOT . '/projet/class/project.class.php';
+
+        $targetProject = new Project($this->db);
+        if ($targetProject->fetch($projectId) <= 0) {
+            $this->errors[] = $langs->trans('ErrorRecordNotFound');
+            return -1;
+        }
+
+        $sourceProjects = [];
+        $nbMoved        = 0;
+        foreach ($taskIds as $taskId) {
+            $task = new Task($this->db);
+            if ($task->fetch($taskId) <= 0 || $task->fk_project == $projectId) {
+                continue;
+            }
+
+            $sourceProjectId = (int) $task->fk_project;
+            if (!isset($sourceProjects[$sourceProjectId])) {
+                $sourceProject                    = new Project($this->db);
+                $sourceProjects[$sourceProjectId] = $sourceProject->fetch($sourceProjectId) > 0 ? $sourceProject->ref : '';
+            }
+
+            // A parent task left behind in the previous project would break the task hierarchy
+            if ($task->fk_task_parent > 0 && !in_array((int) $task->fk_task_parent, $taskIds)) {
+                $task->fk_task_parent = 0;
+            }
+
+            $task->fk_project = $projectId;
+            if ($task->update($user) <= 0) {
+                $this->errors[] = $task->errorsToString();
+                return -1;
+            }
+
+            $this->moveTaskDocuments($task, $sourceProjects[$sourceProjectId], $targetProject->ref);
+
+            $nbMoved++;
+        }
+
+        setEventMessages($langs->trans('MassChangeTasksProjectSuccess', $nbMoved, $targetProject->getNomUrl(1)), []);
+
+        return 0; // or return 1 to replace standard code
+    }
+
+    /**
+     * Move the document directory of a task that has just been attached to another project.
+     * Task files are stored under <project_ref>/<task_ref>, so they have to follow the task.
+     *
+     * @param  Task   $task             Task that has been moved
+     * @param  string $sourceProjectRef Ref of the project the task was attached to
+     * @param  string $targetProjectRef Ref of the project the task is now attached to
+     * @return void
+     */
+    protected function moveTaskDocuments(Task $task, string $sourceProjectRef, string $targetProjectRef): void
+    {
+        global $conf;
+
+        if (empty($sourceProjectRef) || empty($targetProjectRef)) {
+            return;
+        }
+
+        require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
+
+        $entity    = !empty($task->entity) ? (int) $task->entity : (int) $conf->entity;
+        $rootDir   = $conf->project->multidir_output[$entity] ?? $conf->project->dir_output;
+        $sourceDir = $rootDir . '/' . dol_sanitizeFileName($sourceProjectRef) . '/' . dol_sanitizeFileName($task->ref);
+        if (!is_dir($sourceDir)) {
+            return;
+        }
+
+        $targetDir = $rootDir . '/' . dol_sanitizeFileName($targetProjectRef) . '/' . dol_sanitizeFileName($task->ref);
+
+        dol_mkdir(dirname($targetDir));
+        dol_move_dir($sourceDir, $targetDir);
+    }
+
+    /**
      * Overloading the saturneBannerTab function : replacing the parent's function with the one below
      *
      * @param  array  $parameters Hook metadatas (context, etc...)

--- a/langs/en_US/digiriskdolibarr.lang
+++ b/langs/en_US/digiriskdolibarr.lang
@@ -179,3 +179,11 @@ PwaTilePreventionPlanInProgress = Plans in progress
 PwaTilePreventionPlanToSign = Plans to sign
 PwaTileFirePermitInProgress = Permits in progress
 PwaTileFirePermitToSign = Permits to sign
+
+# Task mass actions
+MassValidateTasks = Validate tasks
+MassChangeTasksProject = Change project
+ConfirmMassValidateTasksQuestion = Are you sure you want to validate the %s selected task(s)? Only draft tasks will be validated.
+ConfirmMassChangeTasksProjectQuestion = Are you sure you want to attach the %s selected task(s) to the chosen project?
+MassValidateTasksSuccess = %s task(s) validated out of %s selected
+MassChangeTasksProjectSuccess = %s task(s) attached to project %s

--- a/langs/fr_FR/digiriskdolibarr.lang
+++ b/langs/fr_FR/digiriskdolibarr.lang
@@ -2054,3 +2054,11 @@ PwaTilePreventionPlanInProgress = Plans en cours
 PwaTilePreventionPlanToSign = Plans à signer
 PwaTileFirePermitInProgress = Permis en cours
 PwaTileFirePermitToSign = Permis à signer
+
+# Actions de masse sur les tâches
+MassValidateTasks = Valider les tâches
+MassChangeTasksProject = Changer de projet
+ConfirmMassValidateTasksQuestion = Êtes-vous sûr de vouloir valider les %s tâche(s) sélectionnée(s) ? Seules les tâches au statut brouillon seront validées.
+ConfirmMassChangeTasksProjectQuestion = Êtes-vous sûr de vouloir rattacher les %s tâche(s) sélectionnée(s) au projet choisi ?
+MassValidateTasksSuccess = %s tâche(s) validée(s) sur %s sélectionnée(s)
+MassChangeTasksProjectSuccess = %s tâche(s) rattachée(s) au projet %s


### PR DESCRIPTION
## Changements

Ajout de deux actions de masse sur la liste des tâches, via les hooks `addMoreMassActions`, `doPreMassActions` et `doMassActions` sur les contextes `tasklist` et `projecttaskscard`.

- **Valider les tâches** — passe les tâches sélectionnées au statut Validé. Seules les tâches au statut Brouillon sont traitées, comme sur la fiche tâche ; le message de retour indique le nombre réellement validé sur le nombre sélectionné.
- **Changer de projet** — rattache les tâches sélectionnées au projet choisi dans un `select_projects()` qui écarte les projets clôturés.

Détails d'implémentation :

- Les deux actions sont réservées aux utilisateurs ayant `projet -> creer`, et passent par un écran de confirmation `formconfirm` affichant le nombre de tâches concernées.
- Sur le changement de projet, si une tâche sélectionnée a une tâche parente absente de la sélection, le lien parent est retiré : sans ça la hiérarchie serait cassée entre deux projets.
- Toujours sur le changement de projet, le dossier de documents de la tâche est déplacé, car il est stocké sous `<ref_projet>/<ref_tache>` et les fichiers deviendraient invisibles depuis l'onglet Documents.
- Un code de trigger explicite `TASK_VALIDATE` est passé à `setStatusCommon()`. Sans lui, Dolibarr envoie un trigger au nom vide, ce qui provoque des warnings PHP `Undefined array key 1` et des événements agenda `AC_` vides dans les triggers des autres modules Saturne.
- Aucun nouveau contexte de hook n'est ajouté : `tasklist` et `projecttaskscard` sont déjà enregistrés par le module, donc aucune réactivation n'est nécessaire.

## Tests

Vérifié sur une base réelle dans une transaction annulée : les trois tâches sélectionnées passent bien au statut `1` et au projet cible, sans erreur ni warning PHP.

## Limite connue

`dol_move_dir()` ne réindexe pas `llx_ecm_files` quand le nom du dossier ne change pas, l'index ECM conserve donc l'ancien chemin après un changement de projet. L'onglet Documents de la tâche liste le disque, il n'est pas impacté.

## Fichiers modifiés

- `class/actions_digiriskdolibarr.class.php`
- `langs/fr_FR/digiriskdolibarr.lang`
- `langs/en_US/digiriskdolibarr.lang`

## Issue

#4926
