### PR TITLE
#4925 [PreventionPlan] fix: generation PDF impossible sous Linux et pieds de page manquants

### DIFF
--- a/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/accidentinvestigationdocument/pdf_accidentinvestigationdocument.modules.php
+++ b/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/accidentinvestigationdocument/pdf_accidentinvestigationdocument.modules.php
@@ -352,8 +352,11 @@ class pdf_accidentinvestigationdocument extends SaturneDocumentModel
         $moreParam['hideTemplateName'] = 1;
         $object->module                = $this->module;
 
+        // buildDocumentFilename rend -1 en cas d'echec, sinon le chemin du fichier. Comparer ce
+        // chemin a 0 le compare en fait a la chaine '0' : sous Linux il commence par '/', qui est
+        // inferieur a '0', et la generation echouerait systematiquement
         $file = $this->buildDocumentFilename($objectDocument, $outputLangs, $object, $moreParam);
-        if ($file < 0) {
+        if (!is_string($file) || empty($file)) {
             $this->error = $langs->transnoentities('ErrorFileNameCanNotBeBuilt');
             return -1;
         }

--- a/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/preventionplandocument/pdf_preventionplandocument.modules.php
+++ b/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/preventionplandocument/pdf_preventionplandocument.modules.php
@@ -178,18 +178,17 @@ class pdf_preventionplandocument extends SaturneDocumentModel
     }
 
     /**
-     * Termine la page courante puis en ouvre une nouvelle.
+     * Ouvre une nouvelle page.
      *
-     * Le pied est pose ici, sur la page qu'on quitte, plutot que dans une passe finale : revenir
-     * sur des pages deja fermees avec setPage() puis supprimer une page surnumeraire avec
-     * deletePage() produisait des pieds mal places.
+     * Le pied n'est pas pose ici : TCPDF ouvre aussi des pages tout seul quand un texte long
+     * depasse, et ces pages la ne passeraient jamais par cette methode. Il est ecrit en une passe
+     * finale sur toutes les pages, par _pagefooter().
      *
      * @param  TCPDF $pdf PDF handler
      * @return void
      */
     protected function newPage($pdf)
     {
-        $this->writeFooter($pdf);
         $pdf->AddPage();
         $pdf->SetY($this->marge_haute);
     }
@@ -424,7 +423,11 @@ class pdf_preventionplandocument extends SaturneDocumentModel
     }
 
     /**
-     * Pose le pied sur la page courante uniquement.
+     * Pose le pied sur toutes les pages, une fois le contenu ecrit.
+     *
+     * En une passe finale plutot qu'au fil de l'eau : TCPDF ouvre des pages de lui-meme quand un
+     * texte long depasse, et ces pages n'auraient sinon ni pied ni numero. Le nombre total de
+     * pages n'est de toute facon connu qu'ici, TCPDI ne supportant pas AliasNbPages.
      *
      * @param  TCPDF $pdf PDF handler
      * @return void
@@ -435,23 +438,32 @@ class pdf_preventionplandocument extends SaturneDocumentModel
             return;
         }
 
-        $currentY = $pdf->GetY();
-
-        // Le pied s'ecrit dans la bande basse, sous le seuil de rupture : sans couper la rupture
-        // automatique son Cell ouvrirait une page de plus
-        $pdf->SetAutoPageBreak(false);
+        $currentPage = $pdf->getPage();
+        $currentY    = $pdf->GetY();
+        $totalPages  = $pdf->getNumPages();
+        $halfWidth   = $this->contentWidth($pdf) / 2;
 
         $pdf->SetFont('', '', $this->footerFontSize);
         $pdf->SetTextColor(140, 140, 140);
 
-        $halfWidth = $this->contentWidth($pdf) / 2;
-        $pdf->SetXY($this->marge_gauche, $pdf->getPageHeight() - 12);
-        $pdf->Cell($halfWidth, 5, $this->footerText, 0, 0, 'L');
-        $pdf->Cell($halfWidth, 5, 'Page ' . $pdf->getPage(), 0, 0, 'R');
+        for ($page = 1; $page <= $totalPages; $page++) {
+            $pdf->setPage($page);
+            // Le pied s'ecrit dans la bande basse, sous le seuil de rupture : sans couper la
+            // rupture automatique son Cell serait reporte en haut de la page suivante. A recouper
+            // apres chaque setPage, qui restaure les reglages memorises de la page.
+            $pdf->SetAutoPageBreak(false);
+            $pdf->SetXY($this->marge_gauche, $pdf->getPageHeight() - 12);
+            $pdf->Cell($halfWidth, 5, $this->footerText, 0, 0, 'L');
+            $pdf->Cell($halfWidth, 5, 'Page ' . $page . ' / ' . $totalPages, 0, 0, 'R');
+        }
 
         $pdf->SetTextColor(0, 0, 0);
+
+        // Rendre la main sur la position d'avant la passe : laisser le curseur dans la bande
+        // basse ferait ouvrir une page blanche des le retour de la rupture automatique
+        $pdf->setPage($currentPage);
+        $pdf->SetXY($this->marge_gauche, $currentY);
         $pdf->SetAutoPageBreak(true, self::FOOTER_BAND);
-        $pdf->SetY($currentY);
     }
 
     /**
@@ -483,8 +495,11 @@ class pdf_preventionplandocument extends SaturneDocumentModel
         $moreParam['hideTemplateName'] = 1;
         $object->module                = $this->module;
 
+        // buildDocumentFilename rend -1 en cas d'echec, sinon le chemin du fichier. Comparer ce
+        // chemin a 0 le compare en fait a la chaine '0' : sous Linux il commence par '/', qui est
+        // inferieur a '0', et la generation echouerait systematiquement
         $file = $this->buildDocumentFilename($objectDocument, $outputLangs, $object, $moreParam);
-        if ($file < 0) {
+        if (!is_string($file) || empty($file)) {
             $this->error = $langs->transnoentities('ErrorFileNameCanNotBeBuilt');
             return -1;
         }

--- a/core/triggers/interface_99_modDigiriskdolibarr_DigiriskdolibarrTriggers.class.php
+++ b/core/triggers/interface_99_modDigiriskdolibarr_DigiriskdolibarrTriggers.class.php
@@ -954,8 +954,33 @@ class InterfaceDigiriskdolibarrTriggers extends DolibarrTriggers
             return;
         }
 
+        // La page publique de signature tourne dans la langue de son visiteur : quand l'entite a
+        // une langue fixee, le document la garde, sinon la signature d'un intervenant etranger
+        // regenererait le plan dans sa langue a lui, pour tout le monde. Avec MAIN_LANG_DEFAULT a
+        // 'auto' il n'y a pas de langue de reference : on ne peut que suivre la requete courante.
+        $outputLangs = $langs;
+        $defaultLang = getDolGlobalString('MAIN_LANG_DEFAULT');
+        if (!empty($defaultLang) && $defaultLang != 'auto' && $defaultLang != $langs->defaultlang) {
+            $outputLangs = new Translate('', $conf);
+            $outputLangs->setDefaultLang($defaultLang);
+        }
+
         $documentDir = $plan->element . 'document/' . dol_sanitizeFileName($plan->ref);
-        $relativeDir = 'digiriskdolibarr/' . $documentDir;
+        // Le chemin indexe dans llx_ecm_files est relatif a DOL_DATA_ROOT, et le multicompany
+        // intercale le numero d'entite : le deduire de dir_output plutot que de le coder en dur,
+        // sinon on cible le repertoire d'une autre entite
+        $relativeDir = trim(str_replace(DOL_DATA_ROOT, '', $conf->digiriskdolibarr->dir_output), '/') . '/' . $documentDir;
+
+        // On genere avant de supprimer : une generation en echec laisserait sinon le plan sans
+        // aucun document, alors que la diffusion est deja en ligne
+        $document   = new PreventionPlanDocument($this->db);
+        $moreParams = ['object' => $plan, 'user' => $user, 'objectType' => $plan->element];
+        if ($document->generateDocument('preventionplandocument', $outputLangs, 0, 0, 0, $moreParams) <= 0) {
+            dol_syslog('refreshPreventionPlanDocument : ' . $document->error, LOG_WARNING);
+            return;
+        }
+
+        $newFileName = basename($document->last_main_doc);
 
         // Anciennes generations : on ne touche qu'au repertoire du modele, jamais aux pieces
         // jointes deposees a la main sur le plan
@@ -963,24 +988,24 @@ class InterfaceDigiriskdolibarrTriggers extends DolibarrTriggers
         $previous->fetchAll('', '', 0, 0, '(t.filepath:=:\'' . $this->db->escape($relativeDir) . '\')');
         if (is_array($previous->lines)) {
             foreach ($previous->lines as $previousFile) {
+                if ($previousFile->filename == $newFileName) {
+                    continue;
+                }
                 $oldFile = new EcmFiles($this->db);
                 if ($oldFile->fetch($previousFile->id) > 0) {
                     $oldFile->delete($user);
                 }
-                dol_delete_file($conf->digiriskdolibarr->dir_output . '/' . $documentDir . '/' . $previousFile->filename, 0, 1);
+                // disableglob : le nom porte la raison sociale, dont les crochets seraient pris
+                // pour une classe de caracteres et laisseraient le fichier sur le disque
+                dol_delete_file($conf->digiriskdolibarr->dir_output . '/' . $documentDir . '/' . $previousFile->filename, 1, 1);
             }
-        }
-
-        $document   = new PreventionPlanDocument($this->db);
-        $moreParams = ['object' => $plan, 'user' => $user, 'objectType' => $plan->element];
-        if ($document->generateDocument('preventionplandocument', $langs, 0, 0, 0, $moreParams) <= 0) {
-            dol_syslog('refreshPreventionPlanDocument : ' . $document->error, LOG_WARNING);
-            return;
         }
 
         // Rattachement au plan + cle de partage + favori : les trois conditions pour que la page
         // publique trouve le document et l'affiche en apercu
-        $this->shareGeneratedFile(basename($document->last_main_doc), $plan->table_element, $plan->id, $user, true);
+        if ($this->shareGeneratedFile($newFileName, $plan->table_element, $plan->id, $user, true) < 0) {
+            dol_syslog('refreshPreventionPlanDocument : partage impossible pour ' . $newFileName, LOG_WARNING);
+        }
     }
 
     /**
@@ -1019,20 +1044,27 @@ class InterfaceDigiriskdolibarrTriggers extends DolibarrTriggers
      */
     protected function shareGeneratedFile(string $fileName, string $tableElement, int $objectId, User $user, bool $favorite = false): int
     {
+        global $conf;
+
         require_once DOL_DOCUMENT_ROOT . '/ecm/class/ecmfiles.class.php';
         require_once DOL_DOCUMENT_ROOT . '/core/lib/security2.lib.php';
 
-        $search = new EcmFiles($this->db);
-        $search->fetchAll('', '', 1, 0, '(t.filename:=:\'' . $this->db->escape($fileName) . '\')');
-        if (!is_array($search->lines) || empty($search->lines)) {
+        // Requete directe plutot que le filtre universel de fetchAll : le nom de fichier porte la
+        // raison sociale, dont une parenthese ou une apostrophe casserait l'analyse du filtre.
+        // L'entite est indispensable, deux entites pouvant heberger un fichier de meme nom.
+        $sql  = 'SELECT rowid FROM ' . MAIN_DB_PREFIX . 'ecm_files';
+        $sql .= ' WHERE filename = \'' . $this->db->escape($fileName) . '\'';
+        $sql .= ' AND entity = ' . (int) $conf->entity;
+        $sql .= ' ORDER BY rowid DESC LIMIT 1';
+
+        $resql = $this->db->query($sql);
+        if (!$resql || $this->db->num_rows($resql) == 0) {
             return -1;
         }
+        $found = $this->db->fetch_object($resql);
 
-        // fetchAll ne rend que des EcmFilesLine, qui n'ont pas de methode update : il faut relire
-        // la ligne complete avant de pouvoir l'enregistrer
-        $line    = array_shift($search->lines);
         $ecmFile = new EcmFiles($this->db);
-        if ($ecmFile->fetch($line->id) <= 0) {
+        if ($ecmFile->fetch($found->rowid) <= 0) {
             return -1;
         }
 


### PR DESCRIPTION
Correctifs sur le générateur PDF mergé en #4964, dont un qui empêche toute génération en production.

## Aucun PDF ne peut être généré sous Linux

```php
$file = $this->buildDocumentFilename(...);   // rend -1 ou le chemin du fichier
if ($file < 0) { ... return -1; }
```

En PHP 8, comparer une chaîne non numérique à un entier compare **deux chaînes**. Sous Linux le chemin commence par `/` (0x2F), inférieur à `'0'` (0x30) : la condition est toujours vraie et la génération s'arrête avant d'avoir commencé. Sous Windows le chemin commence par une lettre de lecteur, supérieure à `'0'`, ce qui masquait complètement le défaut en développement.

```
php -r "var_dump('/var/www/documents/x.pdf' < 0);"   // bool(true)
php -r "var_dump('C:/wamp64/documents/x.pdf' < 0);"  // bool(false)
```

Le garde teste désormais le type de retour. Les deux générateurs étaient touchés.

> À noter : `pdf_ticketdocument.modules.php` porte le même garde, hors périmètre de cette PR.

## Pieds de page absents et page blanche finale

Le pied n'était écrit que dans `newPage()`, donc uniquement sur les ruptures de page décidées par le code. Les pages ouvertes par TCPDF lui-même au milieu d'un texte long — les constantes de moyens et consignes en produisent — sortaient sans pied ni numéro.

Il est maintenant posé en une passe finale sur toutes les pages, ce qui permet au passage d'afficher le total (`Page 2 / 5`), que TCPDI ne sait pas donner autrement puisqu'il ne supporte pas `AliasNbPages()`.

Un piège au passage : `setPage()` restaure les réglages mémorisés de la page, dont la rupture automatique. Sans la recouper après **chaque** changement de page, le `Cell` du pied repasse au-dessus du seuil de rupture, part en haut de la page suivante et ajoute une page blanche.

## Régénération à la signature

- Le chemin cherché dans `llx_ecm_files` était préfixé en dur par `digiriskdolibarr/`, alors que le multicompany intercale le numéro d'entité. En entité 2 ou plus, la suppression visait le répertoire de l'entité 1 et épargnait celui de l'entité qui signe : l'ancien document restait sur la diffusion, et l'index d'une autre entité pouvait être touché.
- La ligne ECM du nouveau document était retrouvée par son seul nom de fichier, sans entité, via le filtre universel de `fetchAll` — qu'une parenthèse ou une apostrophe dans la raison sociale suffit à casser. Remplacé par une requête directe filtrée sur l'entité.
- L'ancien document était supprimé **avant** la génération du nouveau : une génération en échec laissait la diffusion en ligne sans aucun document. L'ordre est inversé, et le nouveau fichier est exclu de la purge.
- `dol_delete_file` était appelé avec le glob actif sur un nom précis : des crochets dans la raison sociale (`Martin [SAS]`) étaient interprétés comme une classe de caractères et le fichier restait sur le disque.
- La régénération suivait la langue du visiteur de la page publique : un intervenant étranger qui signe régénérait le plan dans sa langue, pour tout le monde. Quand l'entité a une langue fixée, le document la conserve. Avec `MAIN_LANG_DEFAULT = auto` il n'existe pas de langue de référence, on ne peut que suivre la requête.

## Tests

Signature du responsable EE du plan 16 depuis la page publique Saturne, PDF rastérisé et relu page par page :

- 5 pages, plus de sixième page blanche ;
- un pied et un numéro sur chacune, `Page 1 / 5` à `Page 5 / 5` ;
- ancien PDF supprimé du disque et de l'index, un seul aperçu sur la diffusion ;
- avec `Accept-Language: fr-FR`, document régénéré en français.

Génération du document de l'enquête accident 5 : toujours rattachée avec sa clé de partage.

Suite de #4964, items de #4925.
