### PR TITLE
#4584 [Module] fix: no more fatal error on module list when Saturne is missing

### DIFF
--- a/core/modules/modDigiriskDolibarr.class.php
+++ b/core/modules/modDigiriskDolibarr.class.php
@@ -346,6 +346,11 @@ class modDigiriskdolibarr extends DolibarrModules
 	public $dictionaries = [];
 
 	/**
+	 * @var bool Whether the Saturne module files are available on the filesystem.
+	 */
+	public $saturneAvailable;
+
+	/**
 	 * Constructor. Define names, constants, directories, boxes, permissions
 	 *
 	 * @param DoliDB $db Database handler
@@ -356,7 +361,9 @@ class modDigiriskdolibarr extends DolibarrModules
 
 		$this->db = $db;
 
-		if (file_exists(__DIR__ . '/../../../saturne/lib/saturne_functions.lib.php')) {
+		$this->saturneAvailable = file_exists(__DIR__ . '/../../../saturne/lib/saturne_functions.lib.php');
+
+		if ($this->saturneAvailable) {
 			require_once __DIR__ . '/../../../saturne/lib/saturne_functions.lib.php';
 			saturne_load_langs(['digiriskdolibarr@digiriskdolibarr']);
 		} else {
@@ -1936,6 +1943,11 @@ class modDigiriskdolibarr extends DolibarrModules
 		$this->export_sql_end[$r] .= ' WHERE cat.entity IN ('.getEntity('category').')';
 		$this->export_sql_end[$r] .= ' AND cat.type = 12';
 
+        // Export and import profiles below load Digirisk classes that all extend SaturneObject : without Saturne they raise an uncatchable fatal error that breaks the whole module list page.
+        if (!$this->saturneAvailable) {
+            return;
+        }
+
         $objectMetaDatas = [
             'digiriskelement'       => ['langs' => 'DigiriskElement',       'picto' => 'fontawesome_fa-network-wired_fas_#d35968'],
             'risk'                  => ['langs' => 'Risk',                  'picto' => 'fontawesome_fa-exclamation-triangle_fas_#d35968', 'classPath' => 'riskanalysis'],
@@ -2132,6 +2144,12 @@ class modDigiriskdolibarr extends DolibarrModules
 		global $conf, $langs, $user;
 
 		$langs->load("digiriskdolibarr@digiriskdolibarr");
+
+        // Digirisk cannot run without the Saturne framework : refuse the activation instead of breaking every page of the Dolibarr instance.
+        if (!$this->saturneAvailable) {
+            $this->error = $langs->trans('SaturneModuleMissing');
+            return 0;
+        }
 
         if (empty($conf->global->DIGIRISKDOLIBARR_ACCIDENT_REMOVE_FK_USER_VICTIM)) {
 

--- a/langs/en_US/digiriskdolibarr.lang
+++ b/langs/en_US/digiriskdolibarr.lang
@@ -192,3 +192,6 @@ ConfirmMassValidateTasksQuestion = Are you sure you want to validate the %s sele
 ConfirmMassChangeTasksProjectQuestion = Are you sure you want to attach the %s selected task(s) to the chosen project?
 MassValidateTasksSuccess = %s task(s) validated out of %s selected
 MassChangeTasksProjectSuccess = %s task(s) attached to project %s
+
+# Missing Saturne module
+SaturneModuleMissing = The Saturne module is required by Digirisk. Download it for free on the Dolistore (https://dolistore.com/en/modules/1906-Saturne.html) and install it before enabling Digirisk.

--- a/langs/fr_FR/digiriskdolibarr.lang
+++ b/langs/fr_FR/digiriskdolibarr.lang
@@ -23,6 +23,9 @@ ModuleDigiriskdolibarrName = Digirisk
 # Module description 'ModuleDigiriskdolibarrDesc'
 ModuleDigiriskdolibarrDesc = Digirisk pour Dolibarr
 
+# Module Saturne manquant
+SaturneModuleMissing = Le module Saturne est requis par Digirisk. Téléchargez-le gratuitement sur le Dolistore (https://dolistore.com/fr/modules/1906-Saturne.html) et installez-le avant d'activer Digirisk.
+
 #
 # Page d'administration
 #


### PR DESCRIPTION
Closes #4584

## Problème

Sur une installation vierge, installer Digirisk **sans** Saturne rendait la page `admin/modules.php` entièrement blanche : impossible d'installer le moindre module, Saturne compris. L'installation était dans une impasse.

```
Fatal error: Uncaught Error: Failed opening required
'.../custom/digiriskdolibarr/class/../../saturne/class/saturneobject.class.php'
in .../digiriskelement.class.php:28
#2 .../modDigiriskDolibarr.class.php(1966): require(...)
#3 .../admin/modules.php(548): modDigiriskdolibarr->__construct(...)
```

## Cause

Le constructeur du descripteur construit ses profils d'export/import via `core/commonfieldsinexport.inc.php` et `core/commonfieldsinimport.inc.php`, qui chargent les classes Digirisk — toutes héritent de `SaturneObject`. Sans Saturne, le `require_once` provoque un fatal non rattrapable (le `try/catch` de `admin/modules.php` n'attrape que `Exception`), et comme cette page instancie **tous** les descripteurs, la page entière meurt.

## Correctif

- `$saturneAvailable` : le `file_exists()` déjà présent en tête de constructeur est mémorisé dans une propriété.
- Constructeur : `return` anticipé avant les profils export/import si Saturne est absent (les profils catégories/tickets, qui ne chargent aucune classe Digirisk, restent en place).
- `init()` : refus de l'activation avec un message explicite renvoyant vers le Dolistore. `activateModule()` appelle `init()` **avant** d'écrire la constante d'activation, donc le module reste désactivé. C'est volontaire : Digirisk activé sans Saturne rendrait *toutes* les pages de Dolibarr blanches (menus + hooks), donc pire que le bug initial.
- Nouvelle clé de langue `SaturneModuleMissing` (fr_FR + en_US) avec le lien Dolistore.

## Tests

Instance locale Dolibarr 23.0.3 avec Digirisk seul (pas de Saturne) :

| | avant | après |
|---|---|---|
| Instanciation du descripteur | fatal `require_once saturneobject.class.php` | OK, `saturneAvailable = false`, profils export/import ignorés |
| `init()` | fatal | retourne `0`, message Dolistore, constante d'activation non écrite |
| `admin/modules.php` | page blanche | s'affiche normalement |

## Note

`modEasyURL.class.php` présente le même bug latent (`commonfieldsinexport.inc.php` dans son constructeur, classes héritant de `SaturneObject`) — à traiter côté EasyURL.