### PR TITLE
#4497 [DU] fix: duplicate ODT manifest entries from leftover segment picto

### DIFF
--- a/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/riskassessmentdocument/doc_riskassessmentdocument_odt.modules.php
+++ b/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/riskassessmentdocument/doc_riskassessmentdocument_odt.modules.php
@@ -301,6 +301,10 @@ class doc_riskassessmentdocument_odt extends ModeleODTDigiriskDolibarrDocument
                 $tmpArray[$entityTag . $totalNbRiskByRiskAssessmentCotationType[$riskAssessmentCotationType]['tmpArrayName']] = $totalNbRiskByRiskAssessmentCotationType[$riskAssessmentCotationType]['value'] ?: 0; // Total number by cotation type
             }
 
+            // Drop the segment-only picto left by the loop above: at document level it would register the
+            // last category image a second time and duplicate its entry in the ODT manifest (invalid ODF)
+            unset($tmpArray['picto']);
+
             static::setTmpArrayVars($tmpArray, $odfHandler, $outputLangs, false);
         }
     }
@@ -403,6 +407,10 @@ class doc_riskassessmentdocument_odt extends ModeleODTDigiriskDolibarrDocument
             foreach ($riskAssessmentCotationTypes as $riskAssessmentCotationType) {
                 $tmpArray[$entityTag . $totalNbRiskByRiskAssessmentCotationType[$riskAssessmentCotationType]['tmpArrayName']] = $totalNbRiskByRiskAssessmentCotationType[$riskAssessmentCotationType]['value'] ?: 0; // Total number by cotation type
             }
+
+            // Drop the segment-only picto left by the loop above: at document level it would register the
+            // last category image a second time and duplicate its entry in the ODT manifest (invalid ODF)
+            unset($tmpArray['picto']);
 
             static::setTmpArrayVars($tmpArray, $odfHandler, $outputLangs, false);
         }


### PR DESCRIPTION
Refs #4497

## Problème

Tous les Documents Uniques générés contiennent deux `manifest:file-entry` en double dans `META-INF/manifest.xml` (`Pictures/autre_PictoCategorie_v2.png` et `Pictures/rps_v2.png`) — un `full-path` dupliqué rend le paquet ODF invalide.

## Cause

`setRiskByCategoriesSegment()` et `setPsychosocialRiskByCategoriesSegment()` passent leur `$tmpArray` encore rempli à l'appel `setTmpArrayVars(..., $odfHandler, ..., false)` de niveau document. Le `picto` laissé par la dernière itération de la boucle est donc réenregistré une seconde fois comme image de niveau document, et `Odf::_save()` l'ajoute au manifeste sans dédoublonner — contrairement à `Segment::merge()`, qui teste `getFromName()` avant d'ajouter.

D'où exactement les deux doublons observés : la dernière catégorie de la première boucle et l'unique catégorie (RPS) de la seconde.

## Correctif

`unset($tmpArray['picto'])` avant les deux appels de niveau document.

## Vérification

DU régénéré avec le correctif :

| | avant | après |
|---|---|---|
| Doublons manifeste | 2 | **0** |
| Images référencées absentes du zip | 0 | 0 |
| Ouverture LibreOffice | OK | OK, sans erreur de décodage |

## Portée

Ceci supprime une violation réelle de la spec ODF, mais ne referme pas #4497 à soi seul : j'ai vérifié que ces doublons **ne déclenchent pas** la réparation LibreOffice (« document réparé ») visible sur la capture de l'issue. La corruption constatée sur la démo est d'un niveau supérieur (paquet zip endommagé) et reste à confirmer sur le fichier fautif. L'issue reste donc ouverte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
