### PR TITLE
#4954 [AccidentInvestigation] fix: save action deadline and assignee, hide T1/T2 containers

### DIFF
--- a/lib/digiriskdolibarr_accidentinvestigation.lib.php
+++ b/lib/digiriskdolibarr_accidentinvestigation.lib.php
@@ -46,7 +46,41 @@ function accidentinvestigation_prepare_head(AccidentInvestigation $object): arra
 }
 
 /**
- * Return subtasks of an accident investigation task filtered by digirisk_action_type.
+ * Return the container task (T1 = curative, T2 = corrective) of an accident investigation.
+ *
+ * Both containers are created when the investigation is validated, so the oldest child task of a
+ * given type is always the container, whatever its label has been renamed to afterwards.
+ *
+ * @param  DoliDB $db           Database handler
+ * @param  int    $parentTaskId fk_task of the AccidentInvestigation
+ * @param  int    $type         1 = curative, 2 = corrective
+ * @return int                  Container task ID, 0 if none
+ */
+function getAccidentInvestigationActionContainerTask(DoliDB $db, int $parentTaskId, int $type): int
+{
+    $sql  = 'SELECT t.rowid FROM ' . MAIN_DB_PREFIX . 'projet_task t';
+    $sql .= ' INNER JOIN ' . MAIN_DB_PREFIX . 'projet_task_extrafields ef ON ef.fk_object = t.rowid';
+    $sql .= ' WHERE t.fk_task_parent = ' . $parentTaskId;
+    $sql .= '   AND ef.digirisk_action_type = ' . $type;
+    $sql .= ' ORDER BY t.rowid ASC LIMIT 1';
+
+    $resql = $db->query($sql);
+    if (!$resql) {
+        dol_syslog(__FUNCTION__ . ': ' . $db->lasterror(), LOG_ERR);
+        return 0;
+    }
+
+    $obj = $db->fetch_object($resql);
+    $db->free($resql);
+
+    return !empty($obj) ? (int) $obj->rowid : 0;
+}
+
+/**
+ * Return the actions of an accident investigation filtered by digirisk_action_type.
+ *
+ * The T1/T2 container tasks themselves are excluded: they only group the actions in the project
+ * task view. Actions created before they were parented to the container are still listed.
  *
  * @param  DoliDB $db           Database handler
  * @param  int    $parentTaskId fk_task of the AccidentInvestigation
@@ -57,17 +91,20 @@ function getAccidentInvestigationActionsByType(DoliDB $db, int $parentTaskId, in
 {
     $results = [];
 
+    $containerTaskId = getAccidentInvestigationActionContainerTask($db, $parentTaskId, $type);
+
     $sql  = 'SELECT t.rowid, t.ref, t.label, t.datee, t.progress, t.fk_statut,';
     $sql .= ' (SELECT CONCAT(u2.firstname, \' \', u2.lastname)';
     $sql .= '  FROM ' . MAIN_DB_PREFIX . 'element_contact ec2';
     $sql .= '  INNER JOIN ' . MAIN_DB_PREFIX . 'c_type_contact ctc2';
     $sql .= '   ON ctc2.rowid = ec2.fk_c_type_contact';
-    $sql .= '   AND ctc2.code = \'TASKEXECUTIVE\' AND ctc2.element = \'projet_task\'';
+    $sql .= '   AND ctc2.code = \'TASKEXECUTIVE\' AND ctc2.element = \'project_task\'';
     $sql .= '  INNER JOIN ' . MAIN_DB_PREFIX . 'user u2 ON u2.rowid = ec2.fk_socpeople';
     $sql .= '  WHERE ec2.element_id = t.rowid LIMIT 1) AS user_fullname';
     $sql .= ' FROM ' . MAIN_DB_PREFIX . 'projet_task t';
     $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'projet_task_extrafields ef ON ef.fk_object = t.rowid';
-    $sql .= ' WHERE t.fk_task_parent = ' . $parentTaskId;
+    $sql .= ' WHERE t.fk_task_parent IN (' . $containerTaskId . ', ' . $parentTaskId . ')';
+    $sql .= '   AND t.rowid <> ' . $containerTaskId;
     $sql .= '   AND ef.digirisk_action_type = ' . $type;
     $sql .= ' ORDER BY t.datee ASC, t.rowid ASC';
 

--- a/view/accidentinvestigation/accidentinvestigation_actions.php
+++ b/view/accidentinvestigation/accidentinvestigation_actions.php
@@ -93,16 +93,23 @@ if ($action === 'addAction' && $permissiontoadd) {
     $object->fetch($id);
     $accident->fetch($object->fk_accident);
 
+    // Actions are grouped under the T1/T2 container task created when the investigation is validated
+    $containerTaskId = getAccidentInvestigationActionContainerTask($db, (int) $object->fk_task, $action_type);
+
+    // Each section renders its own form, so field names are suffixed with the action type
+    $deadlinePrefix = 'actiondeadline' . $action_type;
+
     $newTask                 = new Task($db);
     $newTask->fk_project     = $accident->fk_project;
-    $newTask->fk_task_parent = (int) $object->fk_task;
+    $newTask->fk_task_parent = $containerTaskId > 0 ? $containerTaskId : (int) $object->fk_task;
     $newTask->ref            = $modTask->getNextValue(0, $newTask);
     $newTask->label          = GETPOST('action_label', 'alphanohtml');
-    $newTask->datee          = dol_mktime(
+    // Task::create() only writes date_end, the datee property is deprecated and ignored
+    $newTask->date_end       = dol_mktime(
         23, 59, 59,
-        GETPOST('actiondeadlinemonth', 'int'),
-        GETPOST('actiondeadlineday',   'int'),
-        GETPOST('actiondeadlineyear',  'int')
+        GETPOST($deadlinePrefix . 'month', 'int'),
+        GETPOST($deadlinePrefix . 'day',   'int'),
+        GETPOST($deadlinePrefix . 'year',  'int')
     );
     $newTask->progress       = 0;
 
@@ -112,7 +119,7 @@ if ($action === 'addAction' && $permissiontoadd) {
 
     $result = $newTask->create($user);
     if ($result > 0) {
-        $assignedUser = GETPOST('assigned_user', 'int');
+        $assignedUser = GETPOST('assigned_user' . $action_type, 'int');
         if ($assignedUser > 0) {
             $newTask->add_contact($assignedUser, 'TASKEXECUTIVE', 'internal');
         }
@@ -332,12 +339,14 @@ if ($id > 0 || !empty($ref)) {
 
                 print '<td style="width:20%">';
                 print '<label>' . $langs->trans('ActionDeadline') . '</label><br>';
-                print $form->selectDate('', 'actiondeadline', 0, 0, 1, 'addActionForm' . $type);
+                // Prefix suffixed with the type: both sections are rendered on the same page and
+                // the datepicker fills its hidden day/month/year fields through getElementById
+                print $form->selectDate('', 'actiondeadline' . $type, 0, 0, 1, 'addActionForm' . $type);
                 print '</td>';
 
                 print '<td style="width:24%">';
                 print '<label>' . $langs->trans('ActionAssignedTo') . '</label><br>';
-                print $form->select_dolusers('', 'assigned_user', 1, null, 0, '', '', 0, 0, 0, '', 0, '', 'maxwidth200');
+                print $form->select_dolusers('', 'assigned_user' . $type, 1, null, 0, '', '', 0, 0, 0, '', 0, '', 'maxwidth200');
                 print '</td>';
 
                 print '<td style="vertical-align:bottom;white-space:nowrap">';


### PR DESCRIPTION
## Changements

**Échéance enregistrée** — `Task::create()` n'écrit que `date_end`, la propriété `datee` alimentée par le handler est dépréciée et ignorée. La date saisie était donc perdue.

**Responsable affiché** — la sous-requête filtrait sur `ctc.element = 'projet_task'` alors que Dolibarr enregistre `project_task` dans `llx_c_type_contact`. Le contact `TASKEXECUTIVE` était bien créé, mais la colonne affichait toujours `—`.

**Un formulaire fonctionnel par section** — les deux formulaires rendaient les mêmes ids HTML (`actiondeadline`, `assigned_user`). Le datepicker ne se branchait que sur le premier et `dpChangeDay()` écrit dans les champs cachés via `getElementById`, rendant la date inutilisable côté correctif. Les noms de champs sont désormais suffixés par le type d'action.

**Conteneurs T1/T2 masqués** — les actions ajoutées deviennent des sous-tâches du conteneur `T1` / `T2` au lieu d'être leurs sœurs, et les conteneurs ne sont plus listés comme des actions. Le conteneur est identifié comme la plus ancienne tâche enfant du type concerné, ce qui reste juste si son libellé est modifié. Les actions créées par la version précédente restent listées (la clause couvre les deux parentages), aucune migration de données n'est nécessaire.

## Fichiers modifiés

- `lib/digiriskdolibarr_accidentinvestigation.lib.php`
- `view/accidentinvestigation/accidentinvestigation_actions.php`

## Tests

Rejoué la séquence du handler `addAction` sur une enquête validée (tâche parente 1190, conteneurs T1 1191 / T2 1192) :

```
Action creee : tache 1248 (parent 1191)

--- CURATIVES (1) ---
  #1248 | TKTEST-260727144501 | action curative | echeance=2026-08-12 23:59:59 | assigne=Laurent Magnin
--- CORRECTIVES (0) ---
```

Échéance et responsable remontent bien, et les conteneurs T1/T2 ne sont plus listés.

Close #4954
