### PR TITLE
#4962 [Papripact] fix: undefined vars and missing warnings property in a3 pdf

### DIFF
--- a/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/projectdocument/pdf_papripact_a3_paysage_projectdocument.modules.php
+++ b/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/projectdocument/pdf_papripact_a3_paysage_projectdocument.modules.php
@@ -128,6 +128,21 @@ class pdf_papripact_a3_paysage_projectdocument
     public string $document_type = 'papripact_a3_paysage_projectdocument';
 
 	/**
+	 * @var string Error message
+	 */
+	public $error = '';
+
+	/**
+	 * @var string[] Array of error strings
+	 */
+	public $errors = array();
+
+	/**
+	 * @var string[] Array of warnings strings
+	 */
+	public $warnings = array();
+
+	/**
 	 *	Constructor
 	 *
 	 *  @param		DoliDB		$db      Database handler
@@ -442,6 +457,7 @@ class pdf_papripact_a3_paysage_projectdocument
 					return $b['cotation'] <=> $a['cotation'];
 				});
 				// Loop on each lines
+				$totalbudget = 0;
 
 				for ($i = 0; $i < $nblines; $i++) {
 					$curY = $nexY;
@@ -464,7 +480,7 @@ class pdf_papripact_a3_paysage_projectdocument
 					$dateend          = dol_print_date($objectDoc[$i]['date_end'], 'day');
 					$planned_workload = convertSecondToTime((int) $objectDoc[$i]['workload'], 'allhourmin');
                     $userExecutive    = $objectDoc[$i]['userExecutive'];
-					$totalbudget      += $objectDoc[$i]['budget'];
+					$totalbudget      += (float) $objectDoc[$i]['budget'];
 
 					$showpricebeforepagebreak = 1;
                     $labelHeightBefore = $pdf->GetY();
@@ -474,6 +490,7 @@ class pdf_papripact_a3_paysage_projectdocument
 					$pdf->MultiCell($this->posxdatestart - $this->posxlabel, 3, $outputLangs->convToOutputCharset($libelleline), 0, 'L');
                     $labelHeightAfter = $pdf->GetY();
                     $labelHeight = $labelHeightAfter - $labelHeightBefore;
+					$posyafter = $labelHeightAfter; // Y position reached by the label, used below to know if there is still room for the total block
 					$pageposafter = $pdf->getPage();
 					if ($pageposafter > $pageposbefore) { // There is a pagebreak
 						$pdf->rollbackTransaction(true);
@@ -575,7 +592,9 @@ class pdf_papripact_a3_paysage_projectdocument
 
                     // Executive name
                     $pdf->SetXY($this->posxuser, $curY);
-                    $pdf->MultiCell($this->posxrisk - $this->posxuser, 6, ucfirst(substr($userExecutive['firstname'], 0, 1)) . ucfirst(substr($userExecutive['lastname'], 0, 1)), 0, 'C');
+                    // A task has not necessarily a TASKEXECUTIVE contact, then $userExecutive is an empty array
+                    $userExecutiveInitials = ucfirst(substr($userExecutive['firstname'] ?? '', 0, 1)) . ucfirst(substr($userExecutive['lastname'] ?? '', 0, 1));
+                    $pdf->MultiCell($this->posxrisk - $this->posxuser, 6, $userExecutiveInitials, 0, 'C');
                     $pdf->SetFont(pdf_getPDFFont($outputLangs), '', $default_font_size - 1); // We restore font
 
 					// Risk


### PR DESCRIPTION
## Changements

- Initialisation de `$totalbudget` à `0` avant la boucle sur les lignes et cast en `(float)` à l'accumulation : la variable était utilisée avec `+=` sans initialisation, et relue après la boucle même quand le projet n'a aucune tâche.
- Sécurisation des initiales du contact référent : `liste_contact()` ne renvoie pas forcément de contact `TASKEXECUTIVE`, `$userExecutive` restait donc un tableau vide et warnait sur `firstname` / `lastname` pour chaque tâche.
- Assignation de `$posyafter` juste après l'écriture du libellé : la variable était testée pour détecter la place restante avant le bloc total, alors qu'elle n'était affectée que plus bas dans la branche `forcedesconsamepage`. Le branchement reste identique, seul le warning disparaît.
- Déclaration de `$error`, `$errors` et `$warnings` sur la classe du modèle PDF : elle n'hérite pas de `SaturneDocumentModel` / `CommonDocGenerator`, alors que `CommonObject::generateDocument()` lit ces trois propriétés au retour de `write_file()`.

Le `Cannot modify header information` sur `actionplan_list.php` était une conséquence de ces warnings, qui envoyaient le corps de la réponse avant le `header()` de redirection : il disparaît avec ces corrections.

## Fichiers modifiés

- `core/modules/digiriskdolibarr/digiriskdolibarrdocuments/projectdocument/pdf_papripact_a3_paysage_projectdocument.modules.php`

## Issue

Close #4962
