### PR TITLE
#4390 [SCSS] fix: keep the danger category dropdown anchored so lists stop widening the page

### DIFF
--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_inheritedrisklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_inheritedrisklist_view.tpl.php
@@ -355,7 +355,7 @@
 			} elseif ($key == 'fk_element') {
 				print $digiriskelement->selectDigiriskElementList($search['fk_element'], 'search_fk_element', [], 1, 0, array(), 0, 0, 'minwidth100 maxwidth300', 0, false, 1);
 			} elseif ($key == 'category') { ?>
-				<div class="wpeo-dropdown dropdown-large dropdown-grid category-danger padding" style="position: inherit">
+				<div class="wpeo-dropdown dropdown-large dropdown-grid category-danger padding">
 					<input class="input-hidden-danger" type="hidden" name="<?php echo 'search_' . $key ?>" value="<?php echo dol_escape_htmltag($search[$key]) ?>" />
 					<?php if (dol_strlen(dol_escape_htmltag($search[$key])) == 0) : ?>
 						<div class="dropdown-toggle dropdown-add-button button-cotation">

--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
@@ -920,7 +920,7 @@ foreach ($risk->fields as $key => $val) {
         } elseif ($key == 'fk_element') {
             print $digiriskelement->selectDigiriskElementList($search['fk_element'] ?? '', 'search_fk_element', ['customsql' => 'rowid NOT IN (' . implode(',', $deletedElements) . ')'], 1, 0, [], 0, 0, 'minwidth100 maxwidth300', 0, false, 1);
         } elseif ($key == 'category') { ?>
-            <div class="wpeo-dropdown dropdown-large dropdown-grid category-danger padding" style="position: inherit">
+            <div class="wpeo-dropdown dropdown-large dropdown-grid category-danger padding">
                 <input class="input-hidden-danger" type="hidden" name="<?php echo 'search_' . $key ?>" value="<?php echo dol_escape_htmltag($search[$key] ?? '') ?>" />
                 <?php if (dol_strlen(dol_escape_htmltag($search[$key] ?? '')) == 0) : ?>
                     <div class="dropdown-toggle dropdown-add-button button-cotation">

--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_sharedrisklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_sharedrisklist_view.tpl.php
@@ -401,7 +401,7 @@ foreach ($risk->fields as $key => $val) {
 		}  elseif ($key == 'applied_on') {
 //				print $digiriskelement->select_digiriskelement_list($search['search_applied_on_sharedrisk'], 'search_applied_on_sharedrisk', '', 1, 0, array(), 0, 0, 'minwidth100', 0, false, 1, $contextpage);
 		} elseif ($key == 'category') { ?>
-			<div class="wpeo-dropdown dropdown-large dropdown-grid category-danger padding" style="position: inherit">
+			<div class="wpeo-dropdown dropdown-large dropdown-grid category-danger padding">
 				<input class="input-hidden-danger" type="hidden" name="<?php echo 'search_' . $key ?>" value="<?php echo dol_escape_htmltag($search[$key] ?? '') ?>" />
 				<?php if (dol_strlen(dol_escape_htmltag($search[$key] ?? '')) == 0) : ?>
 					<div class="dropdown-toggle dropdown-add-button button-cotation">

--- a/core/tpl/riskanalysis/risksign/digiriskdolibarr_inheritedrisksignlist_view.tpl.php
+++ b/core/tpl/riskanalysis/risksign/digiriskdolibarr_inheritedrisksignlist_view.tpl.php
@@ -182,7 +182,7 @@ foreach ($risksign->fields as $key => $val) {
 		} elseif ($key == 'fk_element') {
 			print $digiriskelement->selectDigiriskElementList($search['fk_element'], 'search_fk_element', [], 1, 0, array(), 0, 0, 'minwidth100 maxwidth300', 0, false, 1);
 		} elseif ($key == 'category') { ?>
-			<div class="wpeo-dropdown dropdown-large dropdown-grid category-danger padding" style="position: inherit">
+			<div class="wpeo-dropdown dropdown-large dropdown-grid category-danger padding">
 				<input class="input-hidden-danger" type="hidden" name="<?php echo 'search_' . $key ?>" value="<?php echo dol_escape_htmltag($search[$key]) ?>" />
 				<?php if (dol_strlen(dol_escape_htmltag($search[$key])) == 0) : ?>
 					<div class="dropdown-toggle dropdown-add-button">

--- a/core/tpl/riskanalysis/risksign/digiriskdolibarr_risksignlist_view.tpl.php
+++ b/core/tpl/riskanalysis/risksign/digiriskdolibarr_risksignlist_view.tpl.php
@@ -260,7 +260,7 @@ foreach ($risksign->fields as $key => $val) {
 		elseif (strpos($val['type'], 'integer:') === 0) {
 			print $risksign->showInputField($val, $key, $search[$key], '', '', 'search_', 'maxwidth150', 1);
 		} elseif ($key == 'category') { ?>
-			<div class="wpeo-dropdown dropdown-large dropdown-grid category-danger padding" style="position: inherit">
+			<div class="wpeo-dropdown dropdown-large dropdown-grid category-danger padding">
 				<input class="input-hidden-danger" type="hidden" name="<?php echo 'search_' . $key ?>" value="<?php echo dol_escape_htmltag($search[$key]) ?>" />
 				<?php if (dol_strlen(dol_escape_htmltag($search[$key])) == 0) : ?>
 					<div class="dropdown-toggle dropdown-add-button">

--- a/core/tpl/riskanalysis/risksign/digiriskdolibarr_sharedrisksignlist_view.tpl.php
+++ b/core/tpl/riskanalysis/risksign/digiriskdolibarr_sharedrisksignlist_view.tpl.php
@@ -260,7 +260,7 @@ foreach ($risksign->fields as $key => $val) {
 		} elseif ($key == 'fk_element') {
 			print $digiriskelement->selectDigiriskElementList($search['fk_element_shared'], 'search_fk_element_shared', ['customsql' => 's.entity NOT IN (' . $conf->entity . ')'], 1, 0, array(), 0, 0, 'minwidth100 maxwidth300', 0, false, 1, $contextpage, false);
 		} elseif ($key == 'category') { ?>
-			<div class="wpeo-dropdown dropdown-large dropdown-grid category-danger padding" style="position: inherit">
+			<div class="wpeo-dropdown dropdown-large dropdown-grid category-danger padding">
 				<input class="input-hidden-danger" type="hidden" name="<?php echo 'search_' . $key ?>" value="<?php echo dol_escape_htmltag($search[$key]) ?>" />
 				<?php if (dol_strlen(dol_escape_htmltag($search[$key])) == 0) : ?>
 					<div class="dropdown-toggle dropdown-add-button">

--- a/css/digiriskdolibarr.min.css
+++ b/css/digiriskdolibarr.min.css
@@ -7900,6 +7900,17 @@ body.digirisk-mobile-create .digirisk-pwa-pagination__page {
   color: #f59e0b;
 }
 
+/** Dropdown de catégories de danger dans une cellule de liste */
+/* Le panneau du dropdown fait 360px et reste dans le flux même fermé (il est masqué par opacity).
+   Ancré au dropdown (position: relative héritée de Saturne), il reste contenu dans le tableau.
+   S'il est ancré au body, il échappe au conteneur .div-table-responsive et élargit la page entière :
+   la mise en page casse dès que l'écran est plus étroit que le panneau.
+   On ne le détache donc qu'une fois le dropdown ouvert, pour qu'il déborde du tableau
+   au lieu d'être rogné par celui-ci. */
+td .wpeo-dropdown.category-danger.dropdown-active {
+  position: static;
+}
+
 /** Cell header */
 .table-cell-header {
   display: flex;

--- a/css/scss/table/_general.scss
+++ b/css/scss/table/_general.scss
@@ -1,3 +1,14 @@
+/** Dropdown de catégories de danger dans une cellule de liste */
+/* Le panneau du dropdown fait 360px et reste dans le flux même fermé (il est masqué par opacity).
+   Ancré au dropdown (position: relative héritée de Saturne), il reste contenu dans le tableau.
+   S'il est ancré au body, il échappe au conteneur .div-table-responsive et élargit la page entière :
+   la mise en page casse dès que l'écran est plus étroit que le panneau.
+   On ne le détache donc qu'une fois le dropdown ouvert, pour qu'il déborde du tableau
+   au lieu d'être rogné par celui-ci. */
+td .wpeo-dropdown.category-danger.dropdown-active {
+  position: static;
+}
+
 /** Cell header */
 .table-cell-header {
   display: flex;

--- a/view/digirisktools.php
+++ b/view/digirisktools.php
@@ -1158,7 +1158,7 @@ if ($user->rights->digiriskdolibarr->adminpage->read) {
             print '<tr class="oddeven">';
             print '<td class="center">'
             ?>
-                <div class="wpeo-dropdown dropdown-large dropdown-grid category-danger padding" style="position: inherit">
+                <div class="wpeo-dropdown dropdown-large dropdown-grid category-danger padding">
                     <input class="input-hidden-danger" type="hidden" name="<?php echo 'search_' . $key ?>" />
                         <div class="dropdown-toggle dropdown-add-button button-cotation">
                             <span class="wpeo-button button-square-50 button-grey"><i class="fas fa-exclamation-triangle button-icon"></i></span>


### PR DESCRIPTION
Closes #4390

## Cause

Les dropdowns de catégories de danger portaient un `style="position: inherit"` en dur dans le HTML.

Le panneau `.saturne-dropdown-content` fait **360 px** de large, est en `position: absolute`, et **reste dans le flux même fermé** (il n'est masqué que par `opacity: 0`). Le style inline annulait le `position: relative` que Saturne pose sur `.wpeo-dropdown` : le panneau prenait alors le `<body>` comme bloc conteneur, échappait au `.div-table-responsive` qui aurait dû le contenir, et fixait `documentElement.scrollWidth` à **488 px quelle que soit la largeur du viewport**.

En dessous de cette largeur, toute la page prenait un scroll horizontal et la mise en page cassait (bande blanche à droite, éléments détachés du contenu).

## Correctif

Ce détachement n'était pas gratuit : c'est lui qui permet au panneau **ouvert** de déborder du tableau au lieu d'être rogné par son conteneur. Le retirer seul aurait coupé la dernière ligne d'icônes sur les listes courtes.

Il est donc déplacé du HTML vers le SCSS et **conditionné à `.dropdown-active`** : le dropdown reste ancré tant qu'il est fermé, et n'est détaché que pendant qu'il est ouvert.

- `css/scss/table/_general.scss` : `td .wpeo-dropdown.category-danger.dropdown-active { position: static; }`
- Suppression du `style="position: inherit"` dans les 7 emplacements concernés (listes risques / signalisations / partagées / héritées + `digirisktools.php`) — au passage, ça lève une violation du « jamais de CSS inline » du CLAUDE.md
- `digiriskdolibarr.min.css` mis à jour (pas de CI build-assets sur ce dépôt) : insertion identique au rendu `sass`, aucun churn ajouté

Le correctif reste dans Digirisk : le composant Saturne était déjà correct, c'est le balisage Digirisk qui le contournait.

## Vérifications (Playwright, local)

| Contrôle | Résultat |
|---|---|
| Débordement page Risques @ 257 / 320 / 467 / 768 / 1600 px | `scrollWidth == clientWidth` partout (avant : 488 px figé) |
| Panneau ouvert sur liste courte (`limit=1`) | toujours entièrement visible, aucun scroll vertical ajouté au tableau |
| Sélection d'une catégorie | le filtre est bien renseigné |

## Hors périmètre

La page Signalisations déborde également (`scrollWidth` 743 @ 257 px, 4936 @ 1600 px), mais c'est **une autre cause, préexistante** : mesures identiques avant et après ce changement, et le débordement se produit aussi en plein écran. `div#id-right` s'étire à 4675 px. À traiter dans une issue séparée.