### PR TITLE
#4238 [RiskAssessment] fix: spread linked medias so their action buttons stop overlapping

### DIFF
--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
@@ -723,10 +723,12 @@ $massactionbutton = $form->selectMassAction('', $arrayofmassactions);
                                                 </div>
                                             </td>
                                             <td>
-                                                <?php
-                                                $relativepath = 'digiriskdolibarr/medias/thumbs';
-                                                print saturne_show_medias_linked('digiriskdolibarr', $conf->digiriskdolibarr->multidir_output[$conf->entity] . '/riskassessment/tmp/RA0', 'small', 0, 0, 0, 0, $onPhone ? 40 : 50, $onPhone ? 40 : 50, 1, 0, 0, '/riskassessment/tmp/RA0');
-                                                ?>
+                                                <div class="element-linked-medias-list">
+                                                    <?php
+                                                    $relativepath = 'digiriskdolibarr/medias/thumbs';
+                                                    print saturne_show_medias_linked('digiriskdolibarr', $conf->digiriskdolibarr->multidir_output[$conf->entity] . '/riskassessment/tmp/RA0', 'small', 0, 0, 0, 0, $onPhone ? 40 : 50, $onPhone ? 40 : 50, 1, 0, 0, '/riskassessment/tmp/RA0');
+                                                    ?>
+                                                </div>
                                             </td>
                                         </tr>
                                     </table>

--- a/core/tpl/riskanalysis/riskassessment/digiriskdolibarr_riskassessment_view.tpl.php
+++ b/core/tpl/riskanalysis/riskassessment/digiriskdolibarr_riskassessment_view.tpl.php
@@ -366,10 +366,12 @@ $evaluation->method = $lastRiskAssessment->method ?: "standard" ;
                                         </div>
                                     </td>
                                     <td>
-                                        <?php
-                                        $relativepath = 'digiriskdolibarr/medias/thumbs';
-                                        print saturne_show_medias_linked('digiriskdolibarr', $conf->digiriskdolibarr->multidir_output[$conf->entity] . '/riskassessment/tmp/RA0/' . $risk->ref, 'small', 0, 0, 0, 0, $onPhone ? 40 : 50, $onPhone ? 40 : 50, 1, 0, 0, '/riskassessment/tmp/RA0/' . $risk->ref);
-                                        ?>
+                                        <div class="element-linked-medias-list">
+                                            <?php
+                                            $relativepath = 'digiriskdolibarr/medias/thumbs';
+                                            print saturne_show_medias_linked('digiriskdolibarr', $conf->digiriskdolibarr->multidir_output[$conf->entity] . '/riskassessment/tmp/RA0/' . $risk->ref, 'small', 0, 0, 0, 0, $onPhone ? 40 : 50, $onPhone ? 40 : 50, 1, 0, 0, '/riskassessment/tmp/RA0/' . $risk->ref);
+                                            ?>
+                                        </div>
                                     </td>
                                 </tr>
                             </table>

--- a/core/tpl/riskanalysis/riskassessment/digiriskdolibarr_riskassessment_view_edit_modal.tpl.php
+++ b/core/tpl/riskanalysis/riskassessment/digiriskdolibarr_riskassessment_view_edit_modal.tpl.php
@@ -70,10 +70,12 @@
                                             </div>
                                         </td>
                                         <td>
-                                            <?php
-                                            $relativepath = 'digiriskdolibarr/medias/thumbs';
-                                            print saturne_show_medias_linked('digiriskdolibarr', $conf->digiriskdolibarr->multidir_output[$conf->entity] . '/riskassessment/' . $lastEvaluation->ref, 'small', 0, 0, 0, 0, $onPhone ? 40 : 50, $onPhone ? 40 : 50, 1, 0, 0, '/riskassessment/' . $lastEvaluation->ref, $lastEvaluation);
-                                            ?>
+                                            <div class="element-linked-medias-list">
+                                                <?php
+                                                $relativepath = 'digiriskdolibarr/medias/thumbs';
+                                                print saturne_show_medias_linked('digiriskdolibarr', $conf->digiriskdolibarr->multidir_output[$conf->entity] . '/riskassessment/' . $lastEvaluation->ref, 'small', 0, 0, 0, 0, $onPhone ? 40 : 50, $onPhone ? 40 : 50, 1, 0, 0, '/riskassessment/' . $lastEvaluation->ref, $lastEvaluation);
+                                                ?>
+                                            </div>
                                         </td>
                                     </tr>
                                 </table>

--- a/css/digiriskdolibarr.min.css
+++ b/css/digiriskdolibarr.min.css
@@ -8248,6 +8248,20 @@ td > .risk-evaluation-list-content .risk-evaluation-container:not(.advanced, .st
   resize: vertical;
 }
 
+/** Medias linked to a risk / a risk assessment
+    The media action buttons overflow their container (top: -10px / bottom: -10px), so stacked medias
+    cover each other and steal their neighbour clicks: keep them spaced on a wrapping row */
+.element-linked-medias .add-medias td {
+  vertical-align: top;
+}
+.element-linked-medias .element-linked-medias-list {
+  display: flex;
+  flex-wrap: wrap;
+  align-content: flex-start;
+  gap: 24px 16px;
+  max-width: 200px;
+}
+
 .wpeo-modal[class*=modal-risk] .modal-container .risk-evaluation-container {
   padding-bottom: 1em;
   margin-bottom: 1em;

--- a/css/scss/modal/_risk.scss
+++ b/css/scss/modal/_risk.scss
@@ -59,6 +59,23 @@
   }
 }
 
+/** Medias linked to a risk / a risk assessment
+    The media action buttons overflow their container (top: -10px / bottom: -10px), so stacked medias
+    cover each other and steal their neighbour clicks: keep them spaced on a wrapping row */
+.element-linked-medias {
+  .add-medias td {
+    vertical-align: top;
+  }
+
+  .element-linked-medias-list {
+    display: flex;
+    flex-wrap: wrap;
+    align-content: flex-start;
+    gap: 24px 16px;
+    max-width: 200px;
+  }
+}
+
 .wpeo-modal[class*="modal-risk"] .modal-container .risk-evaluation-container {
   padding-bottom: 1em;
   margin-bottom: 1em;


### PR DESCRIPTION
Closes #4238

## Problème

Les médias liés d'une évaluation sont affichés dans une seule cellule `<td>`, sans règle de mise en page : à partir de 2 photos ils s'empilent verticalement et collés.

Or leurs boutons d'action débordent de la vignette (`saturne/css/scss/modules/medias/_actions.scss` : `top: -10px` pour « détacher », `bottom: -10px` pour « favori »). Le bouton favori d'un média se retrouve donc **exactement sous le bouton détacher du média suivant** :

```
photo 1 → clic sur l'étoile "favori" → élément réellement touché : media-gallery-unlink de la photo 2
```

Cliquer sur le favori de la 1ʳᵉ photo détachait silencieusement la 2ᵉ — d'où « perte du retour des photos » et « perte du JS » signalées dans l'issue.

## Correctif

- Nouvelle règle SCSS (`css/scss/modal/_risk.scss`) : la liste des médias devient une ligne flex qui passe à la ligne, avec `gap: 24px 16px` (24 px vertical = les 2 × 10 px de débordement des boutons + marge) et `max-width: 200px` → 3 vignettes par ligne.
- Wrapper `<div class="element-linked-medias-list">` autour de `saturne_show_medias_linked()` dans les 3 blocs médias concernés : création de risque, création d'évaluation, édition d'évaluation.
- `css/digiriskdolibarr.min.css` régénéré (patch ciblé pour éviter le churn dû à une version de dart-sass différente).

Nom de classe volontairement `element-linked-medias-list` et non `linked-medias-list` : ce dernier est ciblé par `mediaGallery.js` (`unlinkFile`, `addToFavorite`) et aurait changé le chemin de rafraîchissement AJAX.

## Tests (Playwright, Dolibarr 23)

- Sonde `elementFromPoint` avant → le favori de la photo 1 touchait le `unlink` de la photo 2 ; après → chaque bouton reçoit son propre clic (2 puis 5 photos, y compris sur la 2ᵉ ligne).
- Flux complet galerie → sélection de 2 puis 5 photos → `subaction=addFiles` 200, rendu AJAX correct, aucune erreur JS.
- Détachement testé un par un : la bonne photo est retirée à chaque fois (5/5).
- Les 3 blocs modifiés vérifiés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)