### PR TITLE
#5033 [Config] fix: suppression de la constante orpheline MAIN_MODULE_DIGIRISKDOLIBARR_TABS

### DIFF
--- a/sql/update.sql
+++ b/sql/update.sql
@@ -279,3 +279,6 @@ WHERE ef.fk_object IS NULL
 -- 23.1.x - prevention plan public/private notes
 ALTER TABLE llx_digiriskdolibarr_preventionplan ADD note_public text NULL AFTER cssct_intervention;
 ALTER TABLE llx_digiriskdolibarr_preventionplan ADD note_private text NULL AFTER note_public;
+
+-- 23.1.x - remove orphan const left by the deleted module_parts['tabs'] declaration
+DELETE FROM llx_const WHERE name = 'MAIN_MODULE_DIGIRISKDOLIBARR_TABS';


### PR DESCRIPTION
Closes #5033

## Problème

Sur toute instance existante, un warning PHP 8 est émis à chaque appel de `complete_head_from_modules()` avec le type `digiriskdolibarr` (page de configuration Analyse des risques, entre autres) :

```
PHP Warning:  Undefined array key 1 in htdocs/core/lib/functions.lib.php on line 12696
```

`conf.class.php` alimente `$conf->modules_parts['tabs']['digiriskdolibarr'] = ['mycompany_admin']` depuis la constante `MAIN_MODULE_DIGIRISKDOLIBARR_TABS` (valeur `["mycompany_admin"]`). `complete_head_from_modules()` fait ensuite `explode(':', 'mycompany_admin')` puis lit `$values[1]`, inexistant.

Cette constante vient de `module_parts['tabs'] => ['mycompany_admin']`, supprimé du descripteur en ef11571d (2026-08-13). Dolibarr ne purge les `MAIN_MODULE_DIGIRISKDOLIBARR_*` qu'à la désactivation du module : sans désactivation/réactivation, la constante orpheline subsiste indéfiniment.

## Correction

Ajout du nettoyage dans `sql/update.sql`, joué à la montée de version :

```sql
DELETE FROM llx_const WHERE name = 'MAIN_MODULE_DIGIRISKDOLIBARR_TABS';
```

Sans filtre sur `entity`, la constante pouvant exister sur plusieurs entités.

## Tests

- Reproduit en local : la page `admin/config/riskassessmentdocument.php` émet le warning tant que la constante est présente
- Vérifié que la déclaration `module_parts['tabs']` n'existe plus dans le descripteur (donc la constante n'est plus régénérée)
- Aucun autre usage de cette constante dans le code

🤖 Generated with [Claude Code](https://claude.com/claude-code)