### PR TITLE
#4328 [Search] feat: les objets Digirisk dans la recherche globale

### DIFF
--- a/class/actions_digiriskdolibarr.class.php
+++ b/class/actions_digiriskdolibarr.class.php
@@ -1825,6 +1825,61 @@ class ActionsDigiriskdolibarr
 	}
 
     /**
+     * Overloading the addSearchEntry function : replacing the parent's function with the one below
+     *
+     * @param  array $parameters Hook metadata (context, etc...)
+     * @return int               0 < on error, 0 on success, 1 to replace standard code
+     */
+    public function addSearchEntry(array $parameters): int
+    {
+        global $langs, $user;
+
+        if (strpos($parameters['context'], 'searchform') === false || !$user->hasRight('digiriskdolibarr', 'lire')) {
+            return 0;
+        }
+
+        // The search box is built before the module lang file is loaded, the labels would come out as their key
+        $langs->load('digiriskdolibarr@digiriskdolibarr');
+
+        // Lists opened from the search box, keyed by the right they need : picto, label and path of the list
+        $lists = [
+            'risk'                  => ['exclamation-triangle', 'Riskprofessionals',     'view/digiriskelement/risk_list.php?risk_type=risk'],
+            'riskenvironmental'     => ['leaf',                 'Riskenvironmentals',    'view/digiriskelement/risk_list.php?risk_type=riskenvironmental'],
+            'preventionplan'        => ['info',                 'PreventionPlan',        'view/preventionplan/preventionplan_list.php'],
+            'firepermit'            => ['fire-alt',             'FirePermit',            'view/firepermit/firepermit_list.php'],
+            'accident'              => ['user-injured',         'Accident',              'view/accident/accident_list.php'],
+            'accidentinvestigation' => ['search',               'AccidentInvestigation', 'view/accidentinvestigation/accidentinvestigation_list.php']
+        ];
+
+        $moduleNum     = 436302;
+        $position      = 0;
+        $searchEntries = [];
+        foreach ($lists as $rightName => $list) {
+            if (!$user->hasRight('digiriskdolibarr', $rightName, 'read')) {
+                continue;
+            }
+
+            list($picto, $langKey, $listPath) = $list;
+
+            $position += 10;
+            $picto     = 'fontawesome_fa-' . $picto . '_fas_#d35968';
+            $url       = dol_buildpath('custom/digiriskdolibarr/' . $listPath, 1) . (strpos($listPath, '?') !== false ? '&' : '?') . 'mainmenu=digiriskdolibarr';
+
+            $searchEntries['searchinto' . $rightName] = [
+                'position' => $moduleNum . sprintf('%02d', $position),
+                'img'      => $picto,
+                'label'    => $langs->trans($langKey),
+                'text'     => img_picto('', $picto, 'class="pictofixedwidth"') . $langs->trans($langKey),
+                'url'      => $url . (!empty($parameters['search_boxvalue']) ? '&search_all=' . urlencode($parameters['search_boxvalue']) : '')
+            ];
+        }
+
+        $this->results = $searchEntries;
+
+        return 0; // or return 1 to replace standard code
+    }
+
+    /**
      * Overloading the saturneExtendGetObjectsMetadata function : replacing the parent's function with the one below
      *
      * @param  array $parameters Hook metadata (context, etc...)

--- a/class/riskanalysis/risk.class.php
+++ b/class/riskanalysis/risk.class.php
@@ -1102,6 +1102,43 @@ class Risk extends SaturneObject
     }
 
     /**
+     * Get the SQL criteria of the "search in all" of a risk list
+     *
+     * The refs of the assessments (RA...) are looked up as well: an assessment has no list of its own, so a
+     * search made on its ref has to bring back the risk it belongs to instead of nothing.
+     *
+     * @param  array  $fieldsToSearchAll Fields to search into, keyed by their name prefixed with their table alias,
+     *                                   "ra." standing for the assessments of the risk
+     * @param  string $searchAll         Searched value
+     * @return string                    SQL criteria, empty when there is nothing to search into
+     */
+    public function getSearchAllSqlFilter(array $fieldsToSearchAll, string $searchAll): string
+    {
+        $riskFields       = [];
+        $assessmentFields = [];
+        foreach (array_keys($fieldsToSearchAll) as $field) {
+            if (strpos($field, 'ra.') === 0) {
+                $assessmentFields[] = $field;
+            } else {
+                $riskFields[] = $field;
+            }
+        }
+
+        $criterias = [];
+        if (!empty($riskFields)) {
+            $criterias[] = natural_search($riskFields, $searchAll, 0, 1);
+        }
+        if (!empty($assessmentFields)) {
+            $riskAssessmentTable = MAIN_DB_PREFIX . (new RiskAssessment($this->db))->table_element;
+
+            $criterias[] = 'r.rowid IN (SELECT ra.fk_risk FROM ' . $riskAssessmentTable . ' as ra'
+                         . ' WHERE ' . natural_search($assessmentFields, $searchAll, 0, 1) . ')';
+        }
+
+        return empty($criterias) ? '' : ' AND (' . implode(' OR ', $criterias) . ')';
+    }
+
+    /**
      * Get the level of the cotation scale a cotation falls in
      *
      * @param  float $cotation Cotation of a risk assessment

--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_inheritedrisklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_inheritedrisklist_view.tpl.php
@@ -120,7 +120,7 @@
 					}
 				}
 			}
-			if ($search_all) $sql .= natural_search(array_keys($fieldstosearchall), $search_all);
+			if ($search_all) $sql .= $risk->getSearchAllSqlFilter($fieldstosearchall, $search_all);
 			// Add where from extra fields
 			include DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_list_search_sql.tpl.php';
 			// Add where from hooks
@@ -158,8 +158,9 @@
 				$num = $db->num_rows($resql);
 			}
 
-			// Direct jump if only one record found
-			if ($num == 1 && !empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && !$page) {
+			// Direct jump if only one record found, out of reach once the page header has been printed : the redirect
+			// would only raise a "headers already sent" warning and leave the list truncated
+			if ($num == 1 && !headers_sent() && !empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && !$page) {
 				$obj = $db->fetch_object($resql);
 				$id = $obj->rowid;
 				header("Location: " . dol_buildpath('/digiriskdolibarr/view/digiriskelement/digiriskelement_risk.php', 1) . '?id=' . $id);
@@ -234,7 +235,7 @@
 					}
 				}
 			}
-			if ($search_all) $sql .= natural_search(array_keys($fieldstosearchall), $search_all);
+			if ($search_all) $sql .= $risk->getSearchAllSqlFilter($fieldstosearchall, $search_all);
 			// Add where from extra fields
 			include DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_list_search_sql.tpl.php';
 			// Add where from hooks
@@ -272,8 +273,9 @@
 				$num = $db->num_rows($resql);
 			}
 
-			// Direct jump if only one record found
-			if ($num == 1 && !empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && !$page) {
+			// Direct jump if only one record found, out of reach once the page header has been printed : the redirect
+			// would only raise a "headers already sent" warning and leave the list truncated
+			if ($num == 1 && !headers_sent() && !empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && !$page) {
 				$obj = $db->fetch_object($resql);
 				$id = $obj->rowid;
 				header("Location: " . dol_buildpath('/digiriskdolibarr/view/digiriskelement/digiriskelement_risk.php', 1) . '?id=' . $id);

--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
@@ -395,7 +395,7 @@ if ( ! preg_match('/(evaluation)/', $sortfield)) {
             }
         }
     }
-    if ($search_all) $sql .= natural_search(array_keys($fieldstosearchall), $search_all);
+    if ($search_all) $sql .= $risk->getSearchAllSqlFilter($fieldstosearchall, $search_all);
     if (!empty($conf->categorie->enabled) && getDolGlobalInt('DIGIRISKDOLIBARR_CATEGORY_ON_RISK') > 0) {
         $sql .= Categorie::getFilterSelectQuery('risk', 'r.rowid', $search_category_array);
     }
@@ -437,8 +437,9 @@ if ( ! preg_match('/(evaluation)/', $sortfield)) {
         $num = $db->num_rows($resql);
     }
 
-    // Direct jump if only one record found
-    if ($num == 1 && ! empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && ! $page) {
+    // Direct jump if only one record found, out of reach once the page header has been printed : the redirect
+    // would only raise a "headers already sent" warning and leave the list truncated
+    if ($num == 1 && !headers_sent() && ! empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && ! $page) {
         $obj = $db->fetch_object($resql);
         $id  = $obj->rowid;
         header("Location: " . dol_buildpath('/digiriskdolibarr/view/digiriskelement/digiriskelement_risk.php', 1) . '?id=' . $id);
@@ -508,7 +509,7 @@ if ( ! preg_match('/(evaluation)/', $sortfield)) {
             }
         }
     }
-    if ($search_all) $sql .= natural_search(array_keys($fieldstosearchall), $search_all);
+    if ($search_all) $sql .= $risk->getSearchAllSqlFilter($fieldstosearchall, $search_all);
 
     if (!empty($conf->categorie->enabled) && getDolGlobalInt('DIGIRISKDOLIBARR_CATEGORY_ON_RISK') > 0) {
         $sql .= Categorie::getFilterSelectQuery('risk', 'r.rowid', $search_category_array);
@@ -556,8 +557,9 @@ if ( ! preg_match('/(evaluation)/', $sortfield)) {
         $num = $db->num_rows($resql);
     }
 
-    // Direct jump if only one record found
-    if ($num == 1 && ! empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && ! $page) {
+    // Direct jump if only one record found, out of reach once the page header has been printed : the redirect
+    // would only raise a "headers already sent" warning and leave the list truncated
+    if ($num == 1 && !headers_sent() && ! empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && ! $page) {
         $obj = $db->fetch_object($resql);
         $id  = $obj->rowid;
         header("Location: " . dol_buildpath('/digiriskdolibarr/view/digiriskelement/digiriskelement_risk.php', 1) . '?id=' . $id);

--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_sharedrisklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_sharedrisklist_view.tpl.php
@@ -149,7 +149,7 @@ if ( ! preg_match('/(evaluation)/', $sortfield)) {
 			}
 		}
 	}
-	if ($search_all) $sql .= natural_search(array_keys($fieldstosearchall), $search_all);
+	if ($search_all) $sql .= $risk->getSearchAllSqlFilter($fieldstosearchall, $search_all);
 	// Add where from extra fields
 	include DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_list_search_sql.tpl.php';
 	// Add where from hooks
@@ -187,8 +187,9 @@ if ( ! preg_match('/(evaluation)/', $sortfield)) {
 		$num = $db->num_rows($resql);
 	}
 
-	// Direct jump if only one record found
-	if ($num == 1 && ! empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && ! $page) {
+	// Direct jump if only one record found, out of reach once the page header has been printed : the redirect
+	// would only raise a "headers already sent" warning and leave the list truncated
+	if ($num == 1 && !headers_sent() && ! empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && ! $page) {
 		$obj = $db->fetch_object($resql);
 		$id  = $obj->rowid;
 		header("Location: " . dol_buildpath('/digiriskdolibarr/view/digiriskelement/digiriskelement_risk.php', 1) . '?id=' . $id);
@@ -265,7 +266,7 @@ if ( ! preg_match('/(evaluation)/', $sortfield)) {
 			}
 		}
 	}
-	if ($search_all) $sql .= natural_search(array_keys($fieldstosearchall), $search_all);
+	if ($search_all) $sql .= $risk->getSearchAllSqlFilter($fieldstosearchall, $search_all);
 	// Add where from extra fields
 	include DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_list_search_sql.tpl.php';
 	// Add where from hooks
@@ -303,8 +304,9 @@ if ( ! preg_match('/(evaluation)/', $sortfield)) {
 		$num = $db->num_rows($resql);
 	}
 
-	// Direct jump if only one record found
-	if ($num == 1 && ! empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && ! $page) {
+	// Direct jump if only one record found, out of reach once the page header has been printed : the redirect
+	// would only raise a "headers already sent" warning and leave the list truncated
+	if ($num == 1 && !headers_sent() && ! empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && ! $page) {
 		$obj = $db->fetch_object($resql);
 		$id  = $obj->rowid;
 		header("Location: " . dol_buildpath('/digiriskdolibarr/view/digiriskelement/digiriskelement_risk.php', 1) . '?id=' . $id);

--- a/core/tpl/riskanalysis/risksign/digiriskdolibarr_inheritedrisksignlist_view.tpl.php
+++ b/core/tpl/riskanalysis/risksign/digiriskdolibarr_inheritedrisksignlist_view.tpl.php
@@ -102,8 +102,9 @@ if ($object->fk_parent > 0) {
 		$num = $db->num_rows($resql);
 	}
 
-	// Direct jump if only one record found
-	if ($num == 1 && !empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && !$page) {
+	// Direct jump if only one record found, out of reach once the page header has been printed : the redirect
+	// would only raise a "headers already sent" warning and leave the list truncated
+	if ($num == 1 && !headers_sent() && !empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && !$page) {
 		$obj = $db->fetch_object($resql);
 		$id = $obj->rowid;
 		header("Location: " . dol_buildpath('/digiriskdolibarr/view/digiriskelement/digiriskelement_risksign.php', 1) . '?id=' . $id);

--- a/core/tpl/riskanalysis/risksign/digiriskdolibarr_risksignlist_view.tpl.php
+++ b/core/tpl/riskanalysis/risksign/digiriskdolibarr_risksignlist_view.tpl.php
@@ -127,8 +127,9 @@ if (is_numeric($nbtotalofrecords) && ($limit > $nbtotalofrecords || empty($limit
 	$num = $db->num_rows($resql);
 }
 
-// Direct jump if only one record found
-if ($num == 1 && ! empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && ! $page) {
+// Direct jump if only one record found, out of reach once the page header has been printed : the redirect
+// would only raise a "headers already sent" warning and leave the list truncated
+if ($num == 1 && !headers_sent() && ! empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && ! $page) {
 	$obj = $db->fetch_object($resql);
 	$id  = $obj->rowid;
 	header("Location: " . dol_buildpath('/digiriskdolibarr/view/digiriskelement/digiriskelement_risksign.php', 1) . '?id=' . $id);

--- a/core/tpl/riskanalysis/risksign/digiriskdolibarr_sharedrisksignlist_view.tpl.php
+++ b/core/tpl/riskanalysis/risksign/digiriskdolibarr_sharedrisksignlist_view.tpl.php
@@ -170,8 +170,9 @@ if (is_numeric($nbtotalofrecords) && ($limit > $nbtotalofrecords || empty($limit
 	$num = $db->num_rows($resql);
 }
 
-// Direct jump if only one record found
-if ($num == 1 && ! empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && ! $page) {
+// Direct jump if only one record found, out of reach once the page header has been printed : the redirect
+// would only raise a "headers already sent" warning and leave the list truncated
+if ($num == 1 && !headers_sent() && ! empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && ! $page) {
 	$obj = $db->fetch_object($resql);
 	$id  = $obj->rowid;
 	header("Location: " . dol_buildpath('/digiriskdolibarr/view/digiriskelement/digiriskelement_risksign.php', 1) . '?id=' . $id);

--- a/view/accident/accident_list.php
+++ b/view/accident/accident_list.php
@@ -368,8 +368,9 @@ if (is_numeric($nbtotalofrecords) && ($limit > $nbtotalofrecords || empty($limit
 	$num = $db->num_rows($resql);
 }
 
-	// Direct jump if only one record found
-if ($num == 1 && ! empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && ! $page) {
+// Direct jump if only one record found, out of reach once the page header has been printed : the redirect
+// would only raise a "headers already sent" warning and leave the list truncated
+if ($num == 1 && !headers_sent() && ! empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && ! $page) {
 	$obj = $db->fetch_object($resql);
 	$id  = $obj->rowid;
 	header("Location: " . dol_buildpath('/digiriskdolibarr/view/accident/accident_card.php', 1) . '?id=' . $id);

--- a/view/digiriskelement/digiriskelement_evaluator.php
+++ b/view/digiriskelement/digiriskelement_evaluator.php
@@ -436,8 +436,9 @@ if ($object->id > 0 || $fromid > 0) {
 
 		$num = $db->num_rows($resql);
 	}
-	// Direct jump if only one record found
-	if ($num == 1 && ! empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && ! $page) {
+	// Direct jump if only one record found, out of reach once the page header has been printed : the redirect
+	// would only raise a "headers already sent" warning and leave the list truncated
+	if ($num == 1 && !headers_sent() && ! empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && ! $page) {
 		$obj = $db->fetch_object($resql);
 		$id  = $obj->rowid;
 		header("Location: " . dol_buildpath('/digiriskdolibarr/view/digiriskelement/digiriskelement_evaluator.php', 1) . '?id=' . $id);

--- a/view/digiriskelement/digiriskelement_risk.php
+++ b/view/digiriskelement/digiriskelement_risk.php
@@ -135,6 +135,10 @@ $fieldstosearchall = array();
 foreach ($risk->fields as $key => $val) {
 	if (!empty($val['searchall'])) $fieldstosearchall['r.' . $key] = $val['label'];
 }
+// A risk is also brought back by the ref of one of its assessments, see Risk::getSearchAllSqlFilter()
+foreach ($evaluation->fields as $key => $val) {
+	if (!empty($val['searchall'])) $fieldstosearchall['ra.' . $key] = 'RiskAssessment';
+}
 
 // Definition of fields for list
 $arrayfields = array();

--- a/view/digiriskelement/risk_list.php
+++ b/view/digiriskelement/risk_list.php
@@ -139,6 +139,10 @@ $fieldstosearchall = array();
 foreach ($risk->fields as $key => $val) {
 	if (!empty($val['searchall'])) $fieldstosearchall['r.' . $key] = $val['label'];
 }
+// A risk is also brought back by the ref of one of its assessments, see Risk::getSearchAllSqlFilter()
+foreach ($evaluation->fields as $key => $val) {
+	if (!empty($val['searchall'])) $fieldstosearchall['ra.' . $key] = 'RiskAssessment';
+}
 
 // Definition of array of fields for columns
 $arrayfields = array();

--- a/view/digiriskusers.php
+++ b/view/digiriskusers.php
@@ -384,7 +384,7 @@ if ( ! $result) {
 
 $num = $db->num_rows($result);
 
-if ($num == 1 && ! empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $sall) {
+if ($num == 1 && !headers_sent() && ! empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $sall) {
 	$obj = $db->fetch_object($resql);
 	$id  = $obj->rowid;
 	header("Location: " . DOL_URL_ROOT . '/user/card.php?id=' . $id);

--- a/view/firepermit/firepermit_list.php
+++ b/view/firepermit/firepermit_list.php
@@ -304,8 +304,9 @@ if (is_numeric($nbtotalofrecords) && ($limit > $nbtotalofrecords || empty($limit
 	$num = $db->num_rows($resql);
 }
 
-	// Direct jump if only one record found
-if ($num == 1 && ! empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && ! $page) {
+// Direct jump if only one record found, out of reach once the page header has been printed : the redirect
+// would only raise a "headers already sent" warning and leave the list truncated
+if ($num == 1 && !headers_sent() && ! empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && ! $page) {
 	$obj = $db->fetch_object($resql);
 	$id  = $obj->rowid;
 	header("Location: " . dol_buildpath('/digiriskdolibarr/view/firepermit/firepermit_card.php', 1) . '?id=' . $id);

--- a/view/preventionplan/preventionplan_list.php
+++ b/view/preventionplan/preventionplan_list.php
@@ -345,8 +345,9 @@ if (is_numeric($nbtotalofrecords) && ($limit > $nbtotalofrecords || empty($limit
 	$num = $db->num_rows($resql);
 }
 
-	// Direct jump if only one record found
-if ($num == 1 && ! empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && ! $page) {
+// Direct jump if only one record found, out of reach once the page header has been printed : the redirect
+// would only raise a "headers already sent" warning and leave the list truncated
+if ($num == 1 && !headers_sent() && ! empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && ! $page) {
 	$obj = $db->fetch_object($resql);
 	$id  = $obj->rowid;
 	header("Location: " . dol_buildpath('/digiriskdolibarr/view/preventionplan/preventionplan_card.php', 1) . '?id=' . $id);


### PR DESCRIPTION
Closes #4328

## Le problème

Le sélecteur de la recherche globale de Dolibarr ne proposait **aucune liste Digirisk**. Taper `RK63` ou `RA71` ne ramenait donc rien : aucune entrée de recherche n'existait pour les objets du module. Seuls les tickets (`TK...` / `TS...`) fonctionnaient, parce que le coeur de Dolibarr les propose déjà.

## Ce que fait la PR

**1. Les objets Digirisk dans la recherche globale** — sur le modèle de DigiQuali, le hook `addSearchEntry` ajoute six entrées, chacune soumise à son droit de lecture :

| Entrée | Liste ouverte | Préfixe |
|---|---|---|
| Risques professionnels | `risk_list.php?risk_type=risk` | `RK` |
| Risques environnementaux | `risk_list.php?risk_type=riskenvironmental` | `RK` |
| Plan de prévention | `preventionplan_list.php` | `PP` |
| Permis de feu | `firepermit_list.php` | `FP` |
| Accident | `accident_list.php` | `ACC` |
| Enquête accident | `accidentinvestigation_list.php` | `AI` |

**2. Les références d'évaluation (`RA...`)** — une évaluation n'a pas de liste à elle. `Risk::getSearchAllSqlFilter()` élargit donc le « rechercher partout » de la liste des risques aux références des évaluations : chercher `RA71` ramène le risque `RK63` qui la porte. La ligne de critère affiche bien « Réf., Évaluation ».

**3. Correction du saut direct** — le bloc « une seule ligne trouvée → ouvrir la fiche » de ces listes s'exécute **après** l'entête de page. Son `header('Location: ...')` ne pouvait donc que produire un `Cannot modify header information - headers already sent`, suivi d'un `exit` qui laissait la page vide. Or `MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE` vaut 1 par défaut dans Dolibarr (`conf.class.php`) et une recherche sur une référence exacte ramène justement une seule ligne : le cas se produisait systématiquement. Le saut est désormais ignoré quand l'entête est déjà envoyé, et la liste s'affiche normalement.

## Tests

Vérifié en local (Dolibarr 23, Playwright, compte non-admin) :

- les six entrées apparaissent dans le sélecteur, traduites ;
- `RK63` → liste des risques filtrée sur `RK63` (1 ligne) ;
- `RA71` → liste des risques filtrée sur `RK63`, l'évaluation `RA71` visible sur la ligne ;
- idem avec le tri par cotation **et** le tri par référence (les deux branches SQL du template) ;
- `ACC1`, `PP1` : listes filtrées, plus de page blanche ;
- une référence inconnue donne une liste vide sans erreur ;
- listes sans filtre inchangées (61 risques) ;
- `digiriskelement_risk.php` accepte aussi une référence `RA...` ;
- les tickets passent toujours par l'entrée du coeur de Dolibarr.

## À noter

Les listes bâties sur le template générique de Saturne (`objectfields_list_build_sql_select.tpl.php`, ici les enquêtes accident) portent le **même** défaut de saut direct, non corrigeable depuis Digirisk. Une PR Saturne est à prévoir — elle corrigera du même coup les entrées de recherche de DigiQuali.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
