### PR TITLE
#4388 [Risk] feat: tableau de bord des risques sur la page des risques professionnels

### DIFF
--- a/class/riskanalysis/risk.class.php
+++ b/class/riskanalysis/risk.class.php
@@ -63,6 +63,12 @@ class Risk extends SaturneObject
     public const STATUS_LOCKED    = 2;
     public const STATUS_ARCHIVED  = 3;
 
+    /**
+     * @var int Pseudo level of the cotation scale gathering the risks without any validated assessment.
+     *          Negative so it never collides with a real level, -1 being the empty value of the list filter.
+     */
+    public const COTATION_NOT_ASSESSED = -2;
+
 	/**
 	 * @var string String with name of icon for risk. Must be the part after the 'object_' into object_risk.png
 	 */
@@ -1059,27 +1065,113 @@ class Risk extends SaturneObject
      * A risk is assessed as many times as it is reviewed, and only its last validated assessment tells where it
      * stands today: that is the one the dashboard graph counts, so the criteria reads the same one.
      *
-     * @param  int    $cotationLevel Level of the cotation scale, from 1 (grey) to 4 (black)
+     * @param  int    $cotationLevel Level of the cotation scale, from 1 (grey) to 4 (black),
+     *                               or COTATION_NOT_ASSESSED for the risks still to assess
      * @return string                SQL criteria, empty when the level is not one of the scale
      */
     public function getCotationSqlFilter(int $cotationLevel): string
     {
-        if (empty($this->cotations[$cotationLevel])) {
+        if ($cotationLevel != self::COTATION_NOT_ASSESSED && empty($this->cotations[$cotationLevel])) {
             return '';
         }
 
         $riskAssessmentTable = MAIN_DB_PREFIX . (new RiskAssessment($this->db))->table_element;
 
-        // The highest level has no upper bound, a cotation computed with the advanced method can exceed its end
-        $cotationFilter = ' AND ra.cotation >= ' . (int) $this->cotations[$cotationLevel]['start'];
-        if (isset($this->cotations[$cotationLevel + 1])) {
-            $cotationFilter .= ' AND ra.cotation <= ' . (int) $this->cotations[$cotationLevel]['end'];
+        if ($cotationLevel == self::COTATION_NOT_ASSESSED) {
+            // A risk still to assess is one the levels of the scale leave out: its last validated assessment
+            // is missing, or carries no cotation at all
+            $operator       = 'NOT IN';
+            $cotationFilter = ' WHERE lastra.cotation IS NOT NULL';
+        } else {
+            $operator = 'IN';
+
+            // The highest level has no upper bound, a cotation computed with the advanced method can exceed its end
+            $cotationFilter = ' WHERE lastra.cotation >= ' . (int) $this->cotations[$cotationLevel]['start'];
+            if (isset($this->cotations[$cotationLevel + 1])) {
+                $cotationFilter .= ' AND lastra.cotation <= ' . (int) $this->cotations[$cotationLevel]['end'];
+            }
         }
 
-        return ' AND r.rowid IN (SELECT ra.fk_risk FROM ' . $riskAssessmentTable . ' as ra'
-             . ' WHERE ra.status = ' . RiskAssessment::STATUS_VALIDATED . $cotationFilter
-             . ' AND ra.rowid = (SELECT MAX(lastra.rowid) FROM ' . $riskAssessmentTable . ' as lastra'
-             . ' WHERE lastra.fk_risk = ra.fk_risk AND lastra.status = ' . RiskAssessment::STATUS_VALIDATED . '))';
+        // The last validated assessment of every risk is picked in one pass: correlating that subquery to each
+        // risk costs a full scan of the assessments per risk, seconds long on a base of a few thousand risks
+        return ' AND r.rowid ' . $operator . ' (SELECT lastid.fk_risk'
+             . ' FROM (SELECT ra.fk_risk as fk_risk, MAX(ra.rowid) as rowid FROM ' . $riskAssessmentTable . ' as ra'
+             . ' WHERE ra.status = ' . RiskAssessment::STATUS_VALIDATED . ' GROUP BY ra.fk_risk) as lastid'
+             . ' INNER JOIN ' . $riskAssessmentTable . ' as lastra ON lastra.rowid = lastid.rowid'
+             . $cotationFilter . ')';
+    }
+
+    /**
+     * Get the level of the cotation scale a cotation falls in
+     *
+     * @param  float $cotation Cotation of a risk assessment
+     * @return int             Level of the scale, from 1 (grey) to 4 (black)
+     */
+    public function getCotationLevel(float $cotation): int
+    {
+        $level = (int) array_key_first($this->cotations);
+        foreach ($this->cotations as $cotationLevel => $cotationScale) {
+            if ($cotation >= $cotationScale['start']) {
+                $level = $cotationLevel;
+            }
+        }
+
+        return $level;
+    }
+
+    /**
+     * Get the number of risks by level of the cotation scale, for the dashboard of the risk list
+     *
+     * Counts the risks the list shows when no filter is set: the ones of the current entity attached to an
+     * active element. A risk is placed on the level of its last validated assessment, the one
+     * getCotationSqlFilter() reads, so each count matches the number of rows the list shows once filtered
+     * on that level.
+     *
+     * @param  string $riskType Type of risk ('risk' or 'riskenvironmental')
+     * @return array            Number of risks, by level of the scale plus 'total' and COTATION_NOT_ASSESSED
+     */
+    public function getRiskCountsByCotationLevel(string $riskType = 'risk'): array
+    {
+        global $conf;
+
+        $counts = ['total' => 0, self::COTATION_NOT_ASSESSED => 0];
+        foreach (array_keys($this->cotations) as $cotationLevel) {
+            $counts[$cotationLevel] = 0;
+        }
+
+        $riskAssessmentTable = MAIN_DB_PREFIX . (new RiskAssessment($this->db))->table_element;
+        $elementTable        = MAIN_DB_PREFIX . (new DigiriskElement($this->db))->table_element;
+
+        $sql  = 'SELECT lastra.cotation as cotation, COUNT(r.rowid) as nb';
+        $sql .= ' FROM ' . MAIN_DB_PREFIX . $this->table_element . ' as r';
+        $sql .= ' INNER JOIN ' . $elementTable . ' as e ON e.rowid = r.fk_element';
+        $sql .= ' AND e.status = ' . DigiriskElement::STATUS_VALIDATED . ' AND e.entity = ' . (int) $conf->entity;
+        // The last assessment of every risk is picked in one pass: correlating that subquery to each risk
+        // costs a full scan of the assessments per risk, seconds long on a document unique of a few thousand
+        $sql .= ' LEFT JOIN (SELECT ra.fk_risk as fk_risk, MAX(ra.rowid) as rowid FROM ' . $riskAssessmentTable . ' as ra';
+        $sql .= ' WHERE ra.status = ' . RiskAssessment::STATUS_VALIDATED . ' GROUP BY ra.fk_risk) as lastid ON lastid.fk_risk = r.rowid';
+        $sql .= ' LEFT JOIN ' . $riskAssessmentTable . ' as lastra ON lastra.rowid = lastid.rowid';
+        $sql .= ' WHERE r.entity IN (' . getEntity($this->element) . ')';
+        $sql .= " AND r.type = '" . $this->db->escape($riskType) . "'";
+        $sql .= ' GROUP BY lastra.cotation';
+
+        $resql = $this->db->query($sql);
+        if (!$resql) {
+            $this->errors[] = 'Error ' . $this->db->lasterror();
+            dol_syslog(__METHOD__ . ' ' . implode(',', $this->errors), LOG_ERR);
+
+            return $counts;
+        }
+
+        while ($obj = $this->db->fetch_object($resql)) {
+            $cotationLevel = isset($obj->cotation) ? $this->getCotationLevel((float) $obj->cotation) : self::COTATION_NOT_ASSESSED;
+
+            $counts[$cotationLevel] += (int) $obj->nb;
+            $counts['total']        += (int) $obj->nb;
+        }
+        $this->db->free($resql);
+
+        return $counts;
     }
 
     /**

--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_riskdashboard_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_riskdashboard_view.tpl.php
@@ -1,0 +1,73 @@
+<?php
+/* Copyright (C) 2021-2026 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    core/tpl/riskanalysis/risk/digiriskdolibarr_riskdashboard_view.tpl.php
+ * \ingroup digiriskdolibarr
+ * \brief   Dashboard shown above the risk list: number of risks by level of the cotation scale
+ *
+ * Variables expected from calling PHP:
+ * - $risk                      Risk      Risk object, holds the cotation scale
+ * - $riskCountsByCotationLevel array     Counts from Risk::getRiskCountsByCotationLevel()
+ * - $riskType                  string    Type of risk listed ('risk' or 'riskenvironmental')
+ * - $searchCotation            int       Level the list is currently filtered on, 0 for none
+ * - $langs                     Translate Translation object
+ */
+
+$riskListUrl = dol_buildpath('/digiriskdolibarr/view/digiriskelement/risk_list.php', 1) . '?mainmenu=digiriskdolibarr&risk_type=' . urlencode($riskType);
+
+// The total opens the unfiltered list, each other tile filters the list on its own level of the scale.
+// Clicking the level the list already shows removes the filter, so a tile toggles its own criteria.
+$riskDashboardTiles = [[
+    'scale'    => 'total',
+    'label'    => $langs->transnoentities(ucfirst($riskType) . 's'),
+    'count'    => $riskCountsByCotationLevel['total'],
+    'selected' => empty($searchCotation),
+    'url'      => $riskListUrl
+]];
+
+foreach ($risk->getCotations() as $cotationLevel => $cotation) {
+    $riskDashboardTiles[] = [
+        'scale'    => $cotationLevel,
+        'label'    => $cotation['label'],
+        'count'    => $riskCountsByCotationLevel[$cotationLevel],
+        'selected' => $searchCotation == $cotationLevel,
+        'url'      => $riskListUrl . ($searchCotation == $cotationLevel ? '' : '&search_cotation=' . $cotationLevel)
+    ];
+}
+
+// Risks left to assess only clutter the dashboard of a document unique where every risk is assessed.
+// Sorting the list on a cotation leaves them out, so their tile sorts the list on the risk reference instead.
+if ($riskCountsByCotationLevel[Risk::COTATION_NOT_ASSESSED] > 0) {
+    $riskDashboardTiles[] = [
+        'scale'    => 'notassessed',
+        'label'    => $langs->transnoentities('RisksNotAssessed'),
+        'count'    => $riskCountsByCotationLevel[Risk::COTATION_NOT_ASSESSED],
+        'selected' => $searchCotation == Risk::COTATION_NOT_ASSESSED,
+        'url'      => $riskListUrl . ($searchCotation == Risk::COTATION_NOT_ASSESSED ? '' : '&search_cotation=' . Risk::COTATION_NOT_ASSESSED . '&sortfield=r.ref&sortorder=ASC')
+    ];
+}
+?>
+
+<div class="fichecenter risk-dashboard<?php echo ($riskType == 'riskenvironmental' ? ' risk-dashboard--riskenvironmental' : ''); ?>">
+    <?php foreach ($riskDashboardTiles as $riskDashboardTile) : ?>
+        <a class="risk-dashboard__tile<?php echo ($riskDashboardTile['selected'] ? ' selected' : ''); ?>" href="<?php echo $riskDashboardTile['url']; ?>">
+            <span class="risk-dashboard__count" data-scale="<?php echo $riskDashboardTile['scale']; ?>"><?php echo $riskDashboardTile['count']; ?></span>
+            <span class="risk-dashboard__label"><?php echo dol_escape_htmltag($riskDashboardTile['label']); ?></span>
+        </a>
+    <?php endforeach; ?>
+</div>

--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
@@ -399,9 +399,7 @@ if ( ! preg_match('/(evaluation)/', $sortfield)) {
     if (!empty($conf->categorie->enabled) && getDolGlobalInt('DIGIRISKDOLIBARR_CATEGORY_ON_RISK') > 0) {
         $sql .= Categorie::getFilterSelectQuery('risk', 'r.rowid', $search_category_array);
     }
-    if ($searchCotation > 0) {
-        $sql .= $risk->getCotationSqlFilter($searchCotation);
-    }
+    $sql .= $risk->getCotationSqlFilter($searchCotation);
     // Add where from extra fields
     include DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_list_search_sql.tpl.php';
     // Add where from hooks
@@ -515,9 +513,7 @@ if ( ! preg_match('/(evaluation)/', $sortfield)) {
     if (!empty($conf->categorie->enabled) && getDolGlobalInt('DIGIRISKDOLIBARR_CATEGORY_ON_RISK') > 0) {
         $sql .= Categorie::getFilterSelectQuery('risk', 'r.rowid', $search_category_array);
     }
-    if ($searchCotation > 0) {
-        $sql .= $risk->getCotationSqlFilter($searchCotation);
-    }
+    $sql .= $risk->getCotationSqlFilter($searchCotation);
 
     // Add where from extra fields
     include DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_list_search_sql.tpl.php';
@@ -579,7 +575,7 @@ foreach ($search as $key => $val) {
     if (is_array($search[$key]) && count($search[$key])) foreach ($search[$key] as $skey) $param .= '&search_' . $key . '[]=' . urlencode($skey);
     else $param                                                                                  .= '&search_' . $key . '=' . urlencode($search[$key]);
 }
-if ($searchCotation > 0) $param .= '&search_cotation=' . urlencode($searchCotation);
+if ($searchCotation > 0 || $searchCotation == Risk::COTATION_NOT_ASSESSED) $param .= '&search_cotation=' . urlencode($searchCotation);
 // Add $param from extra fields
 include DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_list_search_param.tpl.php';
 
@@ -965,6 +961,7 @@ foreach ($evaluation->fields as $key => $val) {
             foreach ($risk->getCotations() as $cotationLevel => $cotation) {
                 $cotationLabels[$cotationLevel] = $cotation['label'];
             }
+            $cotationLabels[Risk::COTATION_NOT_ASSESSED] = $langs->trans('RisksNotAssessed');
             print $form->selectarray('search_cotation', $cotationLabels, $searchCotation, 1, 0, 0, '', 0, 0, 0, '', 'maxwidth100');
         }
         print '</td>';

--- a/css/digiriskdolibarr.min.css
+++ b/css/digiriskdolibarr.min.css
@@ -6467,6 +6467,98 @@ textarea.action-textarea:not(:last-child) {
   background: #0d8aff;
 }
 
+/** Risk list dashboard: number of risks by level of the cotation scale, shown above the risk list.
+    Each tile filters the list on its own level (see digiriskdolibarr_riskdashboard_view.tpl.php) */
+.risk-dashboard {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+.risk-dashboard__tile {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 14px 6px 6px;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  background: #fff;
+  color: #333333;
+  text-decoration: none;
+  transition: all 0.2s ease-out;
+}
+.risk-dashboard__tile:hover {
+  border-color: #0d8aff;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+}
+.risk-dashboard__tile.selected {
+  border-color: #0d8aff;
+  box-shadow: 0 0 0 2px #0d8aff;
+}
+.risk-dashboard__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 42px;
+  height: 38px;
+  padding: 0 8px;
+  border-radius: 6px;
+  background: #ececec;
+  color: rgba(0, 0, 0, 0.8);
+  font-size: 18px;
+  font-weight: 700;
+}
+.risk-dashboard__count[data-scale=total] {
+  background: #0d8aff;
+  color: #fff;
+}
+.risk-dashboard__count[data-scale="1"] {
+  background: #ececec;
+}
+.risk-dashboard__count[data-scale="2"] {
+  background: #e9ad4f;
+  color: #fff;
+}
+.risk-dashboard__count[data-scale="3"] {
+  background: #e05353;
+  color: #fff;
+}
+.risk-dashboard__count[data-scale="4"] {
+  background: #2b2b2b;
+  color: #fff;
+}
+.risk-dashboard__count[data-scale=notassessed] {
+  background: #fff;
+  border: 1px dashed #b0b0b0;
+}
+.risk-dashboard__label {
+  font-size: 13px;
+  font-weight: 600;
+}
+.risk-dashboard {
+  /** The environmental risks have their own color, as everywhere else in the module */
+}
+.risk-dashboard--riskenvironmental .risk-dashboard__count[data-scale=total] {
+  background: #22bf4e;
+}
+@media screen and (max-width: 480px) {
+  .risk-dashboard {
+    gap: 6px;
+  }
+  .risk-dashboard__tile {
+    flex: 1 1 auto;
+    padding: 4px 8px 4px 4px;
+  }
+  .risk-dashboard__count {
+    min-width: 34px;
+    height: 30px;
+    font-size: 15px;
+  }
+  .risk-dashboard__label {
+    font-size: 11px;
+  }
+}
+
 /* Mobile quick-creation interfaces, shared by the prevention plan
    (view/preventionplan/preventionplan_mobile_create.php) and the fire permit
    (view/firepermit/firepermit_mobile_create.php). */

--- a/css/scss/page/_page.scss
+++ b/css/scss/page/_page.scss
@@ -7,5 +7,6 @@
 @import "page-ticket-action-card";
 @import "page-ticket-card";
 @import "page-element-risk";
+@import "risk-dashboard";
 @import "mobile-quick-create";
 @import "pwa";

--- a/css/scss/page/_risk-dashboard.scss
+++ b/css/scss/page/_risk-dashboard.scss
@@ -1,0 +1,103 @@
+/** Risk list dashboard: number of risks by level of the cotation scale, shown above the risk list.
+    Each tile filters the list on its own level (see digiriskdolibarr_riskdashboard_view.tpl.php) */
+.risk-dashboard {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 12px;
+
+  &__tile {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 14px 6px 6px;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    background: #fff;
+    color: $color__text-main;
+    text-decoration: none;
+    transition: all 0.2s ease-out;
+
+    &:hover {
+      border-color: $color__primary;
+      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+    }
+
+    &.selected {
+      border-color: $color__primary;
+      box-shadow: 0 0 0 2px $color__primary;
+    }
+  }
+
+  &__count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 42px;
+    height: 38px;
+    padding: 0 8px;
+    border-radius: 6px;
+    background: $color__grey;
+    color: rgba(0, 0, 0, 0.8);
+    font-size: 18px;
+    font-weight: 700;
+
+    &[data-scale="total"] {
+      background: $color__primary;
+      color: $color__primary-text;
+    }
+
+    &[data-scale="1"] {
+      background: $color__grey;
+    }
+
+    &[data-scale="2"] {
+      background: $color__yellow;
+      color: #fff;
+    }
+
+    &[data-scale="3"] {
+      background: $color__red;
+      color: #fff;
+    }
+
+    &[data-scale="4"] {
+      background: $color__dark;
+      color: #fff;
+    }
+
+    &[data-scale="notassessed"] {
+      background: #fff;
+      border: 1px dashed #b0b0b0;
+    }
+  }
+
+  &__label {
+    font-size: 13px;
+    font-weight: 600;
+  }
+
+  /** The environmental risks have their own color, as everywhere else in the module */
+  &--riskenvironmental &__count[data-scale="total"] {
+    background: $color__riskenvironmental;
+  }
+
+  @media screen and (max-width: $media__small) {
+    gap: 6px;
+
+    &__tile {
+      flex: 1 1 auto;
+      padding: 4px 8px 4px 4px;
+    }
+
+    &__count {
+      min-width: 34px;
+      height: 30px;
+      font-size: 15px;
+    }
+
+    &__label {
+      font-size: 11px;
+    }
+  }
+}

--- a/langs/en_US/digiriskdolibarr.lang
+++ b/langs/en_US/digiriskdolibarr.lang
@@ -404,3 +404,6 @@ TimeSpentReportGeneratedAt = Generated on
 TimeSpentReportWholePeriod = Since the beginning of the project
 TimeSpentReportNoData = No time spent matches the selected users and period.
 TimeSpentDocumentPDFDescription = Time spent on a project, grouped by user
+
+# Risk list dashboard - issue #4388
+RisksNotAssessed                     = Risks not assessed

--- a/langs/fr_FR/digiriskdolibarr.lang
+++ b/langs/fr_FR/digiriskdolibarr.lang
@@ -1107,6 +1107,7 @@ GreyRisk                                         = Risque faible
 OrangeRisk                                       = Risque à planifier
 RedRisk                                          = Risque à traiter
 BlackRisk                                        = Risque inacceptable
+RisksNotAssessed                                 = Risques non évalués
 RisksRepartitionByDangerCategories               = Répartition des risques par catégorie de danger
 RiskListsByDangerCategories                      = Liste des risques par catégorie de danger
 DigiriskElementsRepartitionByDepth               = Répartition de l'arborescence des groupements de niveau %s

--- a/view/digiriskelement/risk_list.php
+++ b/view/digiriskelement/risk_list.php
@@ -247,6 +247,12 @@ if (empty($noheader)) saturne_header(1,'', $title, $helpUrl);
 // ------------------------------------------------------------
 $allRisks = 1;
 if (!empty($conf->global->DIGIRISKDOLIBARR_SHOW_RISKS)) {
+    // A dashboard full of zeros teaches nothing on a document unique without any risk of that type yet
+    $riskCountsByCotationLevel = $risk->getRiskCountsByCotationLevel($riskType);
+    if ($riskCountsByCotationLevel['total'] > 0) {
+        require_once './../../core/tpl/riskanalysis/risk/digiriskdolibarr_riskdashboard_view.tpl.php';
+    }
+
 	$contextpage = 'risklist';
 	require_once './../../core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php';
 }


### PR DESCRIPTION
Closes #4388

## Contexte

La page des risques professionnels ouvrait directement sur la liste : rien n'y donnait la répartition des risques, il fallait passer par le DigiBoard pour savoir combien restaient à traiter.

## Modification

Un bandeau de compteurs s'affiche au-dessus de la liste : le total, un compteur par niveau de la grille de cotation et, s'il y en a, les risques encore non évalués. Chaque compteur filtre la liste sur son niveau, recliquer le compteur actif retire le filtre. Le bandeau est masqué quand le type de risque affiché n'en compte aucun.

Les risques non évalués n'étaient jusqu'ici atteignables par aucun filtre (`Risk::COTATION_NOT_ASSESSED`, également proposé dans le filtre cotation de l'en-tête de liste). Le tri par cotation les écartant de la liste, leur compteur la trie sur la référence du risque.

## Cohérence des compteurs

Le comptage (`Risk::getRiskCountsByCotationLevel()`) et le filtre (`Risk::getCotationSqlFilter()`) lisent la même dernière évaluation validée, donc chaque compteur vaut exactement le nombre de lignes de la liste filtrée.

## Performance

La sous-requête corrélée de `getCotationSqlFilter()` — déjà utilisée par le filtre cotation existant et par les liens des graphiques du DigiBoard — coûtait un parcours complet des évaluations par risque. Sur une base de 3 200 risques : **3,6 s → 16 ms**, résultats identiques vérifiés sur les 4 niveaux et deux bases. La requête de comptage utilise la même jointure sur table dérivée (7 ms).

## Tests

- Chaque compteur comparé au nombre de lignes de la liste filtrée, avec les deux tris possibles : concordance sur tous les niveaux, aucune erreur JS.
- Onglet risques d'un GP/UT (tpl de liste partagé) : le nouveau filtre y fonctionne aussi, sans bandeau.
- Liste des risques environnementaux vide : bandeau masqué. Rendu mobile vérifié.
