### PR TITLE
#4977 [Module] fix: activation impossible apres une premiere activation

### DIFF
--- a/core/modules/modDigiriskDolibarr.class.php
+++ b/core/modules/modDigiriskDolibarr.class.php
@@ -2194,6 +2194,10 @@ class modDigiriskdolibarr extends DolibarrModules
 		delDocumentModel('legaldisplay_odt', 'legaldisplay');
 		delDocumentModel('firepermitdocument_odt', 'firepermitdocument');
 		delDocumentModel('preventionplandocument_odt', 'preventionplandocument');
+		// Modele PDF natif : sans cette suppression, la reactivation du module rejoue son insertion
+		// sur une ligne deja presente et addDocumentModel s'arrete sur une erreur de cle dupliquee,
+		// ce qui interrompt l'activation
+		delDocumentModel('preventionplandocument', 'preventionplandocument');
 		delDocumentModel('preventionplandocument_specimen_odt', 'preventionplandocumentspecimen');
 		delDocumentModel('groupmentdocument_odt', 'groupmentdocument');
 		delDocumentModel('groupmentdocument', 'groupmentdocument');
@@ -2213,6 +2217,7 @@ class modDigiriskdolibarr extends DolibarrModules
         delDocumentModel('papripact_a3_paysage_projectdocument', 'project');
         delDocumentModel('orque_projectdocument', 'project');
         delDocumentModel('accidentinvestigationdocument_odt', 'accidentinvestigationdocument');
+        delDocumentModel('accidentinvestigationdocument', 'accidentinvestigationdocument');
         delDocumentModel('registerdocument_odt', 'registerdocument');
         delDocumentModel('ticketdocument', 'ticketdocument');
 


### PR DESCRIPTION
## Changements

`init()` de `modDigiriskDolibarr.class.php` supprime puis réinsère chaque modèle de document, ce qui rend l'activation rejouable. Deux modèles PDF natifs y échappaient : ils étaient **ajoutés sans suppression préalable**.

| Modèle | Avant | Après |
|---|---|---|
| `preventionplandocument` | add seul | del + add |
| `accidentinvestigationdocument` | add seul | del + add |
| `groupmentdocument` | del + add | inchangé |
| `ticketdocument` | del + add | inchangé |

La table portant une clé unique `uk_document_model (nom, type, entity)`, la deuxième activation tombait sur la ligne déjà présente et `addDocumentModel()` terminait par `dol_print_error()` — l'activation s'interrompait sur l'écran d'erreur technique :

```
Duplicate entry 'accidentinvestigationdocument-accidentinvestigationdocument-1' for key 'uk_document_model'
```

Les deux lignes fautives venaient de #4925 (`eaa6f338`, PR #4964), qui a introduit les générateurs PDF natifs.

## Vérifications

Contrôle automatique sur l'ensemble du fichier : **26 `addDocumentModel`, 0 sans `delDocumentModel` correspondant** (2 avant le correctif).

Séquence `del` + `add` rejouée deux fois de suite sur les quatre modèles PDF natifs, avec les lignes déjà présentes en base :

```
--- activation numéro 1 ---
  preventionplandocument           add=1   lignes=1
  accidentinvestigationdocument    add=1   lignes=1
  groupmentdocument                add=1   lignes=1
  ticketdocument                   add=1   lignes=1
--- activation numéro 2 ---
  preventionplandocument           add=1   lignes=1
  accidentinvestigationdocument    add=1   lignes=1
  groupmentdocument                add=1   lignes=1
  ticketdocument                   add=1   lignes=1
```

Aucun doublon, aucune activation interrompue.

## Fichiers modifiés

- `core/modules/modDigiriskDolibarr.class.php`

## Issue

Close #4977
