### PR TITLE
#4449 [Dashboard] fix: wrap-safe cells in risk lists by danger categories

### DIFF
--- a/class/riskanalysis/risk.class.php
+++ b/class/riskanalysis/risk.class.php
@@ -1167,11 +1167,13 @@ class Risk extends SaturneObject
             $arrayRiskLists[$dangerCategory['position']]['numberOfRisks']['value']    = $riskByDangerCategoriesAndRiskAssessments[$dangerCategory['name']]['risk'];
             $arrayRiskLists[$dangerCategory['position']]['numberOfRisks']['value']   .= ($percentage > 0 ? ' (' . $percentage . ' %)' : '');
             $arrayRiskLists[$dangerCategory['position']]['numberOfRisks']['morecss']  = 'risk-evaluation-cotation';
-            $arrayRiskLists[$dangerCategory['position']]['numberOfRisks']['moreAttr'] = 'style="line-height: 0; border-radius: 0; background-color: #A1467EAA; color: #FFF;"';
+            $arrayRiskLists[$dangerCategory['position']]['numberOfRisks']['moreAttr'] = 'style="line-height: normal; height: auto; border-radius: 0; background-color: #A1467EAA; color: #FFF;"';
 
-            $arrayRiskLists[$dangerCategory['position']]['Ref']['value']    = '<img src="' . dol_buildpath('digiriskdolibarr/img/categorieDangers/' . $dangerCategory['thumbnail_name'] . '.png', 1) . '" class="photo" alt="' . $dangerCategory['name'] . '" title="' . $dangerCategory['name'] . '" loading="lazy" width="24px" height="24px" />';
-            $arrayRiskLists[$dangerCategory['position']]['Ref']['value']   .= $dangerCategory['name'];
-            $arrayRiskLists[$dangerCategory['position']]['Ref']['moreAttr'] = 'style="display: flex; align-items: center; max-width: 100%; gap: 5px;"';
+            // Le conteneur flex est un div interne : un td en display: flex sort du flux table-cell et son contenu déborde sur les lignes voisines quand il passe sur plusieurs lignes (mobile)
+            $arrayRiskLists[$dangerCategory['position']]['Ref']['value']  = '<div style="display: flex; align-items: center; max-width: 100%; gap: 5px;">';
+            $arrayRiskLists[$dangerCategory['position']]['Ref']['value'] .= '<img src="' . dol_buildpath('digiriskdolibarr/img/categorieDangers/' . $dangerCategory['thumbnail_name'] . '.png', 1) . '" class="photo" alt="' . $dangerCategory['name'] . '" title="' . $dangerCategory['name'] . '" loading="lazy" width="24px" height="24px" />';
+            $arrayRiskLists[$dangerCategory['position']]['Ref']['value'] .= '<span>' . $dangerCategory['name'] . '</span>';
+            $arrayRiskLists[$dangerCategory['position']]['Ref']['value'] .= '</div>';
 
             for ($i = 1; $i <= 4; $i++) {
                 $array['labels'][$i] = $this->cotations[$i]['label'];
@@ -1183,13 +1185,13 @@ class Risk extends SaturneObject
                 $totalNbRiskAssessments[$i]                                 += $riskByDangerCategoriesAndRiskAssessments[$dangerCategory['name']]['riskAssessments'][$i];
                 $arrayRiskLists[$dangerCategory['position']][$i]['value']   .= ($percentage > 0 ? ' (' . $percentage . ' %)' : '');
                 $arrayRiskLists[$dangerCategory['position']][$i]['morecss']  = 'risk-evaluation-cotation';
-                $arrayRiskLists[$dangerCategory['position']][$i]['moreAttr'] = 'data-scale = ' . $i . ' style="line-height: 0; border-radius: 0;"';
+                $arrayRiskLists[$dangerCategory['position']][$i]['moreAttr'] = 'data-scale = ' . $i . ' style="line-height: normal; height: auto; border-radius: 0;"';
             }
         }
 
         $arrayRiskLists[23]['numberOfRisks']['value']    = '<span class="badge badge-info">' . $riskByDangerCategoriesAndRiskAssessments['totalRisks'] . '</span>';
         $arrayRiskLists[23]['numberOfRisks']['morecss']  = 'risk-evaluation-cotation';
-        $arrayRiskLists[23]['numberOfRisks']['moreAttr'] = 'style="line-height: 0; border-radius: 0; background-color: #A1467EAA; color: #FFF;"';
+        $arrayRiskLists[23]['numberOfRisks']['moreAttr'] = 'style="line-height: normal; height: auto; border-radius: 0; background-color: #A1467EAA; color: #FFF;"';
         $arrayRiskLists[23]['numberOfRisks']['value']   .= ' (' . round($totalPercentages) . ' %)';
 
         $arrayRiskLists[23]['Ref']['value']              = $langs->transnoentities('Total');
@@ -1198,7 +1200,7 @@ class Risk extends SaturneObject
         for ($i = 1; $i <= 4; $i++) {
             $arrayRiskLists[23][$i]['value']    = $totalNbRiskAssessments[$i] . ' (' . round($totalPercentagesRiskAssessment[$i]) . ' %)';
             $arrayRiskLists[23][$i]['morecss']  = 'risk-evaluation-cotation';
-            $arrayRiskLists[23][$i]['moreAttr'] = 'data-scale = ' . $i . ' style="line-height: 0; border-radius: 0;"';
+            $arrayRiskLists[23][$i]['moreAttr'] = 'data-scale = ' . $i . ' style="line-height: normal; height: auto; border-radius: 0;"';
         }
 
         $array['data'] = $arrayRiskLists;


### PR DESCRIPTION
Closes #4449

## Problème

Sur mobile (iPhone SE / Chrome, portrait), les textes du tableau « Liste des risques par catégorie de danger » se superposent et débordent sur les lignes voisines.

Deux styles inline ne tiennent que si le contenu reste sur **une seule ligne** :

- `line-height: 0` sur les cellules de cotation (pour neutraliser le `line-height: 50px` de `.risk-evaluation-cotation`) → dès que « 4 (12.9 %) » se replie, les deux lignes se dessinent au même endroit ;
- `display: flex` sur le `<td>` du libellé → le `td` sort du flux `table-cell`, sa hauteur ne compte plus dans la ligne et son texte déborde sur les lignes du dessus/dessous.

Sur desktop c'est masqué : `SaturneDashboard::show_dashboard()` ajoute `nowraponall tdoverflowmax200` uniquement quand `$conf->browser->layout == 'classic'`. Sur mobile ces classes sautent, le texte se replie, et les deux hacks cassent.

## Correctif

- `line-height: normal; height: auto` à la place de `line-height: 0` (4 emplacements, lignes de données et ligne de total) ;
- le conteneur flex du libellé passe du `<td>` à un `<div>` interne.

## Vérification

Mesuré avec Playwright (viewport iPhone SE, UA mobile) sur le dashboard Digirisk :

| | avant | après |
|---|---|---|
| cellules dont le contenu déborde | 22 | 0 |
| cellules à `line-height: 0` | 115 | 0 |
| `<td>` en `display: flex` | 22 | 0 |

Rendu desktop inchangé (libellés complets, mêmes colonnes), à l'exception de lignes ~9 px plus hautes puisque le `line-height` n'est plus nul.

À compléter par la PR Saturne associée (conteneur scrollable) pour que le tableau ne fasse plus déborder la page entière sur mobile.
