### PR TITLE
#4968 [Ticket] fix: wrong record count and phantom pages with category filter on ticket list

### DIFF
--- a/class/actions_digiriskdolibarr.class.php
+++ b/class/actions_digiriskdolibarr.class.php
@@ -872,12 +872,9 @@ class ActionsDigiriskdolibarr
 
         $sql = '';
 		/* print_r($parameters); print_r($object); echo "action: " . $action; */
-		if (preg_match('/ticketlist|thirdpartyticket|projectticket/', $parameters['context'])) {	    // do something only for the context 'somecontext1' or 'somecontext2'
-			$searchCategoryTicketList = GETPOST('search_category_ticket_list');
-			if (!empty($searchCategoryTicketList)) {
-				$sql = ' LEFT JOIN '.MAIN_DB_PREFIX."categorie_ticket as ct ON t.rowid = ct.fk_ticket"; // We'll need this table joined to the select in order to filter by categ
-			}
-		}
+		// No join on categorie_ticket: the category filter is built with subqueries in printFieldListWhere().
+		// Joining would return one row per category link, and the record count of the list (a COUNT(*) built
+		// from this same request, with the GROUP BY stripped) would count those links instead of the tickets.
 
         $this->resprints = $sql;
         return 0; // or return 1 to replace standard code
@@ -900,7 +897,7 @@ class ActionsDigiriskdolibarr
 			if (is_array($searchCategoryTicketList) && !empty($searchCategoryTicketList)) {
 				foreach ($searchCategoryTicketList as $searchCategoryTicket) {
 					if (intval($searchCategoryTicket) == -2) {
-						$searchCategoryTicketSqlList[] = "ct.fk_categorie IS NULL";
+						$searchCategoryTicketSqlList[] = "t.rowid NOT IN (SELECT fk_ticket FROM " . MAIN_DB_PREFIX . "categorie_ticket)";
 					} elseif (intval($searchCategoryTicket) > 0) {
 						$searchCategoryTicketSqlList[] = "t.rowid IN (SELECT fk_ticket FROM " . MAIN_DB_PREFIX . "categorie_ticket WHERE fk_categorie = " . ((int)$searchCategoryTicket) . ")";
 					}
@@ -910,15 +907,14 @@ class ActionsDigiriskdolibarr
 				}
 			} else {
 				if (!empty($searchCategoryTicketList) && $searchCategoryTicketList > 0) {
-					$sql = " AND ct.fk_categorie = ".((int) $searchCategoryTicketList);
+					$sql = " AND t.rowid IN (SELECT fk_ticket FROM " . MAIN_DB_PREFIX . "categorie_ticket WHERE fk_categorie = " . ((int) $searchCategoryTicketList) . ")";
 				}
 				if ($searchCategoryTicketList == -2) {
-					$sql = " AND ct.fk_categorie IS NULL";
+					$sql = " AND t.rowid NOT IN (SELECT fk_ticket FROM " . MAIN_DB_PREFIX . "categorie_ticket)";
 				}
 			}
-			if (!empty($searchCategoryTicketList)) {
-				$sql .= " GROUP BY t.rowid";
-			}
+			// No GROUP BY: the subqueries above never duplicate a ticket, and a GROUP BY here would be
+			// stripped from the COUNT(*) request of the list, giving a wrong number of records and phantom pages.
 
             $this->resprints = $sql;
 		}
@@ -1658,6 +1654,8 @@ class ActionsDigiriskdolibarr
             if ($serviceId <= 0) {
                 return 0;
             }
+
+            require_once __DIR__ . '/digiriskelement.class.php';
 
             $digiriskelement = new DigiriskElement($db);
             $res = $digiriskelement->fetch($serviceId);


### PR DESCRIPTION
Closes #4968

## Symptôme

L'en-tête de la liste des tickets annonce beaucoup plus d'enregistrements qu'il n'y a de lignes (`Tickets (52)` pour 13 tickets). La pagination étant calculée sur ce compteur, elle propose des pages qui n'existent pas : on y tombe sur **une seule ligne** sous un en-tête qui annonce 52. Remonté par un client, reproduit à l'identique en local.

## Cause

Le filtre catégories ajoutait un `LEFT JOIN llx_categorie_ticket` (`printFieldListFrom`) puis compensait les doublons avec un `GROUP BY t.rowid` (`printFieldListWhere`).

Dolibarr construit le compteur de liste en transformant la requête en `COUNT(*)` **et en supprimant le `GROUP BY`** (`htdocs/ticket/list.php` : `preg_replace('/GROUP BY .*$/', '', $sqlforcount)`). Le compteur comptait donc les lignes de jointure (ticket × catégorie), pas les tickets — vérifié en SQL : 13 tickets réels → 52 lignes de jointure.

De plus `!empty($searchCategoryTicketList)` est vrai pour `['']` : le JOIN et le `GROUP BY` étaient ajoutés **même avec un multiselect catégories vide**, donc le bug se déclenchait sans aucun filtre visible.

## Correction

- JOIN et `GROUP BY` supprimés ; tous les cas passent en sous-requêtes (une sous-requête ne duplique jamais la ligne) ;
- « non catégorisé » : `t.rowid NOT IN (SELECT fk_ticket FROM llx_categorie_ticket)` au lieu de `ct.fk_categorie IS NULL` (même ensemble de résultats, vérifié) ;
- `require_once digiriskelement.class.php` ajouté avant le `new DigiriskElement` de `printFieldListValue` : rien ne garantit que la classe soit chargée à ce moment-là, et un fatal ici tronquerait la liste en plein tableau.

## Vérifications (base locale, 473 tickets)

| filtre | compteur avant | compteur après | lignes réelles |
|---|---|---|---|
| aucun | 67 | 67 | 67 |
| multiselect vide | **94** | 67 | 67 |
| non catégorisé | 52 | 52 | 52 |
| une catégorie (Registre) | **34** | 8 | 8 |
| Registre + ouverts & fermés | **52** | 13 | 13 |

- Pagination : 5 pages → 2 pages.
- Non-régression liste sans filtre : 473 annoncés, 25 lignes affichées, 0 erreur JS console.
- `php -l` OK.
