### PR TITLE
#5029 [Config] fix: warnings PHP $soc indéfini sur la page de configuration analyse des risques

### DIFF
--- a/admin/config/riskassessmentdocument.php
+++ b/admin/config/riskassessmentdocument.php
@@ -298,13 +298,13 @@ if (isModEnabled('project')) {
 	$langs->load("projects");
 	print '<tr class="oddeven"><td><label for="DUProject">' . $langs->trans("DUProject") . '</label></td><td>';
 	$formproject->select_projects(-1,  $conf->global->DIGIRISKDOLIBARR_DU_PROJECT, 'DUProject', 0, 0, 0, 0, 0, 0, 0, '', 0, 0, 'maxwidth500');
-	print ' <a href="' . DOL_URL_ROOT . '/projet/card.php?socid=' . $soc->id . '&action=create&status=1&backtopage=' . urlencode($_SERVER["PHP_SELF"] . '?action=create&socid=' . $soc->id) . '"><span class="fa fa-plus-circle valignmiddle" title="' . $langs->trans("AddProject") . '"></span></a>';
+	print ' <a href="' . DOL_URL_ROOT . '/projet/card.php?action=create&status=1&backtopage=' . urlencode($_SERVER["PHP_SELF"]) . '"><span class="fa fa-plus-circle valignmiddle" title="' . $langs->trans("AddProject") . '"></span></a>';
 	print '<td><input type="submit" class="button" name="save" value="' . $langs->trans("Save") . '">';
 	print '</td></tr>';
 
     print '<tr class="oddeven"><td><label for="EnvironmentProject">' . $langs->trans("EnvironmentProject") . '</label></td><td>';
     $formproject->select_projects(-1,  $conf->global->DIGIRISKDOLIBARR_ENVIRONMENT_PROJECT, 'EnvironmentProject', 0, 0, 0, 0, 0, 0, 0, '', 0, 0, 'maxwidth500');
-    print ' <a href="' . DOL_URL_ROOT . '/projet/card.php?socid=' . $soc->id . '&action=create&status=1&backtopage=' . urlencode($_SERVER["PHP_SELF"] . '?action=create&socid=' . $soc->id) . '"><span class="fa fa-plus-circle valignmiddle" title="' . $langs->trans("AddProject") . '"></span></a>';
+    print ' <a href="' . DOL_URL_ROOT . '/projet/card.php?action=create&status=1&backtopage=' . urlencode($_SERVER["PHP_SELF"]) . '"><span class="fa fa-plus-circle valignmiddle" title="' . $langs->trans("AddProject") . '"></span></a>';
     print '<td><input type="submit" class="button" name="save" value="' . $langs->trans("Save") . '">';
     print '</td></tr>';
 


### PR DESCRIPTION
Closes #5029

## Problème

`admin/config/riskassessmentdocument.php` produisait 4 warnings PHP 8 à chaque chargement :

```
PHP Warning:  Undefined variable $soc … on line 301
PHP Warning:  Attempt to read property "id" on null … on line 301
PHP Warning:  Undefined variable $soc … on line 307
PHP Warning:  Attempt to read property "id" on null … on line 307
```

Les liens « Ajouter un projet » (projet DU et projet Environnement) construisaient leur URL avec `$soc->id`, alors qu'aucune variable `$soc` n'existe sur une page de configuration. Le `socid=` sortait donc vide, et le `backtopage` pointait vers la page de configuration avec un `action=create` qu'elle ne traite pas.

## Correction

Suppression du `socid` et du `action=create` parasite du `backtopage` :

```php
print ' <a href="' . DOL_URL_ROOT . '/projet/card.php?action=create&status=1&backtopage=' . urlencode($_SERVER["PHP_SELF"]) . '">…
```

## Tests

- `php -l` : OK
- Page rechargée (HTTP 200) : plus aucun warning attribué à ce fichier dans `php_error.log`
- Lien rendu : `/projet/card.php?action=create&status=1&backtopage=%2F…%2Friskassessmentdocument.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)