### PR TITLE
#4982 [Risk] fix: listing des risques partagés illisible à l'import

### DIFF
--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_sharedrisklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_sharedrisklist_view.tpl.php
@@ -525,7 +525,8 @@ while ($i < ($limit ? min($num, $limit) : $num)) {
 				<?php
 				print getNomUrlEntity($risk, 1, 'nolink', 1);
 			} elseif ($key == 'fk_element') {
-                if (is_object($alldigiriskelement[$risk->fk_element])) {
+                // L'élément parent est absent de la liste s'il a été mis à la corbeille
+                if (is_object($alldigiriskelement[$risk->fk_element] ?? null)) {
                     // Display either parent element or every parent elements of the risk according to conf
                     if (!getDolGlobalInt('DIGIRISKDOLIBARR_RISK_LIST_PARENT_VIEW')) {
                         print $alldigiriskelement[$risk->fk_element]->getNomUrl(1, 'blank', 0, '', -1, 1);

--- a/css/scss/modal/_risk-shared.scss
+++ b/css/scss/modal/_risk-shared.scss
@@ -7,38 +7,91 @@
     border-collapse: collapse;
   }
   .tagtr {
-    //display: flex;
     border-bottom: 1px solid rgba(0,0,0,0.2);
   }
   .tagtd {
     padding: 0.3em 0;
   }
+  // Chaque ligne est une cellule unique contenant les colonnes du risque partagé. Une
+  // grille au gabarit fixe garantit que toutes les lignes s'alignent, y compris celles
+  // qui portent la case « tout sélectionner » ou le badge « déjà importé » : ces deux
+  // pistes gardent leur largeur même quand elles sont vides.
+  // height: auto est indispensable car le thème eldy impose
+  // `.confirmquestions .tagtr .tagtd { height: 2em }` : hors table-cell cette hauteur
+  // devient fixe et le contenu déborde sur les lignes suivantes.
   .tagtr > .tagtd:first-child {
-    display: flex;
+    display: grid;
+    grid-template-columns:
+      minmax(0, 1fr)    // entité
+      minmax(0, 1.1fr)  // unité de travail
+      minmax(0, 1.9fr)  // risque
+      2.4em             // cotation
+      2.6em             // vignette de l'évaluation
+      minmax(0, 1.7fr)  // commentaire de l'évaluation
+      4.4em             // badge « déjà importé »
+      1.1em;            // sélection de toute l'unité de travail
+    align-items: center;
+    column-gap: 0.5em;
+    height: auto;
 
-    .importsharedrisk:not(.imported):not(.risk-evaluation-cotation) {
-      width: 30%;
-    }
-    .importsharedrisk.imported {
-      width: 10%;
-      text-align: center;
-      font-size: 12px;
+    > * {
+      min-width: 0;
     }
     .importsharedrisk {
+      overflow-wrap: anywhere;
+
       img {
         float: left;
         margin-right: 0.4em;
-        max-width: 35px;
+        max-width: 22px;
+        height: 22px;
       }
+      // overflow crée un contexte de formatage : le libellé reste aligné à côté de
+      // l'icône au lieu de repasser dessous à partir de la deuxième ligne
       > span {
         display: block;
+        overflow: hidden;
       }
       .importsharedrisk-ref {
         font-weight: 600;
       }
     }
+    // Badge et case de sélection groupée sont épinglés : ils apparaissent chacun sur une
+    // partie des lignes seulement, l'auto-placement les ferait glisser d'une piste
+    .importsharedrisk.imported {
+      grid-column: 7;
+      text-align: center;
+      font-size: 11px;
+      line-height: 1.2;
+    }
+    // La cotation garde ses 50px sur les autres écrans, trop large pour ce listing dense
+    > .risk-evaluation-cotation {
+      width: 2.4em;
+      min-width: 0;
+      height: 2.4em;
+      line-height: 2.4em;
+      font-size: 13px;
+      margin-right: 0;
+    }
+    .risk-evaluation-photo .photo {
+      width: 2.6em;
+      height: 2.6em;
+      object-fit: cover;
+    }
+    // Collée à droite de la cellule pour venir toucher la case de sélection de la ligne,
+    // qui est dans la cellule suivante
+    > input[type="checkbox"] {
+      grid-column: 8;
+      justify-self: end;
+      margin: 0;
+    }
   }
   .tagtr > .tagtd:last-child {
     vertical-align: middle;
+    padding-left: 0;
+
+    input[type="checkbox"] {
+      margin-left: 3px;
+    }
   }
 }

--- a/css/scss/modal/_risksign-shared.scss
+++ b/css/scss/modal/_risksign-shared.scss
@@ -7,38 +7,72 @@
     border-collapse: collapse;
   }
   .tagtr {
-    //display: flex;
     border-bottom: 1px solid rgba(0,0,0,0.2);
   }
   .tagtd {
     padding: 0.3em 0;
   }
+  // Même gabarit que pour les risques partagés : grille à pistes fixes pour que toutes
+  // les lignes s'alignent, et height: auto pour neutraliser le `height: 2em` que le thème
+  // eldy applique à `.confirmquestions .tagtr .tagtd`
   .tagtr > .tagtd:first-child {
-    display: flex;
+    display: grid;
+    grid-template-columns:
+      minmax(0, 1fr)    // entité
+      minmax(0, 1.1fr)  // unité de travail
+      minmax(0, 2.4fr)  // signalisation
+      4.4em             // badge « déjà importé »
+      1.1em;            // sélection de toute l'unité de travail
+    align-items: center;
+    column-gap: 0.5em;
+    height: auto;
 
-    .importsharedrisksign:not(.imported) {
-      width: 30%;
-    }
-    .importsharedrisksign.imported {
-      width: 10%;
-      text-align: center;
-      font-size: 12px;
+    > * {
+      min-width: 0;
     }
     .importsharedrisksign {
+      overflow-wrap: anywhere;
+
       img {
         float: left;
         margin-right: 0.4em;
-        max-width: 35px;
+        max-width: 22px;
+        height: 22px;
       }
+      // overflow crée un contexte de formatage : le libellé reste aligné à côté de
+      // l'icône au lieu de repasser dessous à partir de la deuxième ligne
       > span {
         display: block;
+        overflow: hidden;
       }
       .importsharedrisksign-ref {
         font-weight: 600;
       }
     }
+    // Badge et case de sélection groupée sont épinglés : ils apparaissent chacun sur une
+    // partie des lignes seulement, l'auto-placement les ferait glisser d'une piste.
+    // La vue génère la classe au pluriel, les deux sont ciblées.
+    .importsharedrisksign.imported,
+    .importsharedrisksigns.imported {
+      grid-column: 4;
+      text-align: center;
+      font-size: 11px;
+      line-height: 1.2;
+    }
+    // Collée à droite de la cellule pour venir toucher la case de sélection de la ligne,
+    // qui est dans la cellule suivante
+    > input[type="checkbox"] {
+      grid-column: 5;
+      justify-self: end;
+      margin: 0;
+    }
   }
   .tagtr > .tagtd:last-child {
     vertical-align: middle;
+    padding-left: 0;
+
+    input[type="checkbox"] {
+      margin-left: 3px;
+    }
   }
 }

--- a/view/digiriskelement/digiriskelement_risk.php
+++ b/view/digiriskelement/digiriskelement_risk.php
@@ -271,7 +271,9 @@ if ($sharedrisks) {
 
 		$previousDigiriskElement = 0;
 		foreach ($allrisks as $key => $risks) {
-			$digiriskelementtmp = $alldigiriskelement[$risks->fk_element];
+			// Un risque partagé peut pointer sur un élément mis à la corbeille : il est absent
+			// de la liste des éléments actifs, la ligne est alors simplement ignorée
+			$digiriskelementtmp = $alldigiriskelement[$risks->fk_element] ?? null;
 
 			if(is_object($digiriskelementtmp)) {
 				$digiriskelementtmp->element = 'digiriskdolibarr';
@@ -319,7 +321,7 @@ if ($sharedrisks) {
 					$pathToThumb  = DOL_URL_ROOT . '/custom/digiriskdolibarr/documents/viewimage.php?modulepart=digiriskdolibarr&entity=' . $risks->entity . '&file=' . urlencode($lastEvaluation->element . '/' . $lastEvaluation->ref . '/thumbs/');
 					$nophoto      = DOL_URL_ROOT.'/public/theme/common/nophoto.png';
 
-					$importValue .= '<div class="risk-evaluation-photo risk-evaluation-photo-'. ($lastEvaluation->id > 0 ? $lastEvaluation->id : 0) .  ($risk->id > 0 ? ' risk-' . $risk->id : ' risk-new') .' open-medias-linked" style="margin-right: 0.5em">';
+					$importValue .= '<div class="risk-evaluation-photo risk-evaluation-photo-'. ($lastEvaluation->id > 0 ? $lastEvaluation->id : 0) .  ($risk->id > 0 ? ' risk-' . $risk->id : ' risk-new') .' open-medias-linked">';
 					$importValue .= '<span class="risk-evaluation-photo-single">';
 					$importValue .= '<input class="filepath-to-riskassessment filepath-to-riskassessment-'.( $risk->id > 0 ? $risk->id : 'new') .'" type="hidden" value="'. $pathToThumb .'">';
 					$importValue .=	'<input class="filename" type="hidden" value="">';


### PR DESCRIPTION
## Contexte

Le listing de la modale « Importer des risques partagés » sortait illisible : les lignes se chevauchaient les unes sur les autres.

## Cause

Deux règles CSS en conflit :

- thème eldy (`global.inc.php`) : `.confirmquestions .tagtr .tagtd { height: 2em; }`
- Digirisk (`_risk-shared.scss`) : `.tagtr > .tagtd:first-child { display: flex; }`

Sur une `display: table-cell`, `height` n'est qu'un minimum et la cellule grandit avec son contenu. Passée en `display: flex`, ce n'est plus une cellule de tableau : les `2em` deviennent une hauteur fixe et les colonnes (entité / unité / risque / cotation / évaluation), qui font 2 à 4 lignes chacune, débordaient sur les lignes suivantes.

S'ajoutait un `width: 30%` appliqué à quatre colonnes, soit 120 % de la largeur de la cellule, d'où l'écrasement irrégulier des colonnes.

## Changements

- Remplacement du `display: flex` par un `display: grid` à gabarit fixe, identique sur chaque ligne, de sorte que toutes les colonnes s'alignent d'une ligne à l'autre.
- Les pistes de la case « tout sélectionner l'unité de travail » et du badge « Déjà importé » gardent leur largeur même quand elles sont vides : les lignes qui portent ces éléments restent alignées avec les autres.
- La case « tout sélectionner l'unité de travail » est placée en dernière colonne, collée à la case de sélection de la ligne, au lieu d'en être séparée par le badge et le `padding` du thème.
- Cotation ramenée de 50 px à 2.4em et icône de catégorie de danger de 35 px à 22 px : dans ce listing dense, elles laissaient trop peu de place aux colonnes de texte.
- `overflow: hidden` sur les libellés pour qu'ils restent alignés à côté de l'icône du danger au lieu de repasser dessous à partir de la deuxième ligne.
- Même correction appliquée à la modale « Importer des signalisations partagées », qui présentait le défaut à l'identique.
- Suppression d'un `style="margin-right"` inline sur la vignette de l'évaluation, remplacé par le `column-gap` de la grille.

Correction complémentaire d'un warning PHP relevé sur la même page : un risque partagé dont l'élément parent a été mis à la corbeille est absent de la liste des éléments actifs, et l'accès au tableau n'était pas gardé (`Undefined array key`). La ligne est désormais simplement ignorée.

## Fichiers modifiés

- `css/scss/modal/_risk-shared.scss`
- `css/scss/modal/_risksign-shared.scss`
- `view/digiriskelement/digiriskelement_risk.php`
- `core/tpl/riskanalysis/risk/digiriskdolibarr_sharedrisklist_view.tpl.php`

Le `css/digiriskdolibarr.min.css` n'est pas commité, il est régénéré par la CI.

## Issue

Close #4982
