### PR TITLE
#4956 [PreventionPlan] rework: risks, protections and certifications as classic listings

### DIFF
--- a/core/tpl/digiriskdolibarr_mobile_protections_view.tpl.php
+++ b/core/tpl/digiriskdolibarr_mobile_protections_view.tpl.php
@@ -48,26 +48,29 @@ if (is_array($mobileProtections) && !empty($mobileProtections)) {
 
     print '<div class="digirisk-protections-view">';
     print '<div class="digirisk-protections-view__title"><i class="fas fa-hard-hat"></i> ' . $langs->trans('MobilePPProtections') . '</div>';
-    print '<div class="digirisk-protections-view__list">';
+    print '<div class="div-table-responsive-no-min">';
+    print '<table class="noborder centpercent">';
+    print '<tr class="liste_titre">';
+    print '<td>' . $langs->trans('Label') . '</td>';
+    print '<td>' . $langs->trans('Comment') . '</td>';
+    print '<td class="center">' . $langs->trans('MobilePPMandatory') . '</td>';
+    print '</tr>';
     foreach ($mobileProtections as $mobileProtection) {
         if (!isset($protectionMap[$mobileProtection['position']])) {
             continue;
         }
         $protectionCategory = $protectionMap[$mobileProtection['position']];
         $thumb              = DOL_URL_ROOT . '/custom/digiriskdolibarr/img/' . $protectionCategory['name_thumbnail'];
-        print '<div class="digirisk-protections-view__item">';
-        print '<img src="' . $thumb . '" alt="" title="' . dol_escape_htmltag($protectionCategory['name']) . '">';
-        print '<div class="digirisk-protections-view__info">';
-        print '<div class="digirisk-protections-view__name">' . dol_escape_htmltag($protectionCategory['name']) . '</div>';
-        if (!empty($mobileProtection['comment'])) {
-            print '<div class="digirisk-protections-view__comment">' . dol_escape_htmltag($mobileProtection['comment']) . '</div>';
-        }
-        if (!empty($mobileProtection['mandatory'])) {
-            print '<span class="badge badge-info">' . $langs->trans('MobilePPMandatory') . '</span>';
-        }
-        print '</div>';
-        print '</div>';
+        print '<tr class="oddeven">';
+        print '<td class="nowraponall">';
+        print '<img class="cell-risk-view__pic valignmiddle marginrightonly" src="' . $thumb . '" alt="" title="' . dol_escape_htmltag($protectionCategory['name']) . '">';
+        print '<span class="valignmiddle">' . dol_escape_htmltag($protectionCategory['name']) . '</span>';
+        print '</td>';
+        print '<td class="wordbreak">' . (!empty($mobileProtection['comment']) ? dol_escape_htmltag($mobileProtection['comment']) : '<span class="opacitymedium">-</span>') . '</td>';
+        print '<td class="center">' . (!empty($mobileProtection['mandatory']) ? '<span class="badge badge-info">' . $langs->trans('Yes') . '</span>' : '<span class="opacitymedium">' . $langs->trans('No') . '</span>') . '</td>';
+        print '</tr>';
     }
+    print '</table>';
     print '</div>';
     print '</div>';
 }
@@ -78,18 +81,20 @@ if (is_array($mobileCertifications) && !empty($mobileCertifications)) {
     $certificationOptions = digiriskGetCertificationOptions(false);
     print '<div class="digirisk-protections-view">';
     print '<div class="digirisk-protections-view__title"><i class="fas fa-id-badge"></i> ' . $langs->trans('MobilePPCertifications') . '</div>';
-    print '<div class="digirisk-protections-view__list">';
+    print '<div class="div-table-responsive-no-min">';
+    print '<table class="noborder centpercent">';
+    print '<tr class="liste_titre">';
+    print '<td>' . $langs->trans('Label') . '</td>';
+    print '<td class="center">' . $langs->trans('MobilePPMandatory') . '</td>';
+    print '</tr>';
     foreach ($mobileCertifications as $mobileCertification) {
         $certLabel = isset($certificationOptions[$mobileCertification['code']]) ? $certificationOptions[$mobileCertification['code']] : $mobileCertification['code'];
-        print '<div class="digirisk-protections-view__item">';
-        print '<div class="digirisk-protections-view__info">';
-        print '<div class="digirisk-protections-view__name">' . dol_escape_htmltag($certLabel) . '</div>';
-        if (!empty($mobileCertification['mandatory'])) {
-            print '<span class="badge badge-info">' . $langs->trans('MobilePPMandatory') . '</span>';
-        }
-        print '</div>';
-        print '</div>';
+        print '<tr class="oddeven">';
+        print '<td class="wordbreak">' . dol_escape_htmltag($certLabel) . '</td>';
+        print '<td class="center">' . (!empty($mobileCertification['mandatory']) ? '<span class="badge badge-info">' . $langs->trans('Yes') . '</span>' : '<span class="opacitymedium">' . $langs->trans('No') . '</span>') . '</td>';
+        print '</tr>';
     }
+    print '</table>';
     print '</div>';
     print '</div>';
 }

--- a/css/digiriskdolibarr.min.css
+++ b/css/digiriskdolibarr.min.css
@@ -7450,6 +7450,16 @@ body.digirisk-mobile-create .digirisk-mobile-share .copied-to-clipboard {
   margin-right: 4px;
 }
 
+/* Photos of a risk in the prevention plan card listing */
+.digirisk-risk-list-photo {
+  width: 44px;
+  height: 44px;
+  object-fit: cover;
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  vertical-align: middle;
+}
+
 /* Risk cell on the prevention plan card: danger picto + its name */
 .cell-risk-view {
   display: inline-flex;

--- a/css/scss/page/_mobile-quick-create.scss
+++ b/css/scss/page/_mobile-quick-create.scss
@@ -1367,6 +1367,16 @@ body.digirisk-mobile-create {
   margin-right: 4px;
 }
 
+/* Photos of a risk in the prevention plan card listing */
+.digirisk-risk-list-photo {
+  width: 44px;
+  height: 44px;
+  object-fit: cover;
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  vertical-align: middle;
+}
+
 /* Risk cell on the prevention plan card: danger picto + its name */
 .cell-risk-view {
   display: inline-flex;

--- a/langs/en_US/digiriskdolibarr.lang
+++ b/langs/en_US/digiriskdolibarr.lang
@@ -147,6 +147,7 @@ MobilePPDeleteRiskTitle = Delete the risk
 MobilePPDeleteRiskConfirm = "%s" will be removed from the plan, along with its description, its photos and its protections.
 MobilePPUserCompany = User company
 MobilePPUserCompanyShort = EU
+MobilePPConcernedCompanies = Concerns
 MobilePPExteriorCompanyShort = EE
 MobilePPPriorFormalities = Prior formalities
 MobilePPPriorVisitDone = Prior joint inspection done

--- a/langs/fr_FR/digiriskdolibarr.lang
+++ b/langs/fr_FR/digiriskdolibarr.lang
@@ -2045,6 +2045,7 @@ MobilePPDeleteRiskTitle = Supprimer le risque
 MobilePPDeleteRiskConfirm = « %s » va être retiré du plan, avec sa description, ses photos et ses protections.
 MobilePPUserCompany = Entreprise utilisatrice
 MobilePPUserCompanyShort = EU
+MobilePPConcernedCompanies = Concerne
 MobilePPExteriorCompanyShort = EE
 MobilePPPriorFormalities = Formalités préalables
 MobilePPPriorVisitDone = Inspection commune préalable effectuée

--- a/view/preventionplan/preventionplan_card.php
+++ b/view/preventionplan/preventionplan_card.php
@@ -1477,60 +1477,82 @@ if ((empty($action) || ($action != 'create' && $action != 'edit'))) {
 					}
 				}
 
-				print '<div class="digirisk-protections-view__list">';
+				print '<div class="div-table-responsive-no-min">';
+				print '<table class="noborder centpercent">';
+				print '<tr class="liste_titre">';
+				print '<td>' . $langs->trans('INRSRisk') . '</td>';
+				print '<td>' . $langs->trans('Description') . '</td>';
+				print '<td class="center">' . $langs->trans('MobilePPConcernedCompanies') . '</td>';
+				print '<td>' . $langs->trans('MobilePPProtections') . '</td>';
+				print '<td>' . $langs->trans('Photos') . '</td>';
+				print '</tr>';
+
 				foreach ($preventionplandets as $riskLine) {
 					$riskThumb = $risk->getDangerCategory($riskLine);
 					$riskName  = $risk->getDangerCategoryName($riskLine);
-					print '<div class="digirisk-protections-view__item">';
+
+					print '<tr class="oddeven">';
+
+					// Danger category: picto and name
+					print '<td class="nowraponall">';
 					if ($riskThumb != -1) {
-						print '<img src="' . DOL_URL_ROOT . '/custom/digiriskdolibarr/img/categorieDangers/' . $riskThumb . '.png" alt="" title="' . dol_escape_htmltag($riskName != -1 ? $riskName : '') . '">';
+						print '<img class="cell-risk-view__pic valignmiddle marginrightonly" src="' . DOL_URL_ROOT . '/custom/digiriskdolibarr/img/categorieDangers/' . $riskThumb . '.png" alt="" title="' . dol_escape_htmltag($riskName != -1 ? $riskName : '') . '">';
 					}
-					print '<div class="digirisk-protections-view__info">';
-					print '<div class="digirisk-protections-view__name">' . dol_escape_htmltag($riskName != -1 ? $riskName : $riskLine->ref);
+					print '<span class="valignmiddle">' . dol_escape_htmltag($riskName != -1 ? $riskName : $riskLine->ref) . '</span>';
+					print '</td>';
+
+					print '<td class="wordbreak">' . dol_escape_htmltag($riskLine->description) . '</td>';
+
 					// Which company the risk concerns, as captured by the mobile interface
+					print '<td class="center nowraponall">';
 					if (isset($mobileRiskCompanies[(string) $riskLine->category])) {
 						$riskCompanies = $mobileRiskCompanies[(string) $riskLine->category];
 						if (!empty($riskCompanies['eu'])) {
-							print ' <span class="badge badge-info" title="' . dol_escape_htmltag($langs->trans('MobilePPUserCompany')) . '">' . $langs->trans('MobilePPUserCompanyShort') . '</span>';
+							print '<span class="badge badge-info" title="' . dol_escape_htmltag($langs->trans('MobilePPUserCompany')) . '">' . $langs->trans('MobilePPUserCompanyShort') . '</span> ';
 						}
 						if (!empty($riskCompanies['ee'])) {
-							print ' <span class="badge badge-info" title="' . dol_escape_htmltag($langs->trans('MobilePPExteriorCompany')) . '">' . $langs->trans('MobilePPExteriorCompanyShort') . '</span>';
+							print '<span class="badge badge-info" title="' . dol_escape_htmltag($langs->trans('MobilePPExteriorCompany')) . '">' . $langs->trans('MobilePPExteriorCompanyShort') . '</span>';
 						}
+					} else {
+						print '<span class="opacitymedium">-</span>';
 					}
-					print '</div>';
-					if (dol_strlen($riskLine->description)) {
-						print '<div class="digirisk-protections-view__comment">' . dol_escape_htmltag($riskLine->description) . '</div>';
-					}
+					print '</td>';
 
-					$riskPhotos = digiriskMobileGetRiskPhotos($object->element, $object->ref, (int) $riskLine->category);
-					if (!empty($riskPhotos)) {
-						print '<div class="digirisk-protections-view__photos">';
-						foreach ($riskPhotos as $riskPhoto) {
-							print '<a href="' . $riskPhoto['url'] . '" target="_blank"><img src="' . $riskPhoto['url'] . '" alt=""></a>';
-						}
-						print '</div>';
-					}
-
+					// Protections (EPI) attached to this risk: pictos, the name is in the tooltip
+					print '<td class="nowraponall">';
+					$riskHasProtection = false;
 					if (is_array($mobileRiskProtections)) {
 						foreach ($mobileRiskProtections as $mobileRiskProtection) {
 							if (!isset($mobileRiskProtection['risk_category']) || (int) $mobileRiskProtection['risk_category'] !== (int) $riskLine->category || !isset($signalisationMap[$mobileRiskProtection['position']])) {
 								continue;
 							}
 							$protectionCategory = $signalisationMap[$mobileRiskProtection['position']];
-							print '<div class="digirisk-protections-view__subitem">';
-							print '<img src="' . DOL_URL_ROOT . '/custom/digiriskdolibarr/img/' . $protectionCategory['name_thumbnail'] . '" alt="" title="' . dol_escape_htmltag($protectionCategory['name']) . '">';
-							print '<span>' . dol_escape_htmltag($protectionCategory['name']);
-							if (!empty($mobileRiskProtection['comment'])) {
-								print ' — ' . dol_escape_htmltag($mobileRiskProtection['comment']);
-							}
-							print '</span>';
-							print '</div>';
+							$protectionTitle    = $protectionCategory['name'] . (dol_strlen($mobileRiskProtection['comment'] ?? '') ? ' - ' . $mobileRiskProtection['comment'] : '');
+							print '<img class="cell-risk-view__pic marginrightonly" src="' . DOL_URL_ROOT . '/custom/digiriskdolibarr/img/' . $protectionCategory['name_thumbnail'] . '" alt="" title="' . dol_escape_htmltag($protectionTitle) . '">';
+							$riskHasProtection = true;
 						}
 					}
+					if (!$riskHasProtection) {
+						print '<span class="opacitymedium">-</span>';
+					}
+					print '</td>';
 
-					print '</div>';
-					print '</div>';
+					// Photos taken on site from the mobile interface
+					print '<td class="nowraponall">';
+					$riskPhotos = digiriskMobileGetRiskPhotos($object->element, $object->ref, (int) $riskLine->category);
+					if (!empty($riskPhotos)) {
+						foreach ($riskPhotos as $riskPhoto) {
+							// attachment=0 : document.php affiche l'image dans l'onglet au lieu de la telecharger
+							print '<a href="' . $riskPhoto['url'] . '&attachment=0" target="_blank"><img class="digirisk-risk-list-photo marginrightonly" src="' . $riskPhoto['url'] . '" alt=""></a>';
+						}
+					} else {
+						print '<span class="opacitymedium">-</span>';
+					}
+					print '</td>';
+
+					print '</tr>';
 				}
+				print '</table>';
 				print '</div>';
 			} else {
 				print '<span class="opacitymedium">' . $langs->trans('None') . '</span>';

--- a/view/preventionplan/preventionplan_mobile_create.php
+++ b/view/preventionplan/preventionplan_mobile_create.php
@@ -591,10 +591,15 @@ if ($action == 'add_mobile' && $permissiontoadd) {
                     $line->create($user, true);
                 }
 
-                $saveRiskPhotos();
-
                 // Validate so signatures can be collected
                 $object->setPendingSignature($user, true);
+
+                // The definitive ref is only assigned during validation: until then the object
+                // carries its provisional one, which would send the photos to a directory nothing
+                // reads back, and put "(PROV12)" in the signature email
+                $object->fetch($object->id);
+
+                $saveRiskPhotos();
 
                 // Auto-sign the interior side (MasterWorker) with the responsible saved signature
                 $masterWorkers = $signatory->fetchSignatory('MasterWorker', $object->id, 'preventionplan');


### PR DESCRIPTION
## Changements

### Listings classiques

- Les risques de la fiche plan de prévention passent en tableau Dolibarr standard (`noborder` + `liste_titre` + `oddeven`) : catégorie de danger, description, entreprises concernées (EU / EE), protections, photos. Les cellules vides affichent `-` plutôt que de rester blanches.
- Les protections et les certifications obligatoires, partagées avec la fiche permis de feu, suivent le même format.

### Aperçu des photos

- Les photos d'un risque s'ouvrent dans l'onglet au clic (`attachment=0`) au lieu d'être téléchargées.

### Correctif

Le ref définitif d'un plan n'est attribué qu'à sa validation. La création mobile déplaçait les photos des risques **avant** cette étape, donc sous le ref provisoire (`(PROV16)`) : plus aucune photo n'était retrouvée ensuite. Le déplacement se fait maintenant après validation, avec relecture du ref. L'email de demande de signature, qui affichait lui aussi le ref provisoire, est corrigé du même coup.

## Fichiers modifiés

- `core/tpl/digiriskdolibarr_mobile_protections_view.tpl.php`
- `css/scss/page/_mobile-quick-create.scss` + `css/digiriskdolibarr.min.css`
- `langs/fr_FR/digiriskdolibarr.lang`, `langs/en_US/digiriskdolibarr.lang`
- `view/preventionplan/preventionplan_card.php`
- `view/preventionplan/preventionplan_mobile_create.php`

## Issue

Close #4956
