### PR TITLE
#5035 [TicketDocument] fix: remove the whitespace sent before the php tag

### DIFF
--- a/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/ticketdocument/pdf_ticketdocument.modules.php
+++ b/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/ticketdocument/pdf_ticketdocument.modules.php
@@ -1,4 +1,4 @@
-    <?php
+<?php
     /* Copyright (C) 2026 EVARISK <technique@evarisk.com>
      *
      * This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
Closes #5035

## Problème

En prod (`sd_avh`), chaque génération de document de ticket loggue :

```
PHP Warning:  Cannot modify header information - headers already sent
(output started at .../ticketdocument/pdf_ticketdocument.modules.php:1)
in .../saturne/core/tpl/documents/documents_action.tpl.php on line 110
```

Le fichier commençait par **4 espaces avant `<?php`** : PHP les émet dès le chargement du modèle, donc le `header('Location: ...')` de redirection post-génération ne peut plus partir. La redirection est perdue et le warning tombe à chaque génération.

## Correctif

Suppression des 4 espaces de la ligne 1. Diff d'une seule ligne.

Volontairement limité : réindenter les 563 lignes du fichier (indenté de 4 espaces de bout en bout) réécrirait tout le `git blame` pour un gain purement cosmétique. À traiter séparément si souhaité.

## Vérification

```
# avant
$ php -r '$t = token_get_all(file_get_contents($f)); var_export($t[0][1]);'
'    '        # T_INLINE_HTML : PHP émet bien ces 4 espaces

# après
aucune sortie avant <?php
```

`php -l` OK. Le balayage des autres modules custom ne remonte rien d'autre d'actif sur ce motif (deux `index.php` vides, et un `*` parasite dans `saturne/sql/schedules/index.php` qui n'est jamais inclus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)