### PR TITLE
#4925 [PreventionPlan] fix: adresse longue debordant de l'encadre entreprise

### DIFF
--- a/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/preventionplandocument/pdf_preventionplandocument.modules.php
+++ b/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/preventionplandocument/pdf_preventionplandocument.modules.php
@@ -332,11 +332,31 @@ class pdf_preventionplandocument extends SaturneDocumentModel
      */
     protected function twoBoxes($pdf, array $left, array $right, float $size)
     {
-        $gap      = 6;
-        $boxWidth = ($this->contentWidth($pdf) - $gap) / 2;
-        $rowCount = max(count($left['rows']), count($right['rows']));
+        $gap        = 6;
+        $boxWidth   = ($this->contentWidth($pdf) - $gap) / 2;
+        $labelWidth = $boxWidth * 0.34;
+        $valueWidth = $boxWidth - $labelWidth;
+        $rowCount   = max(count($left['rows']), count($right['rows']));
 
-        $this->reserveSpace($pdf, 10 + $rowCount * ($this->height + 1));
+        // Hauteur de chaque ligne, calculee sur les deux encadres a la fois : une adresse longue
+        // passe a la ligne au lieu de deborder du cadre, et les deux colonnes restent alignees
+        $rowHeights = [];
+        for ($index = 0; $index < $rowCount; $index++) {
+            $rowHeight = $this->height + 1;
+            foreach ([$left, $right] as $content) {
+                if (!isset($content['rows'][$index])) {
+                    continue;
+                }
+                $pdf->SetFont('', 'B', $size - 2);
+                $rowHeight = max($rowHeight, $pdf->getStringHeight($labelWidth, ' ' . $content['rows'][$index][0]));
+                $pdf->SetFont('', '', $size - 2);
+                $rowHeight = max($rowHeight, $pdf->getStringHeight($valueWidth, ' ' . $content['rows'][$index][1]));
+            }
+            $rowHeights[$index] = $rowHeight;
+        }
+
+        $bodyHeight = array_sum($rowHeights);
+        $this->reserveSpace($pdf, 10 + $bodyHeight);
 
         // Meme raison que pour les signatures : les deux colonnes partent du meme Y
         $pdf->SetAutoPageBreak(false);
@@ -351,18 +371,22 @@ class pdf_preventionplandocument extends SaturneDocumentModel
             $pdf->SetFillColor($this->headBg[0], $this->headBg[1], $this->headBg[2]);
             $pdf->Cell($boxWidth, 7, ' ' . $content['title'], 1, 1, 'L', true);
 
-            $labelWidth = $boxWidth * 0.34;
-            foreach ($content['rows'] as $row) {
-                $pdf->SetX($x);
+            $rowY = $startY + 7;
+            foreach ($content['rows'] as $index => $row) {
+                $pdf->SetXY($x, $rowY);
                 $pdf->SetFont('', 'B', $size - 2);
-                $pdf->Cell($labelWidth, $this->height + 1, ' ' . $row[0], 1, 0, 'L');
+                $pdf->MultiCell($labelWidth, $rowHeights[$index], ' ' . $row[0], 1, 'L', false, 0);
+
+                $pdf->SetXY($x + $labelWidth, $rowY);
                 $pdf->SetFont('', '', $size - 2);
-                $pdf->Cell($boxWidth - $labelWidth, $this->height + 1, ' ' . $row[1], 1, 1, 'L');
+                $pdf->MultiCell($valueWidth, $rowHeights[$index], ' ' . $row[1], 1, 'L', false, 0);
+
+                $rowY += $rowHeights[$index];
             }
         }
 
         $pdf->SetAutoPageBreak(true, self::FOOTER_BAND);
-        $pdf->SetY($startY + 7 + $rowCount * ($this->height + 1) + 2);
+        $pdf->SetY($startY + 7 + $bodyHeight + 2);
     }
 
     /**


### PR DESCRIPTION
Les lignes des deux encadrés « Entreprise Utilisatrice » et « Entreprise Extérieure » étaient écrites en `Cell()`, qui ne renvoie jamais à la ligne : une adresse un peu longue sortait du cadre et se superposait à l'encadré voisin.

**Avant** — l'adresse de l'entreprise extérieure déborde à droite :

```
| Adresse | L'APOGEE - BAT D1, 51 CORNICHE FLEURIE →
```

**Après** — elle passe à la ligne dans le cadre :

```
| Adresse | L'APOGEE - BAT D1, 51 CORNICHE |
|         | FLEURIE                        |
```

Les lignes passent en `MultiCell`, et la hauteur de chaque ligne est calculée sur les **deux** encadrés à la fois, via `getStringHeight()` : une adresse longue à droite fait grandir la ligne correspondante à gauche, de sorte que les deux colonnes restent alignées ligne à ligne et se terminent à la même hauteur. La hauteur réservée avant le tracé suit la même somme, pour que la rupture de page tienne compte des lignes repliées.

`table()` calculait déjà sa hauteur de ligne avec `getNumLines()`, seuls les encadrés étaient concernés.

## Tests

PDF du plan 16 régénéré et rastérisé :

- l'adresse `L'APOGEE - BAT D1, 51 CORNICHE FLEURIE` tient sur deux lignes à l'intérieur du cadre, plus aucun débordement ;
- les lignes Code postal et Ville restent alignées entre les deux encadrés ;
- toujours 5 pages, pieds de page et numérotation intacts (`Page 1 / 5` à `Page 5 / 5`).

Suite de #4965, items de #4925.
