### PR TITLE
Fix: module activation failing due to missing extrafields tables

### DIFF
--- a/core/modules/modDigiriskDolibarr.class.php
+++ b/core/modules/modDigiriskDolibarr.class.php
@@ -387,7 +387,7 @@ class modDigiriskdolibarr extends DolibarrModules
 		$this->descriptionlong = "Digirisk";
 		$this->editor_name     = 'Evarisk';
 		$this->editor_url      = 'https://evarisk.com';
-		$this->version         = '23.1.0';
+		$this->version         = '23.1.1';
 		$this->const_name      = 'MAIN_MODULE_' . strtoupper($this->name);
 		$this->picto           = 'digiriskdolibarr_color@digiriskdolibarr';
 

--- a/sql/firepermit/llx_digiriskdolibarr_firepermit_extrafields.key.sql
+++ b/sql/firepermit/llx_digiriskdolibarr_firepermit_extrafields.key.sql
@@ -1,0 +1,16 @@
+-- Copyright (C) 2021-2023 EVARISK <technique@evarisk.com>
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see https://www.gnu.org/licenses/.
+
+ALTER TABLE llx_digiriskdolibarr_firepermit_extrafields ADD INDEX idx_fk_object(fk_object);

--- a/sql/firepermit/llx_digiriskdolibarr_firepermit_extrafields.sql
+++ b/sql/firepermit/llx_digiriskdolibarr_firepermit_extrafields.sql
@@ -1,0 +1,22 @@
+-- Copyright (C) 2021-2023 EVARISK <technique@evarisk.com>
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see https://www.gnu.org/licenses/.
+
+create table llx_digiriskdolibarr_firepermit_extrafields(
+    rowid      integer AUTO_INCREMENT PRIMARY KEY,
+    tms        timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+--     entity     integer DEFAULT 1 NOT NULL,
+    import_key varchar(14),
+    fk_object  integer NOT NULL
+) ENGINE=innodb;

--- a/sql/preventionplan/llx_digiriskdolibarr_preventionplan_extrafields.key.sql
+++ b/sql/preventionplan/llx_digiriskdolibarr_preventionplan_extrafields.key.sql
@@ -1,0 +1,16 @@
+-- Copyright (C) 2021-2023 EVARISK <technique@evarisk.com>
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see https://www.gnu.org/licenses/.
+
+ALTER TABLE llx_digiriskdolibarr_preventionplan_extrafields ADD INDEX idx_fk_object(fk_object);

--- a/sql/preventionplan/llx_digiriskdolibarr_preventionplan_extrafields.sql
+++ b/sql/preventionplan/llx_digiriskdolibarr_preventionplan_extrafields.sql
@@ -1,0 +1,22 @@
+-- Copyright (C) 2021-2023 EVARISK <technique@evarisk.com>
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see https://www.gnu.org/licenses/.
+
+create table llx_digiriskdolibarr_preventionplan_extrafields(
+    rowid      integer AUTO_INCREMENT PRIMARY KEY,
+    tms        timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+--     entity     integer DEFAULT 1 NOT NULL,
+    import_key varchar(14),
+    fk_object  integer NOT NULL
+) ENGINE=innodb;


### PR DESCRIPTION
Resolves #4980. This PR adds the missing SQL creation scripts for llx_digiriskdolibarr_preventionplan_extrafields and llx_digiriskdolibarr_firepermit_extrafields tables. Without these tables, the saturne_manage_extrafields call during module initialization fails, preventing the activation of the module.