### PR TITLE
#4619 [DigiriskElement] feat: éditeur WYSIWYG sur la description des GP/UT

### DIFF
--- a/class/digiriskelement.class.php
+++ b/class/digiriskelement.class.php
@@ -89,7 +89,7 @@ class DigiriskElement extends SaturneObject
         'import_key'       => ['type' => 'integer', 'label' => 'ImportId', 'enabled' => '1', 'position' => 60, 'notnull' => 1, 'visible' => -2,],
         'status'           => ['type' => 'smallint', 'label' => 'Status', 'enabled' => '1', 'position' => 70, 'notnull' => 1, 'default' => 1, 'visible' => 1, 'index' => 1,],
         'label'            => ['type' => 'varchar(255)', 'label' => 'Label', 'enabled' => '1', 'position' => 80, 'notnull' => 1, 'visible' => 1, 'searchall' => 1, 'css' => 'minwidth400', 'showoncombobox' => '1',],
-        'description'      => ['type' => 'textarea', 'label' => 'Description', 'enabled' => '1', 'position' => 90, 'notnull' => 0, 'visible' => 3,],
+        'description'      => ['type' => 'html', 'label' => 'Description', 'enabled' => '1', 'position' => 90, 'notnull' => 0, 'visible' => 3,],
         'element_type'     => ['type' => 'varchar(50)', 'label' => 'ElementType', 'enabled' => '1', 'position' => 100, 'notnull' => -1, 'visible' => 1,],
         'photo'            => ['type' => 'varchar(255)', 'label' => 'Photo', 'enabled' => '1', 'position' => 105, 'notnull' => -1, 'visible' => -2,],
         'show_in_selector' => ['type' => 'boolean', 'label' => 'ShowInSelectOnPublicTicketInterface', 'enabled' => '1', 'position' => 106, 'notnull' => 1, 'visible' => 1, 'default' => 1,],
@@ -603,11 +603,16 @@ class DigiriskElement extends SaturneObject
 
         // Description shown after a comment icon, made inline-editable (contenteditable) when the
         // user can write; saved via saturne_update_field.php like the list inline edits.
+        // The field is filled with the WYSIWYG editor on the card, so the banner only shows its
+        // plain text projection: block tags would break the one line banner layout and the inline
+        // editor handles plain text only. Closing block tags become spaces so paragraphs and list
+        // items are not glued together once the markup is dropped.
         $descriptionIcon = '<i class="fas fa-comment-dots" title="' . dol_escape_htmltag($langs->trans("Description")) . '"></i> ';
+        $descriptionText = dol_string_nohtmltag(str_replace(['</p>', '</li>'], ' ', $this->description));
         if (!empty($user->rights->digiriskdolibarr->digiriskelement->write)) {
-            $descriptionHtml = $descriptionIcon . '<span class="contenteditable" contenteditable="true" role="textbox" aria-label="' . dol_escape_htmltag($langs->trans("Description")) . '" data-field="description" data-id="' . ((int) $this->id) . '" data-element="' . dol_escape_htmltag($this->element . '@' . $this->module) . '" data-table="' . dol_escape_htmltag($this->table_element) . '" data-type="text" data-success="' . dol_escape_htmltag($langs->trans("RecordSaved")) . '" data-error="' . dol_escape_htmltag($langs->trans("Error")) . '">' . dol_escape_htmltag($this->description) . '</span>';
+            $descriptionHtml = $descriptionIcon . '<span class="contenteditable" contenteditable="true" role="textbox" aria-label="' . dol_escape_htmltag($langs->trans("Description")) . '" data-field="description" data-id="' . ((int) $this->id) . '" data-element="' . dol_escape_htmltag($this->element . '@' . $this->module) . '" data-table="' . dol_escape_htmltag($this->table_element) . '" data-type="text" data-success="' . dol_escape_htmltag($langs->trans("RecordSaved")) . '" data-error="' . dol_escape_htmltag($langs->trans("Error")) . '">' . dol_escape_htmltag($descriptionText) . '</span>';
         } else {
-            $descriptionHtml = $descriptionIcon . dol_escape_htmltag($this->description);
+            $descriptionHtml = $descriptionIcon . dol_escape_htmltag($descriptionText);
         }
 
         if ($result > 0) {

--- a/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/riskassessmentdocument/doc_riskassessmentdocument_odt.modules.php
+++ b/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/riskassessmentdocument/doc_riskassessmentdocument_odt.modules.php
@@ -194,7 +194,10 @@ class doc_riskassessmentdocument_odt extends ModeleODTDigiriskDolibarrDocument
 
             foreach ($orderedDigiriskElements as $orderedDigiriskElementId => $orderedDigiriskElement) {
                 $tmpArray['digiriskElementLabel']         = 'S' . $orderedDigiriskElement['object']->entity . ' - ' . $orderedDigiriskElement['object']->ref . ' - ' . $orderedDigiriskElement['object']->label;
-                $tmpArray['description']                  = $orderedDigiriskElement['object']->description;
+                // The description is filled with the WYSIWYG editor and the ODT library only keeps
+                // inline tags: closing block tags become spaces so paragraphs and list items are
+                // not glued together in the document.
+                $tmpArray['description']                  = str_replace(['</p>', '</li>'], ' ', $orderedDigiriskElement['object']->description);
                 $tmpArray['totalRiskAssessmentCotations'] = $riskByRiskAssessmentCotations[$orderedDigiriskElementId]['totalRiskAssessmentCotations'] ?: 0;
                 foreach ($riskAssessmentCotationTypes as $i => $riskAssessmentCotationType) {
                     $tmpArray['nb' . $riskAssessmentCotationType] = $riskByRiskAssessmentCotations[$orderedDigiriskElementId][$i] ?? 0;

--- a/view/digiriskelement/digiriskelement_card.php
+++ b/view/digiriskelement/digiriskelement_card.php
@@ -217,7 +217,6 @@ if ($action == 'create') {
 	unset($object->fields['fk_parent']);
 	unset($object->fields['last_main_doc']);
 	unset($object->fields['entity']);
-	unset($object->fields['description']);
 	unset($object->fields['show_in_selector']);
 
 	print '<table class="border centpercent tableforfieldcreate">' . "\n";
@@ -233,11 +232,6 @@ if ($action == 'create') {
 	print '</td></tr>';
 
 	include DOL_DOCUMENT_ROOT . '/core/tpl/commonfields_add.tpl.php';
-
-	print '<tr><td>' . $langs->trans("Description") . '</td><td>';
-	print '<input hidden class="flat" type="text" size="36" name="description" id="description">';
-	print '<textarea name="description" id="description" class="minwidth400" rows="' . ROWS_3 . '">' . '</textarea>' . "\n";
-	print '</td></tr>';
 
 	print '<input hidden class="flat" type="text" size="36" name="element_type" value="' . $element_type . '">';
 	print '<input hidden class="flat" type="text" size="36" name="fk_parent" value="' . $fkParent . '">';
@@ -358,6 +352,9 @@ if ((empty($action) || ($action != 'edit' && $action != 'create'))) {
 	print '<div class="fichecenter">';
 	print '<div class="fichehalfleft">';
 	print '<table class="border centpercent tableforfield">';
+
+	print '<tr><td class="titlefield tdtop">' . $langs->trans("Description") . '</td>';
+	print '<td>' . (dol_strlen($object->description) ? $object->description : '<span class="opacitymedium">&mdash;</span>') . '</td></tr>';
 
 	print '<tr><td class="titlefield">';
 	print $langs->trans("ShowInSelectOnPublicTicketInterface");


### PR DESCRIPTION
Closes #4619

La description d'un groupement ou d'une unité de travail se saisissait dans un simple textarea : aucune mise en forme n'était possible, et les balises saisies à la main étaient de toute façon supprimées à l'enregistrement (le type `textarea` fait lire le champ en `GETPOST … 'nohtml'`).

## Ce que fait la PR

- `description` passe en type `html` : les formulaires de **création** et de **modification** affichent l'éditeur WYSIWYG standard de Dolibarr — comme les autres descriptions du module (accident, permis de feu, configuration) — et le contenu est enregistré au filtre `restricthtml`.
- Le textarea écrit à la main dans le formulaire de création laisse la place au gabarit commun `commonfields_add.tpl.php`. Cela supprime au passage l'`<input hidden name="description" id="description">` qui dupliquait l'identifiant du champ juste au-dessus du textarea.
- La fiche gagne une ligne « Description » qui affiche la mise en forme.
- Le bandeau continue d'afficher la description, mais en texte brut : les balises de bloc casseraient sa mise en page sur une ligne, et son édition en ligne (`contenteditable`, #4896) ne manipule que du texte. Les fins de bloc (`</p>`, `</li>`) deviennent des espaces pour que les paragraphes et les puces ne se collent pas.
- Même précaution pour le document unique : la bibliothèque ODT ne conserve que les balises en ligne (`<strong>`, `<em>`, `<u>`, `<br>`…) et laisse tomber les autres, donc les fins de bloc y deviennent aussi des espaces.

## Point d'attention

Modifier la description depuis le bandeau (édition en ligne) la remplace par le texte brut affiché : la mise en forme se fait via **Modifier**. Faire manipuler du HTML au `contenteditable` supposerait un type `html` côté Saturne (`contentEditable.js` envoie `$el.text()`), à voir dans une évolution séparée si le besoin se confirme.

## Tests

Playwright sur Dolibarr 23.0.3 en local (module FCKeditor actif, `FCKEDITOR_ENABLE_SOCIETE = 1`) :

- formulaire de modification : `#cke_description` présent, plus aucun textarea nu visible ;
- saisie gras + liste puis enregistrement : le HTML est bien stocké (`restricthtml` ne l'a pas filtré) ;
- fiche : la description s'affiche mise en forme, le bandeau en texte brut ;
- formulaire de création : éditeur présent, un seul champ `#description` ;
- aucune erreur JS nouvelle (la seule remontée, `offset().top` sur `#unit…` dans l'arborescence de gauche, préexiste et ne vient pas d'ici).

### Formulaire de modification

![Éditeur WYSIWYG sur la description](https://raw.githubusercontent.com/nicolas-eoxia/digiriskdolibarr/screenshots/4619/edit-wysiwyg.png)

### Fiche du groupement

![Description mise en forme sur la fiche](https://raw.githubusercontent.com/nicolas-eoxia/digiriskdolibarr/screenshots/4619/card-description.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
