### PR TITLE
#5044 [SCSS] fix: phantom vertical scrollbar on risk list

### DIFF
--- a/css/scss/table/_general.scss
+++ b/css/scss/table/_general.scss
@@ -9,6 +9,14 @@ td .wpeo-dropdown.category-danger.dropdown-active {
   position: static;
 }
 
+/* Fermé, le panneau n'est masqué que par opacity : ses 360px de haut restent dans le flux du
+   tableau et gonflent la hauteur défilable de .div-table-responsive (overflow: auto), qui
+   affiche alors une barre de défilement verticale ne montrant rien — y compris sur une liste
+   vide. On le sort donc du flux tant que le dropdown n'est pas ouvert. */
+.div-table-responsive .wpeo-dropdown:not(.dropdown-active) .saturne-dropdown-content {
+  display: none;
+}
+
 /** Cell header */
 .table-cell-header {
   display: flex;


### PR DESCRIPTION
## Changements

- Le panneau du sélecteur de catégorie de danger est sorti du flux tant que le dropdown n'est pas ouvert. Fermé, il n'était masqué que par `opacity: 0` : ses 360 px de haut restaient dans le flux du tableau et gonflaient la hauteur défilable de `.div-table-responsive` (`overflow: auto`), qui affichait une barre de défilement verticale ne montrant rien — y compris sur une liste vide.
- La règle voisine traitait déjà l'état ouvert (`position: static` sur `.dropdown-active`, pour que le panneau échappe au conteneur au lieu d'être rogné). Ce commit ajoute le pendant sur l'état fermé.
- Portée limitée aux conteneurs de liste : les dropdowns du reste du module gardent leur fondu.

## Fichiers modifiés

- `css/scss/table/_general.scss`

`css/digiriskdolibarr.min.css` n'est pas commité, la CI le recompile au merge.

## Vérification

Rendu headless sur une install locale, avant / après :

| Page | Avant | Après |
|---|---|---|
| `digiriskelement_risk.php?id=1889` (liste vide) | 190 / 409 → scroll | 190 / 190 |
| idem, liste des risques partagés | 191 / 434 → scroll | 191 / 191 |
| `digiriskelement_risk.php?id=3` (liste peuplée) | 505 / 505 | 505 / 505 |
| `digiriskelement_risksign.php?id=1889` | scroll | plus de scroll |

(clientHeight / scrollHeight du `.div-table-responsive`)

Le sélecteur de catégorie de danger s'ouvre toujours normalement et déborde du tableau. Le défilement horizontal des listes larges est conservé.

Close #5044
