### PR TITLE
#4617 [PreventionPlan] fix: filter list join on active ExtSociety resource

### DIFF
--- a/view/preventionplan/preventionplan_list.php
+++ b/view/preventionplan/preventionplan_list.php
@@ -282,7 +282,8 @@ $sql       .= " FROM " . MAIN_DB_PREFIX . $object->table_element . " as t";
 
 if (isset($extrafields->attributes[$object->table_element]['label']) &&
     is_array($extrafields->attributes[$object->table_element]['label']) && count($extrafields->attributes[$object->table_element]['label'])) $sql .= " LEFT JOIN " . MAIN_DB_PREFIX . $object->table_element . "_extrafields as ef on (t.rowid = ef.fk_object)";
-$sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'digiriskdolibarr_digiriskresources as rs ON rs.ref = "ExtSociety" AND rs.object_type = "preventionplan" AND rs.object_id = t.rowid';
+// Only join the active resource: setDigiriskResources keeps previous ones with status = 0, they would duplicate the object row
+$sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'digiriskdolibarr_digiriskresources as rs ON rs.ref = "ExtSociety" AND rs.object_type = "preventionplan" AND rs.object_id = t.rowid AND rs.status = 1';
 
 if ($object->ismultientitymanaged == 1) $sql                                                                                                      .= " WHERE t.entity IN (" . getEntity($object->element) . ")";
 else $sql                                                                                                                                         .= " WHERE 1 = 1";


### PR DESCRIPTION
Closes #4617

## Problème

Sur la liste des plans de prévention, un plan pouvait apparaître **deux fois** (PP3 sur la demo), et le compteur d'entête était gonflé d'autant.

## Cause

`DigiriskResources::setDigiriskResources()` fonctionne en versionnage : à chaque modification, les anciennes lignes passent à `status = 0` et une nouvelle ligne `status = 1` est insérée. La table `llx_digiriskdolibarr_digiriskresources` conserve donc l'historique.

Le `LEFT JOIN` ajouté en #4153 pour le filtre « Entreprise Extérieure » ne filtrait pas `rs.status` → chaque ligne historique multipliait la ligne du plan de prévention.

`fetchResourcesFromObject()` filtre bien `status = 1`, d'où deux lignes affichant exactement les mêmes données.

## Correctif

Ajout de `AND rs.status = 1` sur la condition de jointure. Corrige au passage un second bug : le filtre « Entreprise Extérieure » remontait les plans sur leur **ancienne** entreprise extérieure.

## Tests

Reproduit en local (base `dolibarr_22_evarisk`, Dolibarr 23.0.3) avec un plan `TESTDUP1` ayant 1 ressource `ExtSociety` obsolète + 1 active, et un témoin `TESTDUP2` sans historique :

| | avant | après |
|---|---|---|
| lignes affichées | 3 (TESTDUP1 ×2) | 2 |
| compteur d'entête | (3) | (2) |
| filtre sur la société **obsolète** | TESTDUP1 (faux positif) | aucun résultat |
| filtre sur la société **active** | TESTDUP1 | TESTDUP1 |

Vérifié aussi en SQL sur le jeu de données de la demo (base `dolibarr_23`) : 21 lignes retournées avant, 20 après, pour 20 plans de prévention réels.

Aucun nettoyage de données nécessaire : les lignes `status = 0` sont légitimes (historique).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
