### PR TITLE
#4272 [Projet] fix: compute consumed time and cost on the right project

### DIFF
--- a/class/actions_digiriskdolibarr.class.php
+++ b/class/actions_digiriskdolibarr.class.php
@@ -523,8 +523,9 @@ class ActionsDigiriskdolibarr
                     if (strpos($parameters['context'], 'projecttaskcard') !== false && !GETPOSTISSET('withproject')) {
                         return 0;
                     } else {
-                        if (preg_match('/projectcard|projectcontactcard|projecttaskscard/', $parameters['context'])) {
-                            $projectId = GETPOST('id');
+                        if (preg_match('/projectcard|projectcontactcard|projecttaskscard|projectOverview/', $parameters['context'])) {
+                            $project->fetch(GETPOSTINT('id'), GETPOST('ref', 'alpha'));
+                            $projectId = $project->id;
                         } else if (GETPOSTISSET('projectid') || GETPOSTISSET('ref')) {
                             $project->fetch( GETPOST('projectid'), GETPOST('ref'));
                             $projectId = $project->id;
@@ -532,6 +533,12 @@ class ActionsDigiriskdolibarr
                             $task->fetch(GETPOST('id'));
                             $projectId = $task->fk_project;
                         }
+
+                        // Sans projet identifié, getTasksArray() agrégerait les tâches de toute l'instance
+                        if ($projectId <= 0) {
+                            return 0;
+                        }
+
                         $allTasks = $task->getTasksArray(null, null, $projectId, 0, 0, '', '-1', '', 0, 0, $extrafields);
                         $totalConsumedTime       = 0;
                         $totatConsumedTimeAmount = 0;
@@ -541,14 +548,16 @@ class ActionsDigiriskdolibarr
                         if (is_array($allTasks) && !empty($allTasks)) {
                             $nbTasks = count($allTasks);
                             foreach ($allTasks as $taskSingle) {
-                                $filter       = ' AND fk_element = ' . $taskSingle->id;
-                                $allTimespent = $task->fetchAllTimeSpentAllUsers($filter);
-                                foreach ($allTimespent as $timespent) {
-                                    $totatConsumedTimeAmount += ((float)$timespent->timespent_duration / 3600) * (float)$timespent->timespent_thm;
-                                }
-                                $totalConsumedTime += (float)$taskSingle->duration;
-                                $totalProgress     += (float)$taskSingle->progress;
-                                $totalTasksBudget  += (float)$taskSingle->budget_amount;
+                                $totalConsumedTime += (float) $taskSingle->duration_effective;
+                                $totalProgress     += (float) $taskSingle->progress;
+                                $totalTasksBudget  += (float) $taskSingle->budget_amount;
+                            }
+                        }
+
+                        $allTimespent = $task->fetchAllTimeSpentAllUsers(' AND project_id = ' . ((int) $projectId));
+                        if (is_array($allTimespent)) {
+                            foreach ($allTimespent as $timespent) {
+                                $totatConsumedTimeAmount += ((float) $timespent->timespent_duration / 3600) * (float) $timespent->timespent_thm;
                             }
                         }
                         $outTotatConsumedTime       = '<tr><td>' . $langs->trans('TotalConsumedTime') . '</td><td>' . convertSecondToTime($totalConsumedTime, 'allhourmin') . '</td></tr>';


### PR DESCRIPTION
Closes #4272

## Problème

Sur l'onglet **Vue d'ensemble** d'un projet (`projet/element.php`), les indicateurs Digirisk affichaient les totaux de **toute l'instance** (1111 tâches, 425 398,83 €), et « Total temps consommé sur le projet » restait à **0** sur toutes les pages.

## Causes

1. **Mauvais périmètre** — le contexte `projectOverview` ne figurait pas dans la liste des pages où `id` est un id de **projet** ; le hook le lisait comme un id de **tâche** (`$task->fetch(GETPOST('id'))`). Si une tâche portait ce rowid → totaux d'un autre projet ; sinon → `fk_project` vide → `getTasksArray(..., projectid = 0, ...)` → toutes les tâches de l'instance.
2. **Total temps consommé toujours à 0** — `getTasksArray()` renseigne `duration_effective`, pas `duration` ; la propriété lue n'existait pas (0 + warning PHP 8).
3. **N+1** — une requête de temps passé par tâche (~1111 requêtes sur la page concernée).

## Correctif

- `projectOverview` ajouté aux contextes « id = projet », avec résolution par `Project::fetch(id, ref)` — l'accès par `ref` fonctionne désormais aussi (il était cassé sur `card.php` également).
- Garde `if ($projectId <= 0) return 0;` : sans projet identifié, on n'affiche plus rien au lieu d'agréger l'instance entière.
- `duration` → `duration_effective`.
- Coût calculé en **1 requête** filtrée sur le projet (`AND project_id = X`) au lieu de N, avec garde `is_array()` (la méthode renvoie `-1` en erreur).

## Tests

Comparaison au SQL de référence (nb tâches, durée, coût, budget) sur 4 projets (282 / 111 / 358 / 958) : concordance sur les 4.

Vérification UI (Playwright) sur les 3 onglets, projet 282 :

| | Vue d'ensemble | Projet | Tâches |
|---|---|---|---|
| **avant** | 1 tâche / **0** / **2,54 €** | 17 / **0** / 5 948,09 € | 17 / **0** / 5 948,09 € |
| **après** | 17 / **2161:50** / 5 948,09 € | idem | idem |

## Note

`SaturneTask::fetchAllTimeSpentAllUsers()` ne filtre pas `elementtype = 'task'` (le core Dolibarr le fait). Sans impact aujourd'hui, mais à corriger côté Saturne dans une issue dédiée.