### PR TITLE
#4606 [Document] fix: aperçu des modèles PDF depuis la configuration Documents

### DIFF
--- a/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/accidentinvestigationdocument/pdf_accidentinvestigationdocument.modules.php
+++ b/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/accidentinvestigationdocument/pdf_accidentinvestigationdocument.modules.php
@@ -452,7 +452,7 @@ class pdf_accidentinvestigationdocument extends SaturneDocumentModel
         $preventiveActionTask = is_array($actionTask) ? array_pop($actionTask) : null;
         $totalCATask          = is_object($curativeActionTask) ? $curativeActionTask->hasChildren() : 0;
         $totalPATask          = is_object($preventiveActionTask) ? $preventiveActionTask->hasChildren() : 0;
-        $totalBudget          = get_recursive_task_budget($object->fk_task);
+        $totalBudget          = get_recursive_task_budget((int) $object->fk_task);
 
         $data = [
             'investigation_date_start' => $object->date_start ? dol_print_date($object->date_start, 'dayhour', 'tzuser') : '',

--- a/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/projectdocument/pdf_papripact_a3_paysage_projectdocument.modules.php
+++ b/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/projectdocument/pdf_papripact_a3_paysage_projectdocument.modules.php
@@ -280,10 +280,12 @@ class pdf_papripact_a3_paysage_projectdocument
 
             $objectDocumentRef = dol_sanitizeFileName($objectDocument->ref);
 
-            $dir = $conf->projet->dir_output . '/' . (dol_strlen($object->ref) > 0 ? $object->ref : '');
-
+            // A generated report is filed with the project it reports on, a specimen has no
+            // project: file it in the module directory, where the admin preview looks for it
             if ($moreParam['specimen'] == 1 && $moreParam['zone'] == 'public') {
-                $dir .= 'public_specimen';
+                $dir = getMultidirOutput($objectDocument, $objectDocument->module) . '/' . $objectDocument->element . '/public_specimen';
+            } else {
+                $dir = $conf->projet->dir_output . '/' . (dol_strlen($object->ref) > 0 ? $object->ref : '');
             }
 
             if (!file_exists($dir)) {

--- a/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/ticketdocument/pdf_ticketdocument.modules.php
+++ b/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/ticketdocument/pdf_ticketdocument.modules.php
@@ -22,6 +22,9 @@
      * \brief   File of class to generate control document pdf
      */
 
+    // Load Dolibarr libraries
+    require_once DOL_DOCUMENT_ROOT . '/categories/class/categorie.class.php';
+
     // Load Saturne libraries
     require_once __DIR__ . '/../../../../../../saturne/core/modules/saturne/modules_saturne.php';
     require_once __DIR__ . '/../../../../../../saturne/lib/medias.lib.php';


### PR DESCRIPTION
Closes #4606

Le lien Aperçu des 4 modèles PDF de la configuration Documents ouvrait une page blanche. La part générique du bug (résolution de la classe document, redirection vers le spécimen, objet spécimen vide) est corrigée dans **Evarisk/Saturne#1521** ; cette PR corrige les bugs propres aux modèles Digirisk.

## Correctifs

- **PAPRIPACT** — le spécimen était écrit dans le répertoire du module Projet (`documents/projet/public_specimen/`), là où l'aperçu ne le cherche pas : `document.php` répondait « Le fichier n'existe pas » pour un rapport pourtant généré. Un rapport réel reste classé avec son projet, seul le spécimen part dans le répertoire du module.
- **Ticket** — le modèle construit des objets `Categorie` sans requérir la classe : ça ne marchait que si un autre include l'avait déjà chargée, et c'était fatal depuis la page Documents.
- **Enquête accident** — `get_recursive_task_budget()` recevait un `fk_task` non chargé alors que son paramètre est typé `int`.

## Tests

Sur Dolibarr 23, les 4 aperçus renvoient `200 application/pdf` et s'affichent correctement (PAPRIPACT-A3-PAYSAGE, Plan de prévention 3 pages, Ticket, Enquête accident). La case « Défaut » de la ligne PAPRIPACT se coche, et la page ne produit plus de warning PHP.

Dépend de Evarisk/Saturne#1521 (mergée).

🤖 Generated with [Claude Code](https://claude.com/claude-code)