### PR TITLE
#3771 [ListingRisksDocument] fix: les modèles de listing manquants dans la configuration

### DIFF
--- a/class/actions_digiriskdolibarr.class.php
+++ b/class/actions_digiriskdolibarr.class.php
@@ -1700,6 +1700,10 @@ class ActionsDigiriskdolibarr
 				'documentType' => 'listingrisksaction',
 				'picto'        => 'fontawesome_fa-exclamation_fas_#d35968'
 			],
+            'ListingRisksEnvironmentalDocument' => [
+                'documentType' => 'listingrisksenvironmentaldocument',
+                'picto'        => 'fontawesome_fa-leaf_fas_#d35968'
+            ],
             'ListingRisksEnvironmentalAction' => [
                 'documentType' => 'listingrisksenvironmentalaction',
                 'picto'        => 'fontawesome_fa-exclamation_fas_#d35968'

--- a/core/modules/modDigiriskDolibarr.class.php
+++ b/core/modules/modDigiriskDolibarr.class.php
@@ -599,6 +599,9 @@ class modDigiriskdolibarr extends DolibarrModules
             $i++ => ['DIGIRISKDOLIBARR_LISTINGRISKSENVIRONMENTALACTION_CUSTOM_ADDON_ODT_PATH', 'chaine', 'DOL_DATA_ROOT' . (($conf->entity == 1 ) ? '/' : '/' . $conf->entity . '/') . 'ecm/digiriskdolibarr/listingrisksenvironmentalaction/', '', 0, 'current'],
             $i++ => ['DIGIRISKDOLIBARR_LISTINGRISKSENVIRONMENTALACTION_DEFAULT_MODEL', 'chaine', 'listingrisksenvironmentalaction_odt', '', 0, 'current'],
 
+            // CONST LISTING RISKS ENVIRONMENTAL DOCUMENT
+            $i++ => ['DIGIRISKDOLIBARR_LISTINGRISKSENVIRONMENTALDOCUMENT_DEFAULT_MODEL', 'chaine', 'listingrisksenvironmentalaction_odt', '', 0, 'current'],
+
 			// CONST GROUPMENT DOCUMENT
 			$i++ => ['DIGIRISKDOLIBARR_MAIN_AGENDA_ACTIONAUTO_GROUPMENTDOCUMENT_GENERATE', 'integer', 1, '', 0, 'current'],
 			$i++ => ['DIGIRISKDOLIBARR_GROUPMENTDOCUMENT_ADDON', 'chaine', 'mod_groupmentdocument_standard', '', 0, 'current'],

--- a/langs/fr_FR/digiriskdolibarr.lang
+++ b/langs/fr_FR/digiriskdolibarr.lang
@@ -1150,6 +1150,13 @@ ListingRisksEnvironmentalActionGenerated   = Génération de listing des risques
 listingrisksenvironmentalaction.odt        = Listing des risques environnementaux avec actions correctives
 listingrisksenvironmentalaction_custom.odt = Listing des risques environnementaux avec actions correctives personnalisé
 
+#
+# ListingRisksEnvironmentalDocument - Listing des risques environnementaux documents
+#
+
+# Data - Donnée
+ListingRisksEnvironmentalDocument = Listing risques environnementaux
+
 
 
 #


### PR DESCRIPTION
Closes #3771

⚠️ Nécessite Evarisk/Saturne#1535 : sans lui, seule la nouvelle section apparaît, les deux modèles de l'issue restent masqués.

## Problème

Sur la page de configuration des documents, il manquait **3** modèles ODT existants :

| Modèle | Cause |
|---|---|
| `listingrisksaction_odt` | son générateur vit dans `listingrisksdocument/`, masqué par le filtre de nom de saturne |
| `listingrisksphoto_odt` | idem |
| `listingrisksenvironmentalaction_odt` | son type parent `listingrisksenvironmentaldocument` n'était pas déclaré dans `saturneAdminDocumentData()` |

Les deux premiers sont les « 2 documents listings » de l'issue. Le troisième est arrivé depuis, avec le même symptôme.

## Correctif

- Déclaration du type parent `listingrisksenvironmentaldocument` (le seul à porter le générateur du listing environnemental) et de son libellé `ListingRisksEnvironmentalDocument`.
- Ajout de `DIGIRISKDOLIBARR_LISTINGRISKSENVIRONMENTALDOCUMENT_DEFAULT_MODEL`, la constante que relit `saturne_show_documents()` sur l'onglet de génération — les autres types parents l'avaient déjà.

Les modèles `listingrisksaction_odt` / `listingrisksphoto_odt` n'avaient rien à corriger côté Digirisk : ils étaient déjà enregistrés sous le parent `listingrisksdocument`, c'est le filtre de saturne qui les cachait.

## Avant / Après

Section « Listing risques » : 1 modèle → 3 modèles, et nouvelle section « Listing risques environnementaux ».

| Avant | Après |
|---|---|
| <img src="https://raw.githubusercontent.com/nicolas-eoxia/digiriskdolibarr/assets/3771-screenshots/.screenshots/3771-avant.png" width="420"> | <img src="https://raw.githubusercontent.com/nicolas-eoxia/digiriskdolibarr/assets/3771-screenshots/.screenshots/3771-apres.png" width="420"> |

## Vérification

- Bascule activer / désactiver d'un modèle nouvellement visible : il apparaît / disparaît du sélecteur de génération de l'onglet listing.
- « Défaut » sur un de ces modèles : la présélection du sélecteur suit bien.
- Les liens portent le bon `type` (`listingrisksdocument`, `listingrisksenvironmentaldocument`, ceux enregistrés dans `llx_document_model`) et la bonne constante `*_ADDON_ODT_PATH` par modèle.
- Génération des 4 documents de listing : les ODT sont bien produits (la conversion PDF échoue en local faute de LibreOffice utilisable, à l'identique avant le correctif).
- Les 16 autres sections de la page sont inchangées.

## Reste à faire, hors périmètre

Quand une section porte plusieurs modèles, toutes les lignes s'appellent « ODT par défaut » / « ODT personnalisé » et ne se distinguent que par le nom du fichier gabarit affiché dans la description. C'est le comportement actuel des sections Groupement et Unité de travail, antérieur à ce correctif — à traiter dans une issue à part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)