### PR TITLE
#4694 [PreventionPlan] feat: notes publique et privée

### DIFF
--- a/class/preventionplan.class.php
+++ b/class/preventionplan.class.php
@@ -89,6 +89,8 @@ class PreventionPlan extends SaturneObject
         'prior_visit_text'     => ['type' => 'text',         'label' => 'PriorVisitText',    'enabled' => 1, 'position' => 100, 'notnull' => 0, 'visible' => 3],
         'prior_visit_date'     => ['type' => 'datetime',     'label' => 'PriorVisitDate',    'enabled' => 1, 'position' => 110, 'notnull' => 0, 'visible' => 3],
         'cssct_intervention'   => ['type' => 'boolean',      'label' => 'CSSCTIntervention', 'enabled' => 1, 'position' => 120, 'notnull' => 0, 'visible' => 3],
+        'note_public'          => ['type' => 'html',         'label' => 'NotePublic',        'enabled' => 1, 'position' => 130, 'notnull' => 0, 'visible' => 0],
+        'note_private'         => ['type' => 'html',         'label' => 'NotePrivate',       'enabled' => 1, 'position' => 135, 'notnull' => 0, 'visible' => 0],
         'fk_user_creat'        => ['type' => 'integer:User:user/class/user.class.php',           'label' => 'UserAuthor', 'picto' => 'user',    'enabled' => 1,                         'position' => 140, 'notnull' => 1, 'visible' => 0, 'foreignkey' => 'user.rowid'],
         'fk_user_modif'        => ['type' => 'integer:User:user/class/user.class.php',           'label' => 'UserModif',  'picto' => 'user',    'enabled' => 1,                         'position' => 150, 'notnull' => 0, 'visible' => 0, 'foreignkey' => 'user.rowid'],
         'fk_project'           => ['type' => 'integer:Project:projet/class/project.class.php:1', 'label' => 'Project',    'picto' => 'project', 'enabled' => '$conf->project->enabled', 'position' => 85,  'notnull' => 1, 'visible' => 1, 'index' => 1, 'css' => 'maxwidth500 widthcentpercentminusxx', 'validate' => 1, 'foreignkey' => 'projet.rowid'],

--- a/sql/preventionplan/llx_digiriskdolibarr_preventionplan.sql
+++ b/sql/preventionplan/llx_digiriskdolibarr_preventionplan.sql
@@ -28,6 +28,8 @@ CREATE TABLE llx_digiriskdolibarr_preventionplan(
   prior_visit_date   datetime,
   prior_visit_text   text,
   cssct_intervention boolean,
+  note_public        text,
+  note_private       text,
   fk_user_creat      integer NOT NULL,
   fk_user_modif      integer,
   fk_project         integer NOT NULL

--- a/sql/update.sql
+++ b/sql/update.sql
@@ -275,3 +275,7 @@ FROM llx_projet_task t
 LEFT JOIN llx_projet_task_extrafields ef ON ef.fk_object = t.rowid
 WHERE ef.fk_object IS NULL
   AND (t.label LIKE '% - T1 - %' OR t.label LIKE '% - T2 - %');
+
+-- 23.1.x - prevention plan public/private notes
+ALTER TABLE llx_digiriskdolibarr_preventionplan ADD note_public text NULL AFTER cssct_intervention;
+ALTER TABLE llx_digiriskdolibarr_preventionplan ADD note_private text NULL AFTER note_public;


### PR DESCRIPTION
## Contexte

Le plan de prévention était le seul objet Digirisk signable à ne pas exposer d'onglet **Notes** : ni note publique ni note privée, alors que l'enquête accident (et tous les objets Dolibarr standard) les proposent.

## Modifications

- `class/preventionplan.class.php` : ajout de `note_public` / `note_private` (type `html`, `visible => 0`) dans `$fields`. L'onglet Notes de Saturne est conditionné à la présence de ces champs (`saturne_object_prepare_head`), il apparaît donc sans code supplémentaire, avec son compteur.
- `sql/preventionplan/llx_digiriskdolibarr_preventionplan.sql` : les deux colonnes pour les nouvelles installations.
- `sql/update.sql` : les `ALTER TABLE` pour les bases existantes.

`visible => 0` : l'édition passe par l'onglet Notes, les notes ne viennent donc ni alourdir le formulaire de création/modification ni ajouter de colonnes à la liste.

## Tests réalisés (local, Dolibarr 23.0.3)

- Création d'un plan de prévention via le formulaire : OK, pas de champ parasite.
- Onglet **Notes** présent sur la fiche, saisie et enregistrement de la note publique **et** de la note privée : contenu persisté en base, badge du compteur à 2.
- Modification du plan (libellé) : les deux notes sont conservées.
- Liste des plans de prévention : inchangée.

⚠️ Comme pour toute évolution de schéma, il faut **désactiver/réactiver le module** pour que `update.sql` soit joué, sinon les `fetch()` échouent (colonnes manquantes).

Closes #4694

🤖 Generated with [Claude Code](https://claude.com/claude-code)