### PR TITLE
#4743 [CI] add: workflow build-assets appelant le workflow reutilisable Saturne

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -1,0 +1,21 @@
+---
+name: Build assets
+
+on:
+    push:
+        branches:
+            - main
+            - develop
+        paths:
+            - 'css/scss/**'
+            - 'js/**/*.js'
+            - '!js/**/*.min.js'
+
+jobs:
+    build:
+      uses: Evarisk/Saturne/.github/workflows/build-assets-reusable.yml@main
+      with:
+        module: digiriskdolibarr
+
+      permissions:
+        contents: write


### PR DESCRIPTION
## Description

Ajout du workflow `.github/workflows/build-assets.yml` : compilation et commit automatiques de `digiriskdolibarr.min.css` / `digiriskdolibarr.min.js` sur push vers `main` et `develop`.

Plutôt qu'un workflow autonome (`npm ci` + `gulp` dans le dépôt), il appelle le workflow réutilisable déjà présent dans Saturne — `Evarisk/Saturne/.github/workflows/build-assets-reusable.yml@main` — comme le fait déjà `release.yml`, et comme reedcrm le fait de son côté. La chaîne de build (Node, dépendances, `gulpfile-shared.js`) reste ainsi centralisée dans Saturne.

## Détails

- Déclencheur : push sur `main` / `develop`, filtré sur `css/scss/**` et `js/**/*.js` (les `.min.js` sont exclus pour éviter la boucle avec le commit automatique de la CI)
- `permissions: contents: write` sur le job, comme dans `release.yml`
- Aucun `gulpfile` ni `package.json` modifié : la CI utilise le gulpfile partagé de Saturne

## Tests

Build vérifié en local avec la chaîne partagée de Saturne sur les sources Digirisk :

```
MODULE_NAME=digiriskdolibarr node ../saturne/node_modules/gulp/bin/gulp.js --gulpfile ../saturne/gulpfile-shared.js build
```

Les deux tâches (`scss_core:prod`, `js_backend`) se terminent sans erreur et produisent bien `css/digiriskdolibarr.min.css` et `js/digiriskdolibarr.min.js` (uniquement des avertissements de dépréciation sass sur `darken()` et `@import`).

## Points d'attention

1. **Ruleset de branche** — le ruleset « Develop » du dépôt s'applique à `~ALL` avec une règle `pull_request` : tout push direct sur `develop` / `main` est refusé. Le workflow réutilisable pousse directement sur la branche, il faut donc autoriser GitHub Actions en `bypass actor` sur ce ruleset (ou utiliser un PAT), sinon l'étape de commit échouera.
2. **Premier run** — le `.min.css` actuellement versionné a été compilé avec le gulpfile local (sass `compressed`, 222 Ko) alors que le gulpfile partagé passe par `clean-css` (178 Ko). Le premier passage de la CI produira donc un gros diff, une seule fois.
3. Tant que Digirisk conserve son `gulpfile.js` local, les compilations faites en dev seront réécrites par la CI au push suivant. L'alignement de `package.json` sur `gulpfile-shared.js` (comme reedcrm) est hors périmètre de cette issue mais serait la suite logique.

Close #4743
