### PR TITLE
#4706 [Ticket] feat: entrée de menu Ticket dans le menu gauche Digirisk

### DIFF
--- a/core/modules/modDigiriskDolibarr.class.php
+++ b/core/modules/modDigiriskDolibarr.class.php
@@ -371,7 +371,7 @@ class modDigiriskdolibarr extends DolibarrModules
 			$this->errors[] = $langs->trans('activateModuleDependNotSatisfied', 'Digirisk', 'Saturne');
 		}
 
-		$langs->loadLangs(['digiriskdolibarr@digiriskdolibarr', 'categories']);
+		$langs->loadLangs(['digiriskdolibarr@digiriskdolibarr', 'categories', 'ticket']);
 
 		// Id for module (must be unique).
 		// Use here a free id (See in Home -> System information -> Dolibarr for list of used modules id).
@@ -1731,6 +1731,53 @@ class modDigiriskdolibarr extends DolibarrModules
             'perms'    => '$user->rights->digiriskdolibarr->lire && $user->rights->digiriskdolibarr->accidentinvestigation->read', // Use 'perms'=>'$user->rights->digiriskdolibarr->level1->level2' if you want your menu with a permission rules
             'target'   => '',
             'user'     => 0,				                // 0=Menu for internal users, 1=external users, 2=both
+        ];
+
+        // Issue #4706 - Registre des tickets accessible directement depuis le menu gauche Digirisk.
+        $this->menu[$r++] = [
+            'fk_menu'  => 'fk_mainmenu=digiriskdolibarr',	    // '' if this is a top menu. For left menu, use 'fk_mainmenu=xxx' or 'fk_mainmenu=xxx,fk_leftmenu=yyy' where xxx is mainmenucode and yyy is a leftmenucode
+            'type'     => 'left',			                // This is a Left menu entry
+            'titre'    => $langs->transnoentities('Ticket'),
+            'prefix'   => '<i class="fas fa-ticket-alt pictofixedwidth"></i>',
+            'mainmenu' => 'digiriskdolibarr',
+            'leftmenu' => 'digiriskticket',
+            'url'      => '/digiriskdolibarr/view/ticket/ticket_management_dashboard.php',
+            'langs'    => 'digiriskdolibarr@digiriskdolibarr',	        // Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
+            'position' => 100 + $r,
+            'enabled'  => 'isModEnabled(\'digiriskdolibarr\') && isModEnabled(\'ticket\')',  // Define condition to show or hide menu entry. Use '!empty($conf->digiriskdolibarr->enabled)' if entry must be visible if module is enabled. Use '$leftmenu==\'system\'' to show if leftmenu system is selected.
+            'perms'    => '$user->rights->digiriskdolibarr->lire && $user->rights->ticket->read', // Use 'perms'=>'$user->rights->digiriskdolibarr->level1->level2' if you want your menu with a permission rules
+            'target'   => '',
+            'user'     => 0,				                // 0=Menu for internal users, 1=external users, 2=both
+        ];
+
+        $this->menu[$r++] = [
+            'fk_menu'  => 'fk_mainmenu=digiriskdolibarr,fk_leftmenu=digiriskticket',
+            'type'     => 'left',
+            'titre'    => '<i class="fas fa-list pictofixedwidth"></i>' . $langs->transnoentities('TicketList'),
+            'mainmenu' => 'digiriskdolibarr',
+            'leftmenu' => 'digiriskdolibarr_ticketlist',
+            'url'      => '/ticket/list.php',
+            'langs'    => 'digiriskdolibarr@digiriskdolibarr',
+            'position' => 100 + $r,
+            'enabled'  => 'isModEnabled(\'digiriskdolibarr\') && isModEnabled(\'ticket\')',
+            'perms'    => '$user->rights->digiriskdolibarr->lire && $user->rights->ticket->read',
+            'target'   => '',
+            'user'     => 0,
+        ];
+
+        $this->menu[$r++] = [
+            'fk_menu'  => 'fk_mainmenu=digiriskdolibarr,fk_leftmenu=digiriskticket',
+            'type'     => 'left',
+            'titre'    => '<i class="fas fa-tags pictofixedwidth" style="padding-right: 4px;"></i>' . $langs->transnoentities('Categories'),
+            'mainmenu' => 'digiriskdolibarr',
+            'leftmenu' => 'digiriskdolibarr_tickettags',
+            'url'      => '/categories/categorie_list.php?type=ticket',
+            'langs'    => 'digiriskdolibarr@digiriskdolibarr',
+            'position' => 100 + $r,
+            'enabled'  => 'isModEnabled(\'digiriskdolibarr\') && isModEnabled(\'ticket\') && isModEnabled(\'categorie\')',
+            'perms'    => '$user->rights->digiriskdolibarr->lire && $user->rights->ticket->read',
+            'target'   => '',
+            'user'     => 0,
         ];
 
 		$this->menu[$r++] = [


### PR DESCRIPTION
Closes #4706

## Contexte

Les tickets n'étaient accessibles que depuis le menu principal **Tickets** de Dolibarr. Cette PR les rend accessibles directement depuis le menu gauche de Digirisk, au même titre que les autres registres.

## Modifications

`core/modules/modDigiriskDolibarr.class.php` — trois entrées de menu gauche ajoutées sous `fk_mainmenu=digiriskdolibarr`, construites sur le même modèle que le bloc « Accident » et placées juste après « Enquête accident » :

| Entrée | `leftmenu` | Cible |
|---|---|---|
| **Ticket** (parent, `fa-ticket-alt`) | `digiriskticket` | `view/ticket/ticket_management_dashboard.php` |
| **Liste des tickets** (`fa-list`) | `digiriskdolibarr_ticketlist` | `/ticket/list.php` |
| **Tags/catégories** (`fa-tags`) | `digiriskdolibarr_tickettags` | `/categories/categorie_list.php?type=ticket` |

- `enabled` : module Ticket requis (+ module Catégories pour les tags).
- `perms` : `digiriskdolibarr->lire && ticket->read`.
- Les codes `leftmenu` sont distincts de ceux des entrées existantes sous `fk_mainmenu=ticket` (`digiriskticketlist`, `ticketstats`) pour éviter toute collision.
- Le fichier de langue `ticket` est chargé dans le descripteur afin que `Ticket` / `TicketList` soient traduits au moment de l'insertion des menus.

## Tests effectués

Menus régénérés (`delete_menus()` + `insert_menus()`), puis vérification navigateur (Playwright, compte admin) :

- les trois entrées apparaissent au bon endroit dans le menu gauche Digirisk ;
- **Ticket** → « Tableau de bord de gestion des tickets » ;
- **Liste des tickets** → liste Dolibarr (473 tickets), onglet Digirisk conservé dans le menu haut ;
- **Tags/catégories** → « Tags/catégories (Tickets) » (25 catégories) ;
- aucune erreur JS, aucun warning PHP introduit (les warnings `saturnedashboard.class.php:319` du tableau de bord sont préexistants et identiques via l'ancien point d'entrée).

> ⚠️ Une réactivation du module (ou une régénération des menus) est nécessaire pour que les entrées apparaissent.