### PR TITLE
#5031 [Risk] fix: IHM de la modale d'ajout d'évaluation

### DIFF
--- a/core/tpl/riskanalysis/riskassessment/digiriskdolibarr_riskassessment_view.tpl.php
+++ b/core/tpl/riskanalysis/riskassessment/digiriskdolibarr_riskassessment_view.tpl.php
@@ -347,7 +347,7 @@ $evaluation->method = $lastRiskAssessment->method ?: "standard" ;
 					<?php endif; ?>
                     <div class="riskassessment-medias linked-medias riskassessment-from-riskassessment-create-<?php echo $risk->id ?>">
                         <div class="element-linked-medias element-linked-medias-0 risk-<?php echo $risk->id ?>">
-                            <div class="medias section-title"><i class="fas fa-picture-o"></i><?php echo $langs->trans('Medias'); ?></div>
+                            <div class="medias section-title"><i class="fas fa-images"></i> <?php echo $langs->trans('Medias'); ?></div>
                             <table class="add-medias">
                                 <tr>
                                     <td>
@@ -415,6 +415,9 @@ $evaluation->method = $lastRiskAssessment->method ?: "standard" ;
 			</div>
 			<!-- Modal-Footer -->
 			<div class="modal-footer">
+				<div class="wpeo-button button-grey modal-close">
+					<span><?php echo $langs->trans('CloseModal'); ?></span>
+				</div>
 				<?php if ($permissiontoadd) : ?>
 					<div class="risk-evaluation-create wpeo-button button-blue button-disable modal-close"value="<?php echo $risk->id ?>">
 						<i class="fas fa-plus"></i> <span style="color: #fff"><?php echo $langs->trans('Add'); ?></span>

--- a/css/digiriskdolibarr.min.css
+++ b/css/digiriskdolibarr.min.css
@@ -1,9 +1,16 @@
 @charset "UTF-8";
 .risk-evaluation-cotation {
-  width: 50px;
+  /* The longest label ("81-100") is exactly as wide as the 50px square that holds it: size the chip
+     on its own text so it keeps some padding, and keep the square look for the shorter ones. */
+  box-sizing: border-box;
+  width: max-content;
   min-width: 50px;
+  padding: 0 10px;
   height: 50px;
   line-height: 50px;
+  /* Badge: never shrink nor wrap, whatever flex or table cell it is dropped into. */
+  flex: none;
+  white-space: nowrap;
   text-align: center;
   border-radius: 6px;
   background: #ececec;
@@ -9099,6 +9106,7 @@ td > .risk-evaluation-list-content .risk-evaluation-container:not(.advanced, .st
     cover each other and steal their neighbour clicks: keep them spaced on a wrapping row */
 .element-linked-medias .add-medias td {
   vertical-align: top;
+  border-bottom: 0 !important;
 }
 .element-linked-medias .element-linked-medias-list {
   display: flex;
@@ -9453,8 +9461,95 @@ td > .risk-evaluation-list-content .risk-evaluation-container:not(.advanced, .st
   align-items: center;
 }
 
+/** Add / edit evaluation modals share the same layout.
+    The container hugs its content: the simple method no longer leaves a large empty area above the
+    footer, and only the content scrolls when the advanced method grid is taller than the window. */
+.risk-evaluation-add-modal, .risk-evaluation-edit-modal {
+  /** Method switch (simple / advanced) and its help icon on the same baseline */
+  /** The cotation labels ("81-100") are as wide as the 50px square that holds them, so they touched
+      both of its edges: equal columns sized on the longest label give every chip some breathing room */
+  /** saturne_show_medias_linked() falls back to nophoto.png: next to the two upload buttons that
+      placeholder reads as a third, disabled one */
+  /** Reminder of the evaluation being replaced: read-only, so it is set apart from the form above */
+}
 .risk-evaluation-add-modal .modal-container, .risk-evaluation-edit-modal .modal-container {
-  max-height: 750px;
+  display: flex;
+  flex-direction: column;
+  height: auto;
+  max-height: calc(100% - 4em);
+  /** min-height: 0 lets the flex item shrink below its content so its own overflow-y takes over */
+}
+.risk-evaluation-add-modal .modal-container .modal-header, .risk-evaluation-add-modal .modal-container .modal-footer, .risk-evaluation-edit-modal .modal-container .modal-header, .risk-evaluation-edit-modal .modal-container .modal-footer {
+  height: auto;
+  flex: 0 0 auto;
+}
+.risk-evaluation-add-modal .modal-container .modal-content, .risk-evaluation-edit-modal .modal-container .modal-content {
+  height: auto;
+  min-height: 0;
+  flex: 1 1 auto;
+}
+.risk-evaluation-add-modal .risk-evaluation-header, .risk-evaluation-edit-modal .risk-evaluation-header {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.risk-evaluation-add-modal .risk-evaluation-header .fa-info-circle, .risk-evaluation-edit-modal .risk-evaluation-header .fa-info-circle {
+  margin-left: 0.75em;
+}
+.risk-evaluation-add-modal .cotation-listing, .risk-evaluation-edit-modal .cotation-listing {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+}
+.risk-evaluation-add-modal .cotation-listing .risk-evaluation-cotation, .risk-evaluation-edit-modal .cotation-listing .risk-evaluation-cotation {
+  width: auto;
+  margin: 0;
+}
+.risk-evaluation-add-modal .element-linked-medias-list img[src*=nophoto],
+.risk-evaluation-add-modal .last-risk-assessment .photo img[src*=nophoto], .risk-evaluation-edit-modal .element-linked-medias-list img[src*=nophoto],
+.risk-evaluation-edit-modal .last-risk-assessment .photo img[src*=nophoto] {
+  display: none;
+}
+.risk-evaluation-add-modal .last-risk-assessment, .risk-evaluation-edit-modal .last-risk-assessment {
+  padding: 1em;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.03);
+}
+.risk-evaluation-add-modal .last-risk-assessment h2, .risk-evaluation-edit-modal .last-risk-assessment h2 {
+  margin: 0 0 0.8em;
+  font-size: 16px;
+}
+.risk-evaluation-add-modal .wpeo-modal[class*=modal-risk] .modal-container .risk-evaluation-container .risk-evaluation-content-wrapper, .risk-evaluation-edit-modal .wpeo-modal[class*=modal-risk] .modal-container .risk-evaluation-container .risk-evaluation-content-wrapper {
+  gap: 1.5em;
+  align-items: flex-start;
+  /** Below the tablet breakpoint the two columns squeeze the cotation chips into a single
+      column: stack the comment under them instead */
+}
+@media (max-width: 770px) {
+  .risk-evaluation-add-modal .wpeo-modal[class*=modal-risk] .modal-container .risk-evaluation-container .risk-evaluation-content-wrapper, .risk-evaluation-edit-modal .wpeo-modal[class*=modal-risk] .modal-container .risk-evaluation-container .risk-evaluation-content-wrapper {
+    flex-wrap: wrap;
+    /** saturne collapses every .wpeo-gridlayout to one column below this breakpoint (with
+        !important): a four step scale reads better as a compact wrapping row */
+  }
+  .risk-evaluation-add-modal .wpeo-modal[class*=modal-risk] .modal-container .risk-evaluation-container .risk-evaluation-content-wrapper .risk-evaluation-content, .risk-evaluation-add-modal .wpeo-modal[class*=modal-risk] .modal-container .risk-evaluation-container .risk-evaluation-content-wrapper .risk-evaluation-comment, .risk-evaluation-edit-modal .wpeo-modal[class*=modal-risk] .modal-container .risk-evaluation-container .risk-evaluation-content-wrapper .risk-evaluation-content, .risk-evaluation-edit-modal .wpeo-modal[class*=modal-risk] .modal-container .risk-evaluation-container .risk-evaluation-content-wrapper .risk-evaluation-comment {
+    width: 100%;
+  }
+  .risk-evaluation-add-modal .wpeo-modal[class*=modal-risk] .modal-container .risk-evaluation-container .risk-evaluation-content-wrapper .cotation-listing, .risk-evaluation-edit-modal .wpeo-modal[class*=modal-risk] .modal-container .risk-evaluation-container .risk-evaluation-content-wrapper .cotation-listing {
+    display: flex;
+    flex-wrap: wrap;
+  }
+}
+.risk-evaluation-add-modal .wpeo-modal[class*=modal-risk] .modal-container .risk-evaluation-container .risk-evaluation-content-wrapper .cotation-standard, .risk-evaluation-edit-modal .wpeo-modal[class*=modal-risk] .modal-container .risk-evaluation-container .risk-evaluation-content-wrapper .cotation-standard {
+  margin-right: 0;
+}
+.risk-evaluation-add-modal .wpeo-modal[class*=modal-risk] .modal-container .risk-evaluation-container .risk-evaluation-content-wrapper .risk-evaluation-comment, .risk-evaluation-edit-modal .wpeo-modal[class*=modal-risk] .modal-container .risk-evaluation-container .risk-evaluation-content-wrapper .risk-evaluation-comment {
+  margin-left: 0;
+  /** A one line field next to a 50px high cotation row looks unfinished: align both columns */
+}
+.risk-evaluation-add-modal .wpeo-modal[class*=modal-risk] .modal-container .risk-evaluation-container .risk-evaluation-content-wrapper .risk-evaluation-comment textarea, .risk-evaluation-edit-modal .wpeo-modal[class*=modal-risk] .modal-container .risk-evaluation-container .risk-evaluation-content-wrapper .risk-evaluation-comment textarea {
+  height: 50px !important;
+  min-height: 50px !important;
 }
 
 .risk-evaluation-edit-modal .wpeo-modal.modal-risk.modal-active {

--- a/css/scss/element/_cotation.scss
+++ b/css/scss/element/_cotation.scss
@@ -1,8 +1,15 @@
 .risk-evaluation-cotation {
-  width: 50px;
+  /* The longest label ("81-100") is exactly as wide as the 50px square that holds it: size the chip
+     on its own text so it keeps some padding, and keep the square look for the shorter ones. */
+  box-sizing: border-box;
+  width: max-content;
   min-width: 50px;
+  padding: 0 10px;
   height: 50px;
   line-height: 50px;
+  /* Badge: never shrink nor wrap, whatever flex or table cell it is dropped into. */
+  flex: none;
+  white-space: nowrap;
   text-align: center;
   border-radius: 6px;
   background: $color__grey;

--- a/css/scss/modal/_risk.scss
+++ b/css/scss/modal/_risk.scss
@@ -65,6 +65,9 @@
 .element-linked-medias {
   .add-medias td {
     vertical-align: top;
+    // Dolibarr underlines the cells of every table nested in a .noborder list, and the modal is
+    // printed inside the risk list: that rule drew a stray line under the upload buttons.
+    border-bottom: 0 !important;
   }
 
   .element-linked-medias-list {

--- a/css/scss/modal/_riskassessment.scss
+++ b/css/scss/modal/_riskassessment.scss
@@ -1,6 +1,104 @@
+/** Add / edit evaluation modals share the same layout.
+    The container hugs its content: the simple method no longer leaves a large empty area above the
+    footer, and only the content scrolls when the advanced method grid is taller than the window. */
 .risk-evaluation-add-modal, .risk-evaluation-edit-modal {
   .modal-container {
-    max-height: 750px;
+    display: flex;
+    flex-direction: column;
+    height: auto;
+    max-height: calc(100% - 4em);
+
+    .modal-header, .modal-footer {
+      height: auto;
+      flex: 0 0 auto;
+    }
+    /** min-height: 0 lets the flex item shrink below its content so its own overflow-y takes over */
+    .modal-content {
+      height: auto;
+      min-height: 0;
+      flex: 1 1 auto;
+    }
+  }
+
+  /** Method switch (simple / advanced) and its help icon on the same baseline */
+  .risk-evaluation-header {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+
+    .fa-info-circle {
+      margin-left: 0.75em;
+    }
+  }
+
+  /** The cotation labels ("81-100") are as wide as the 50px square that holds them, so they touched
+      both of its edges: equal columns sized on the longest label give every chip some breathing room */
+  .cotation-listing {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 8px;
+
+    .risk-evaluation-cotation {
+      width: auto;
+      margin: 0;
+    }
+  }
+
+  /** saturne_show_medias_linked() falls back to nophoto.png: next to the two upload buttons that
+      placeholder reads as a third, disabled one */
+  .element-linked-medias-list img[src*="nophoto"],
+  .last-risk-assessment .photo img[src*="nophoto"] {
+    display: none;
+  }
+
+  /** Reminder of the evaluation being replaced: read-only, so it is set apart from the form above */
+  .last-risk-assessment {
+    padding: 1em;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    border-radius: 6px;
+    background: rgba(0, 0, 0, 0.03);
+
+    h2 {
+      margin: 0 0 0.8em;
+      font-size: 16px;
+    }
+  }
+
+  .wpeo-modal[class*="modal-risk"] .modal-container .risk-evaluation-container {
+    .risk-evaluation-content-wrapper {
+      gap: 1.5em;
+      align-items: flex-start;
+
+      /** Below the tablet breakpoint the two columns squeeze the cotation chips into a single
+          column: stack the comment under them instead */
+      @media ( max-width: $media__medium ) {
+        flex-wrap: wrap;
+
+        .risk-evaluation-content, .risk-evaluation-comment {
+          width: 100%;
+        }
+
+        /** saturne collapses every .wpeo-gridlayout to one column below this breakpoint (with
+            !important): a four step scale reads better as a compact wrapping row */
+        .cotation-listing {
+          display: flex;
+          flex-wrap: wrap;
+        }
+      }
+
+      .cotation-standard {
+        margin-right: 0;
+      }
+      .risk-evaluation-comment {
+        margin-left: 0;
+
+        /** A one line field next to a 50px high cotation row looks unfinished: align both columns */
+        textarea {
+          height: 50px !important;
+          min-height: 50px !important;
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Closes #5031

## Ce qui était cassé

| Constat | Cause |
|---|---|
| « 81-100 » rogné dans sa pastille | le libellé fait exactement 50 px, la pastille aussi (`width: 50px`, aucun `padding`) |
| ~200 px de vide sous « Dernière évaluation » | `.modal-container` en hauteur fixe (750 px + padding) |
| En méthode avancée, commentaire et médias hors écran | même hauteur fixe : contenu coupé au lieu de défiler |
| 3ᵉ bouton média grisé | `saturne_show_medias_linked()` retombe sur `nophoto.png` quand aucun média n'est lié |
| Pas d'icône devant « Medias » | `fa-picture-o` est du Font Awesome 4, supprimé en FA5 |
| Trait parasite sous les boutons médias | la modale est imprimée dans la liste des risques, et Dolibarr souligne les `td` de toute table imbriquée dans un `.noborder` |

## Modifications

- `css/scss/element/_cotation.scss` — pastille dimensionnée sur son libellé (`width: max-content`, `padding: 0 10px`, `min-width: 50px` pour garder le carré), `flex: none` + `white-space: nowrap` pour qu'elle ne se comprime ni ne se coupe dans une ligne flex.
- `css/scss/modal/_riskassessment.scss` — conteneur en flex colonne, `height: auto` / `max-height: calc(100% - 4em)` (780 → 544 px en méthode simple, défilement interne en méthode avancée) ; échelle de cotation en 4 colonnes égales ; placeholder `nophoto` masqué ; bloc « Dernière évaluation » présenté en carte ; commentaire aligné sur la hauteur des pastilles ; empilement des colonnes sous 770 px.
- `css/scss/modal/_risk.scss` — `border-bottom: 0 !important` sur les cellules du sélecteur de médias.
- `core/tpl/.../digiriskdolibarr_riskassessment_view.tpl.php` — icône `fa-images`, bouton **Fermer** dans le pied de modale (comme la modale « liste des évaluations »).
- `css/digiriskdolibarr.min.css` recompilé par patch des seules règles concernées (pas de churn de la version de sass).

Les deux modales d'évaluation (ajout et édition) partagent ces règles, elles profitent toutes les deux de la correction.

## Tests

Vérifié au navigateur (Playwright, Chromium) sur la liste des risques, sans erreur JS :

- méthode simple : pastilles 70 px égales, plus aucun vide, sélection d'une cotation → `selected-cotation` + seuil renseigné + bouton « Ajouter » activé ;
- méthode avancée : grille complète, commentaire et médias atteignables, cotation calculée affichée ;
- bascule simple ↔ avancée (simulée avec `DIGIRISKDOLIBARR_MULTIPLE_RISKASSESSMENT_METHOD = 1`) : affichage, sélection et bouton OK ;
- modale d'édition d'une évaluation : même mise en page ;
- bouton « Fermer » : ferme sans créer ;
- 480 px : cotation sur une ligne, commentaire en dessous ;
- liste des risques et modale d'ajout de risque : pas de régression des pastilles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)