### PR TITLE
#4358 [Arborescence] fix: use mini thumb format for the 40x40 element photo

### DIFF
--- a/lib/digiriskdolibarr_function.lib.php
+++ b/lib/digiriskdolibarr_function.lib.php
@@ -427,7 +427,7 @@ function display_recurse_tree($digiriskElementTree, $i = 1)
                 <span class="open-media-gallery add-media modal-open photo-container digirisk-element-photo-<?php echo $obj->id; ?>" value="0">
                     <input type="hidden" class="modal-options" data-modal-to-open="media_gallery" data-from-id="<?php echo $obj->id; ?>" data-from-type="<?php echo $type; ?>" data-from-subtype="photo" data-from-subdir="" data-photo-class="digirisk-element-photo-<?php echo $obj->id; ?>"/>
                     <?php
-                    $mediaOutput = saturne_show_medias_linked('digiriskdolibarr', $conf->digiriskdolibarr->multidir_output[$conf->entity] . '/' . $type . '/' . $obj->ref, 'small', 1, 0, 0, 0, 40, 40, 1, 0, 0, $type . '/' . $obj->ref, $obj, 'photo', 0, 0, 0, 1, 'cursorpointer');
+                    $mediaOutput = saturne_show_medias_linked('digiriskdolibarr', $conf->digiriskdolibarr->multidir_output[$conf->entity] . '/' . $type . '/' . $obj->ref, 'small', 1, 0, 0, 0, 40, 40, 1, 0, 0, $type . '/' . $obj->ref, $obj, 'photo', 0, 0, 1, 1, 'cursorpointer');
                     if (strpos($mediaOutput, 'nophoto.png') !== false) {
                         print '<svg class="nophoto-placeholder" width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg"><rect width="40" height="40" rx="6" fill="#f0f0f0"/><path d="M20 16a3 3 0 100 6 3 3 0 000-6z" fill="#bbb"/><path d="M14 13h3l1.5-2h3l1.5 2h3a2 2 0 012 2v10a2 2 0 01-2 2H14a2 2 0 01-2-2V15a2 2 0 012-2z" stroke="#bbb" stroke-width="1.5" fill="none"/></svg>';
                     } else {
@@ -501,7 +501,7 @@ function display_recurse_tree_organization($digiriskElementTree, $i = 1, $riskIn
 
                         <div class="photo-container">
                             <?php
-                            $mediaOutput = saturne_show_medias_linked('digiriskdolibarr', $conf->digiriskdolibarr->multidir_output[$conf->entity] . '/' . $obj->element_type . '/' . $obj->ref, 'small', 1, 0, 0, 0, 40, 40, 1, 0, 0, $obj->element_type . '/' . $obj->ref, $obj, 'photo', 0, 0, 0, 1, 'cursorpointer');
+                            $mediaOutput = saturne_show_medias_linked('digiriskdolibarr', $conf->digiriskdolibarr->multidir_output[$conf->entity] . '/' . $obj->element_type . '/' . $obj->ref, 'small', 1, 0, 0, 0, 40, 40, 1, 0, 0, $obj->element_type . '/' . $obj->ref, $obj, 'photo', 0, 0, 1, 1, 'cursorpointer');
                             if (strpos($mediaOutput, 'nophoto.png') !== false) {
                                 print '<svg class="nophoto-placeholder" width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg"><rect width="40" height="40" rx="6" fill="#f0f0f0"/><path d="M20 16a3 3 0 100 6 3 3 0 000-6z" fill="#bbb"/><path d="M14 13h3l1.5-2h3l1.5 2h3a2 2 0 012 2v10a2 2 0 01-2 2H14a2 2 0 01-2-2V15a2 2 0 012-2z" stroke="#bbb" stroke-width="1.5" fill="none"/></svg>';
                             } else {


### PR DESCRIPTION
Closes #4358

## Contexte

L'arborescence affiche la photo d'un élément dans un emplacement de 40x40 mais demandait le format de vignette `small` (480x270). Le format `mini` (128x72) suffit largement et pèse quatre fois moins.

## Correctif

`use_mini_format = 1` sur les deux appels à `saturne_show_medias_linked()` de l'arborescence (`display_recurse_tree` et `display_recurse_tree_organization`).

## À propos du tooltip signalé sur l'issue

Le `Taille: 4000x2252` du tooltip ne correspondait pas à l'image réellement chargée : c'est l'attribut `title` qui annonçait la taille de l'original quel que soit le fichier servi. Ce défaut, ainsi que le vrai cas d'affichage en taille maximale (l'original était servi quand la vignette manquait sur le disque) et le repli sur un média sans rapport quand le favori a disparu, sont corrigés côté framework dans [Evarisk/Saturne#1472](https://github.com/Evarisk/Saturne/pull/1472).

## Vérification

Mesures Playwright avec interception réseau sur l'arborescence :

| Ligne | Avant | Après |
|---|---|---|
| GP1 | `_small` 203x270 — 4 789 o | `_mini` 54x72 — 1 195 o |

0 erreur PHP sur les pages arborescence, fiche élément et organisation. Rendu visuel de l'arbre inchangé (l'image reste affichée en 28x40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
