### PR TITLE
#4908 [Ticket] fix: array_filter type error on public ticket creation

### DIFF
--- a/public/ticket/create_ticket.php
+++ b/public/ticket/create_ticket.php
@@ -132,9 +132,9 @@ if (empty($resHook)) {
         $ticketTmpId  = GETPOST('ticket_id');
 
         $mainCategoryObject              = $category->rechercher($conf->global->DIGIRISKDOLIBARR_TICKET_MAIN_CATEGORY, '', 'ticket', true);
-        $mainCategoryExtrafields         = json_decode($mainCategoryObject[0]->array_options['options_ticket_category_config'], true);
-        $mainCategoryChildrenExtrafields = new StdClass();
-        $subCategoryExtrafields          = new StdClass();
+        $mainCategoryExtrafields         = json_decode($mainCategoryObject[0]->array_options['options_ticket_category_config'] ?? '', true);
+        $mainCategoryChildrenExtrafields = [];
+        $subCategoryExtrafields          = [];
         $mainCategoryChildrenItem        = null;
 
         if ( ! empty($mainCategoryObject) && $mainCategoryObject > 0) {
@@ -160,7 +160,7 @@ if (empty($resHook)) {
                 }
             }
         }
-        $config = array_merge(array_filter($mainCategoryExtrafields ?? []), array_filter($mainCategoryChildrenExtrafields ?? []), array_filter($subCategoryExtrafields ?? []));
+        $config = array_merge(array_filter((array) $mainCategoryExtrafields), array_filter((array) $mainCategoryChildrenExtrafields), array_filter((array) $subCategoryExtrafields));
 
         // Check parameters
         if (empty($parentCategoryId)) {


### PR DESCRIPTION
## Contexte

La création d'un ticket depuis l'interface publique renvoie une erreur 500. L'iframe échoue, Chrome affiche sa page d'erreur interne, et le JS parent qui tente d'y accéder loggue `Unsafe attempt to load URL`.

## Cause

Dans le bloc `action == 'add'`, les configs de catégorie sont décodées en **tableaux** (`json_decode(..., true)`), mais `$mainCategoryChildrenExtrafields` et `$subCategoryExtrafields` sont initialisées avec `new StdClass()`.

Si aucune sous-catégorie ne matche, elles conservent leur type `stdClass` et `array_filter()` lève un `TypeError` en PHP 8 (PHP 7 se contentait d'un warning) :

```
TypeError : array_filter(): Argument #1 ($array) must be of type array, stdClass given
```

## Changements

- Initialisation de `$mainCategoryChildrenExtrafields` et `$subCategoryExtrafields` en tableau vide, cohérent avec le mode tableau de `json_decode`
- Cast `(array)` dans `array_merge` comme garde-fou : `json_decode` renvoie `null` quand l'extrafield de config de catégorie est vide
- Ajout de `?? ''` sur la lecture de la config de la catégorie principale pour éviter les warnings quand la catégorie n'est pas trouvée

## Fichiers modifiés

- `public/ticket/create_ticket.php`

## Test

Reproduit en PHP 8.1 avant / après le correctif :

```
AVANT : TypeError : array_filter(): Argument #1 ($array) must be of type array, stdClass given
APRES : OK
```

## Issue

#4908
