### PR TITLE
#4946 [TicketDashboard] fix: pad category rows so DolGraph stops warning on missing keys

### DIFF
--- a/class/ticketdashboard.class.php
+++ b/class/ticketdashboard.class.php
@@ -453,18 +453,15 @@ class TicketDashboard extends DigiriskDolibarrDashboard
             ];
         }
 
+        // Chaque ligne doit compter exactement une valeur par catégorie, dans l'ordre des libellés :
+        // une ligne plus courte déclenche des warnings "Undefined array key" dans DolGraph et décale les séries
         foreach ($digiriskElements as $digiriskElement) {
-            $array['data'][$digiriskElement->id][0] = $digiriskElement->ref . ' - ' . $digiriskElement->label;
-            if (!isset($ticketByCategoriesAndDigiriskElements[$digiriskElement->id])) {
-                continue;
+            $data = [$digiriskElement->ref . ' - ' . $digiriskElement->label];
+            foreach ($categories as $category) {
+                $data[] = $ticketByCategoriesAndDigiriskElements[$digiriskElement->id][$category->id] ?? 0;
             }
 
-            $array['data'][$digiriskElement->id] = $array['data'][$digiriskElement->id] + $ticketByCategoriesAndDigiriskElements[$digiriskElement->id];
-            $array['data'][$digiriskElement->id] = array_values($array['data'][$digiriskElement->id]);
-
-            if (count($array['data'][$digiriskElement->id]) - 1 < count($categories)) {
-                $array['data'][$digiriskElement->id] = array_pad($array['data'][$digiriskElement->id], count($categories) + 1, 0);
-            }
+            $array['data'][$digiriskElement->id] = $data;
         }
 
         return $array;


### PR DESCRIPTION
Closes #4946

## Problème

La page d'accueil Digirisk (`digiriskdolibarrindex.php`) émettait **120 warnings PHP** `Undefined array key 1..8` depuis `htdocs/core/class/dolgraph.class.php` (lignes 1232 et 1242).

`TicketDashboard::getTicketsByCategoriesAndDigiriskElements()` construisait un tableau de données irrégulier : les GP/UT sans aucun ticket sortaient de la boucle via `continue`, en ne laissant qu'une ligne réduite au libellé. DolGraph dimensionne ses séries sur la ligne la plus longue puis lit `$valarray[$i + 1]` sur **toutes** les lignes.

Mesure sur l'instance locale (instrumentation temporaire de `SaturneDashboard::display()`, retirée depuis) :

```
Nombre de registres par catégorie et par GP      nblabels=4  lens=5,1,5,1,1,1,1
Nombre de registres par sous-catégorie et par GP nblabels=8  lens=9,1,9,1,1,1,1
```

→ 5 lignes courtes × 4 clés + 5 × 8 clés, × 2 lignes de code = 120 warnings.

## Correctif

Chaque ligne est désormais construite explicitement, une valeur par catégorie (0 par défaut), indexée par `$category->id`.

Cela remplace le triptyque `union + array_values() + array_pad()`, qui avait un second défaut plus discret : `array_values()` compactait les catégories absentes et `array_pad()` complétait à droite, donc **les valeurs se retrouvaient attribuées aux mauvaises catégories** dès qu'un GP/UT n'avait de tickets que sur une partie des catégories. L'indexation par `$category->id` garantit l'alignement colonne ↔ légende.

## Vérification

- Rechargement de la page : **0** message PHP (`Warning` / `Notice` / `Deprecated` / `Fatal`) — contre 120 avant.
- `php -l` : pas d'erreur de syntaxe.
- Les deux graphes s'affichent toujours, avec la bonne catégorie : GP1 → *Qualité* / *Améliorations*, GP3 → *Santé et sécurité au travail* / *Problème matériel*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
