### PR TITLE
#4589 [Ticket] fix: les utilisateurs désactivés dans la liste d'assignation

### DIFF
--- a/class/actions_digiriskdolibarr.class.php
+++ b/class/actions_digiriskdolibarr.class.php
@@ -488,7 +488,8 @@ class ActionsDigiriskdolibarr
 
                 $userGroupID = GETPOSTISSET('user_group') ? GETPOST('user_group') : getDolGlobalInt('DIGIRISKDOLIBARR_TICKET_DEFAULT_USER_GROUP');
                 $userGroup->fetch($userGroupID);
-                $users = $userGroup->listUsersForGroup();
+                // Only enabled users can be assigned to a ticket, a disabled one has no business showing up in the list
+                $users = $userGroup->listUsersForGroup('u.statut > 0');
                 $users = array_map(fn($userTmp) => $userTmp->getFullName($langs), $users);
 
                 $out .= '<tr class="field_fk_user_assign"><td class="titlefieldmax45 wordbreak">';
@@ -540,7 +541,7 @@ class ActionsDigiriskdolibarr
                 if (GETPOST('action') == 'get_user_group') {
                     $userGroupID = GETPOST('user_group');
                     $userGroup->fetch($userGroupID);
-                    $users = $userGroup->listUsersForGroup();
+                    $users = $userGroup->listUsersForGroup('u.statut > 0');
                     $users = array_map(fn($userTmp) => $userTmp->getFullName($langs), $users);
 
                     echo '<input type="hidden" name="users_list" value="' . base64_encode(json_encode($users)) . '">';


### PR DESCRIPTION
Closes #4589

## Problème

Le select « Assigné à » du formulaire d'assignation d'un ticket (et du formulaire de création) liste les utilisateurs désactivés.

## Cause

Les deux appels de `UserGroup::listUsersForGroup()` dans le hook `printCommonFooter` — rendu initial du select, et rechargement AJAX (`action=get_user_group`) au changement de groupe — étaient faits sans `$excludefilter`. Or cette méthode ne filtre **rien** par défaut ; le noyau lui passe systématiquement un filtre (cf. `projet/contact.php` qui utilise `'statut = 1'`).

Facteur aggravant : quand `DIGIRISKDOLIBARR_TICKET_DEFAULT_USER_GROUP` n'est pas configurée, `$userGroup->fetch(0)` échoue, `$this->id` reste vide, et `listUsersForGroup()` ne pose même plus la jointure sur le groupe → elle retourne **tous** les utilisateurs de l'entité.

## Correctif

`listUsersForGroup('u.statut > 0')` sur les deux appels.

## Tests

Vérifié en local (Playwright, ticket `TS2604-0471`, base contenant 41 utilisateurs désactivés) :

| | avant | après |
|---|---|---|
| Options de `#fk_user_assign` (aucun groupe par défaut configuré) | 63 (dont `SuperAdmin`, `Alexandre Techer`, `Jimmy Latour`, `Stage administratif`, `Mickael Grezes`…) | 21 |
| AJAX `get_user_group`, groupe « Technique » (4 membres, 1 désactivé) | 4 | 3 |
| AJAX `get_user_group`, groupe « Salariés » (15 membres, 9 désactivés) | 15 | 6 |

Le kanban tickets (`view/ticket/ticket_action_card.php`) filtrait déjà `u.statut = 1`, il n'était pas concerné.

## Hors périmètre, repéré au passage

- `Form::selectarray('fk_user_assign', $users, GETPOSTINT('fk_user_assign') ?? $object->fk_user_assign, ...)` : `GETPOSTINT()` renvoie `0` et jamais `null`, donc le `??` est mort et l'assigné courant n'est jamais présélectionné.
- Ce bloc (2 requêtes `UserGroup` + `listUsersForGroup`) s'exécute dans `printCommonFooter` sans garde de contexte, donc sur **chaque** page, alors que le JS ne l'injecte que si `action=create` ou `set=assign_ticket`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
