### PR TITLE
#4928 [ActionPlan] feat: displayed project selector with cookie memory

### DIFF
--- a/core/tpl/actionplan/actionplan_list_gantt.tpl.php
+++ b/core/tpl/actionplan/actionplan_list_gantt.tpl.php
@@ -7,7 +7,7 @@
  * Variables expected from calling PHP:
  * - $tasksJson   array  Task data (enriched)
  * - $langs       Translate
- * - $projectId   int    DU project ID
+ * - $projectId   int    Displayed project ID
  */
 
 // Create clean data for Gantt JS (without HTML fields like risk_nomurl)

--- a/core/tpl/actionplan/actionplan_list_kanban.tpl.php
+++ b/core/tpl/actionplan/actionplan_list_kanban.tpl.php
@@ -10,7 +10,7 @@
  * - $globalProgress     int    Global PAPRIPACT progress (average of all task percentages)
  * - $globalTaskCount    int    Total number of corrective actions
  * - $langs              Translate
- * - $projectId          int    DU project ID
+ * - $projectId          int    Displayed project ID
  */
 
 // Number of cards rendered live per column; the rest are lazy-loaded by the JS module

--- a/core/tpl/actionplan/actionplan_project_selector.tpl.php
+++ b/core/tpl/actionplan/actionplan_project_selector.tpl.php
@@ -1,0 +1,66 @@
+<?php
+/* Copyright (C) 2021-2026 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    core/tpl/actionplan/actionplan_project_selector.tpl.php
+ * \ingroup digiriskdolibarr
+ * \brief   Displayed project banner and project switcher for the action plan
+ *
+ * Variables expected from calling PHP:
+ * - $project     Project     Currently displayed project (fetched, may be empty)
+ * - $projectId   int         Currently displayed project ID
+ * - $duProjectId int         Document Unique project ID (default project)
+ * - $formproject FormProjets Dolibarr project form helper
+ * - $view        string      Current view ('kanban' or 'gantt')
+ * - $langs       Translate
+ */
+
+// Keep the menu highlighted after the switch (the selector reloads the page)
+$menuMain = GETPOST('mainmenu', 'aZ09');
+$menuLeft = GETPOST('leftmenu', 'aZ09');
+$menuId   = GETPOSTINT('idmenu');
+?>
+
+<div class="actionplan-project-bar">
+    <div class="app-project-current">
+        <i class="fas fa-project-diagram"></i>
+        <span class="app-project-caption"><?php echo $langs->trans('ActionPlanDisplayedProject'); ?></span>
+        <?php if ($projectId > 0 && $project->id > 0) : ?>
+            <?php echo $project->getNomUrl(1); ?>
+            <span class="app-project-title"><?php echo dol_escape_htmltag($project->title); ?></span>
+            <?php if ($projectId == $duProjectId) : ?>
+                <span class="app-project-badge"><?php echo $langs->trans('ActionPlanDefaultProject'); ?></span>
+            <?php endif; ?>
+        <?php else : ?>
+            <span class="app-project-none"><?php echo $langs->trans('ActionPlanNoProjectConfigured'); ?></span>
+        <?php endif; ?>
+    </div>
+    <form class="app-project-form" method="GET" action="<?php echo $_SERVER['PHP_SELF']; ?>">
+        <input type="hidden" name="view" value="<?php echo dol_escape_htmltag($view); ?>">
+        <?php if (!empty($menuMain)) : ?>
+            <input type="hidden" name="mainmenu" value="<?php echo dol_escape_htmltag($menuMain); ?>">
+        <?php endif; ?>
+        <?php if (!empty($menuLeft)) : ?>
+            <input type="hidden" name="leftmenu" value="<?php echo dol_escape_htmltag($menuLeft); ?>">
+        <?php endif; ?>
+        <?php if ($menuId > 0) : ?>
+            <input type="hidden" name="idmenu" value="<?php echo $menuId; ?>">
+        <?php endif; ?>
+        <label for="projectid"><i class="fas fa-exchange-alt"></i> <?php echo $langs->trans('ActionPlanChangeProject'); ?></label>
+        <?php $formproject->select_projects(-1, $projectId, 'projectid', 0, 0, 0, 0, 0, 0, 0, '', 0, 1, 'maxwidth300'); ?>
+    </form>
+</div>

--- a/css/scss/page/_page-actionplan.scss
+++ b/css/scss/page/_page-actionplan.scss
@@ -92,6 +92,95 @@
 }
 
 /* =============================================
+ * DISPLAYED PROJECT BAR (info + switcher)
+ * ============================================= */
+
+.actionplan-project-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 12px;
+    background: #fff;
+    border: 1px solid #e0e0e0;
+    border-radius: 10px;
+    padding: 10px 16px;
+    margin-bottom: 12px;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+
+.app-project-current {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+    font-size: 13px;
+    color: #333;
+
+    > i {
+        color: #3085d6;
+        font-size: 15px;
+    }
+
+    a {
+        font-weight: 700;
+    }
+}
+
+.app-project-caption {
+    color: #888;
+    text-transform: uppercase;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.4px;
+}
+
+.app-project-title {
+    font-weight: 600;
+}
+
+.app-project-badge {
+    background: #eef4fc;
+    color: #3085d6;
+    border: 1px solid #cfe0f5;
+    border-radius: 12px;
+    padding: 2px 10px;
+    font-size: 11px;
+    font-weight: 700;
+}
+
+.app-project-none {
+    color: #e05353;
+    font-weight: 600;
+}
+
+.app-project-form {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0;
+
+    label {
+        font-size: 11px;
+        font-weight: 600;
+        color: #666;
+        white-space: nowrap;
+
+        i {
+            color: #999;
+            margin-right: 3px;
+        }
+    }
+}
+
+@media (max-width: 767px) {
+    .actionplan-project-bar {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+}
+
+/* =============================================
  * KANBAN SETTINGS
  * ============================================= */
 

--- a/js/modules/actionplan_project.js
+++ b/js/modules/actionplan_project.js
@@ -1,0 +1,37 @@
+/**
+ * Action plan — displayed project switcher
+ *
+ * @memberof digiriskdolibarr
+ */
+window.digiriskdolibarr.actionplanProject = {};
+
+/**
+ * Init — auto-called by saturne.js on document.ready
+ */
+window.digiriskdolibarr.actionplanProject.init = function() {
+    if (!$('.actionplan-project-bar').length) {
+        return;
+    }
+    window.digiriskdolibarr.actionplanProject.event();
+};
+
+/**
+ * Register delegated events
+ */
+window.digiriskdolibarr.actionplanProject.event = function() {
+    $(document).on('change', '.app-project-form select, .app-project-form input[name="projectid"]', window.digiriskdolibarr.actionplanProject.reload);
+};
+
+/**
+ * Reload the action plan on the newly selected project — the server stores the
+ * choice in a cookie, so the next visits reopen the same project
+ *
+ * @return {void}
+ */
+window.digiriskdolibarr.actionplanProject.reload = function() {
+    var projectId = $(this).val();
+    if (!projectId || parseInt(projectId, 10) <= 0) {
+        return;
+    }
+    $(this).closest('form').trigger('submit');
+};

--- a/langs/fr_FR/digiriskdolibarr.lang
+++ b/langs/fr_FR/digiriskdolibarr.lang
@@ -1724,6 +1724,10 @@ ColumnGap                          = Espacement
 ActionPlanExportCsv                = Télécharger le PAPRIPACT au format CSV
 ActionPlanExportA3                 = Télécharger le PAPRIPACT en PDF A3 paysage
 ActionPlanExportGantt              = Télécharger le diagramme de Gantt en image PNG
+ActionPlanDisplayedProject         = Projet affiché
+ActionPlanChangeProject            = Changer de projet
+ActionPlanDefaultProject           = Document Unique (par défaut)
+ActionPlanNoProjectConfigured      = Aucun projet configuré
 
 # ActionPlan — ActionComm Logging
 ActionPlanLogging                  = Plan d'Action — Historique des modifications

--- a/view/digiriskstandard/actionplan_list.php
+++ b/view/digiriskstandard/actionplan_list.php
@@ -32,7 +32,9 @@ if (file_exists('../digiriskdolibarr.main.inc.php')) {
 
 // Load Dolibarr libraries
 require_once DOL_DOCUMENT_ROOT . '/projet/class/task.class.php';
+require_once DOL_DOCUMENT_ROOT . '/projet/class/project.class.php';
 require_once DOL_DOCUMENT_ROOT . '/categories/class/categorie.class.php';
+require_once DOL_DOCUMENT_ROOT . '/core/class/html.formprojet.class.php';
 
 // Load Saturne libraries
 require_once __DIR__ . '/../../../saturne/class/task/saturnetask.class.php';
@@ -57,15 +59,56 @@ if (empty($view) || !in_array($view, ['gantt', 'kanban'])) {
 }
 
 // Initialize technical objects
-$object  = new DigiriskStandard($db);
-$task    = new SaturneTask($db);
-$risk    = new Risk($db);
+$object      = new DigiriskStandard($db);
+$task        = new SaturneTask($db);
+$risk        = new Risk($db);
+$project     = new Project($db);
+$formproject = new FormProjets($db);
 
 $hookmanager->initHooks(['actionplanlist', 'globalcard']);
 
 // Load object
 $object->fetch(0, '', ' AND t.entity = ' . $conf->entity);
-$projectId = getDolGlobalInt('DIGIRISKDOLIBARR_DU_PROJECT');
+
+// Displayed project — the Document Unique project stays the default, but the user
+// can switch to any other project he is allowed to read. The last choice is kept in
+// an entity-scoped cookie so coming back on the page reopens the same project.
+$duProjectId       = getDolGlobalInt('DIGIRISKDOLIBARR_DU_PROJECT');
+$projectCookieName = 'digiriskdolibarr_actionplan_project_' . $conf->entity;
+$askedProjectId    = GETPOSTINT('projectid');
+$isExplicitChoice  = ($askedProjectId > 0);
+
+if (!$isExplicitChoice && !empty($_COOKIE[$projectCookieName])) {
+    $askedProjectId = (int) $_COOKIE[$projectCookieName];
+}
+
+// The Document Unique project is always allowed (historical behaviour of this page),
+// any other one must be visible from the current entity and readable by the user
+$allowedEntities = array_map('intval', explode(',', getEntity('project')));
+if ($askedProjectId > 0 && $project->fetch($askedProjectId) > 0
+    && ($askedProjectId == $duProjectId
+        || (in_array((int) $project->entity, $allowedEntities, true) && $project->restrictedProjectArea($user, 'read') > 0))) {
+    $projectId = $askedProjectId;
+} else {
+    // Deleted, forbidden or not configured project — fall back on the Document Unique
+    $project   = new Project($db);
+    $projectId = $duProjectId;
+    if ($projectId > 0) {
+        $project->fetch($projectId);
+    }
+}
+
+// Persist the choice for the next visits (kept in sync when the stored value is stale)
+if ($projectId > 0 && ($isExplicitChoice || (int) ($_COOKIE[$projectCookieName] ?? 0) != $projectId)) {
+    setcookie($projectCookieName, (string) $projectId, [
+        'expires'  => dol_now() + 365 * 24 * 3600,
+        'path'     => '/',
+        'secure'   => !empty($_SERVER['HTTPS']),
+        'httponly' => true,
+        'samesite' => 'Lax',
+    ]);
+    $_COOKIE[$projectCookieName] = (string) $projectId;
+}
 
 // Security check
 $permissiontoread = $user->hasRight('digiriskdolibarr', 'riskassessmentdocument', 'read');
@@ -987,6 +1030,9 @@ print dol_get_fiche_head($head, $view, $title, -1, 'task');
 
 // Top-right export toolbar (CSV / PAPRIPACT A3 PDF / Gantt PNG), shared by both views
 require __DIR__ . '/../../core/tpl/actionplan/actionplan_export_buttons.tpl.php';
+
+// Displayed project banner + project switcher, shared by both views
+require __DIR__ . '/../../core/tpl/actionplan/actionplan_project_selector.tpl.php';
 
 // Include appropriate TPL
 if ($view === 'kanban') {


### PR DESCRIPTION
## Changements

- **Projet affiché résolu côté serveur** dans `actionplan_list.php`, par ordre de priorité : paramètre `projectid` de l'URL → cookie → projet du Document Unique. Le comportement par défaut reste donc inchangé.
- **Mémorisation du dernier projet choisi** dans le cookie `digiriskdolibarr_actionplan_project_<entite>` (1 an, `HttpOnly`, `SameSite=Lax`). Le cookie est scopé par entité pour rester correct en multicompany. Choix d'un cookie plutôt que d'un `localStorage` (utilisé pour l'onglet actif du Kanban ticket) car le projet doit être connu par PHP avant le chargement des tâches, sinon la page afficherait le projet par défaut puis rechargerait.
- **Nouveau bandeau** `core/tpl/actionplan/actionplan_project_selector.tpl.php`, affiché pour les deux vues sous les boutons d'export : « Projet affiché : REF – Titre » avec lien vers la fiche projet, badge « Document Unique (par défaut) » quand c'est le projet du DU, et sélecteur `select_projects` à droite. Les paramètres `mainmenu` / `leftmenu` / `idmenu` sont repassés pour garder le menu surligné après le rechargement.
- **Contrôle d'accès** : hors projet du Document Unique, le projet demandé doit être visible depuis l'entité courante et passer `restrictedProjectArea($user, 'read')`. Projet supprimé, d'une autre entité ou interdit → retour silencieux sur le projet du Document Unique.
- **Nouveau module JS** `actionplanProject` : soumet le formulaire au `change` du sélecteur (gère aussi le mode autocomplete si `PROJECT_USE_SEARCH_TO_SELECT` est activé). Aucun JS inline.
- **SCSS** : bloc `.actionplan-project-bar`, même style carte que la barre de progression globale, empilé en colonne sous 767px.
- Les exports (CSV, PDF A3 PAPRIPACT) et les actions AJAX du Kanban suivent automatiquement le projet affiché.

## Fichiers modifiés

- `view/digiriskstandard/actionplan_list.php`
- `core/tpl/actionplan/actionplan_project_selector.tpl.php` (nouveau)
- `core/tpl/actionplan/actionplan_list_kanban.tpl.php` (commentaire d'en-tête)
- `core/tpl/actionplan/actionplan_list_gantt.tpl.php` (commentaire d'en-tête)
- `js/modules/actionplan_project.js` (nouveau)
- `css/scss/page/_page-actionplan.scss`
- `langs/fr_FR/digiriskdolibarr.lang`

## Tests

- Lint PHP OK sur les fichiers modifiés, compilation gulp (`scss_core`, `js_backend`) OK.
- Vérification visuelle en local non effectuée (accès au Dolibarr de test indisponible).

## Issue

#4928
