### PR TITLE
#4255 [PreventionPlan] fix: incrémentation du YYMM des références au clonage

### DIFF
--- a/class/firepermit.class.php
+++ b/class/firepermit.class.php
@@ -177,9 +177,10 @@ class FirePermit extends SaturneObject
         unset($object->import_key);
 
         // Clear fields
+        // Date creation must be set before ref: numbering modules build the YYMM part of the ref from it
+        $object->date_creation = dol_now();
         $object->ref           = $refFirePermitMod->getNextValue($object);
         $object->label         = $options['clone_label'];
-        $object->date_creation = dol_now();
         $object->status        = self::STATUS_DRAFT;
 
         // Create clone
@@ -222,6 +223,8 @@ class FirePermit extends SaturneObject
             if (!empty($options['firepermit_risk'])) {
                 if (is_array($firepermitdets) && !empty($firepermitdets)) {
                     foreach ($firepermitdets as $line) {
+                        // Date creation must be reset before ref: it is kept from the cloned line otherwise
+                        $line->date_creation = dol_now();
                         $line->ref           = $refFirePermitDetMod->getNextValue($line);
                         $line->fk_firepermit = $firePermitID;
                         $line->create($user, 1);

--- a/class/preventionplan.class.php
+++ b/class/preventionplan.class.php
@@ -183,9 +183,10 @@ class PreventionPlan extends SaturneObject
         unset($object->import_key);
 
         // Clear fields
+        // Date creation must be set before ref: numbering modules build the YYMM part of the ref from it
+        $object->date_creation = dol_now();
         $object->ref           = $refPreventionPlanMod->getNextValue($object);
         $object->label         = $options['clone_label'];
-        $object->date_creation = dol_now();
         $object->status        = self::STATUS_DRAFT;
 
         // Create clone
@@ -228,6 +229,8 @@ class PreventionPlan extends SaturneObject
             if (!empty($options['preventionplan_risk'])) {
                 if (is_array($preventionplandets) && !empty($preventionplandets)) {
                     foreach ($preventionplandets as $line) {
+                        // Date creation must be reset before ref: it is kept from the cloned line otherwise
+                        $line->date_creation     = dol_now();
                         $line->ref               = $refPreventionPlanDetMod->getNextValue($line);
                         $line->fk_preventionplan = $preventionPlanID;
                         $line->create($user, 1);


### PR DESCRIPTION
Closes #4255

## Problème

Au clonage d'un plan de prévention de 2024, la nouvelle référence reste en `PP2401-xxxx` : seul le compteur `nnnn` s'incrémente, la partie `YYMM` reste celle de l'original (`PP2401-0016` au lieu de `PP2609-xxxx`).

## Cause

Dans `createFromClone()`, la référence était calculée **avant** la remise à jour de `date_creation` :

```php
$object->ref           = $refPreventionPlanMod->getNextValue($object); // lit date_creation = 2024
$object->label         = $options['clone_label'];
$object->date_creation = dol_now();                                    // trop tard
```

Côté Saturne, `getNextValue()` construit le `YYMM` à partir de `$object->date_creation` :

```php
$date = !empty($object->date_creation) ? $object->date_creation : dol_now();
$yymm = dol_print_date($date, "%y%m");
return $this->prefix . $yymm . '-' . $num;
```

## Correction

- Plan de prévention et permis de feu : `date_creation` positionnée **avant** le calcul de la référence.
- Lignes de risque (`preventionplandet` / `firepermitdet`) : `date_creation` réinitialisée avant le calcul de la référence. `createCommon()` ne renseigne `date_creation` que si elle est vide (`if (array_key_exists('date_creation', $fieldvalues) && empty($fieldvalues['date_creation']))`), les lignes clonées étaient donc **aussi enregistrées en base avec la date de création de l'original**, en plus d'avoir une référence figée.

## Tests

Reproduction avant correctif, sur un objet dont `date_creation` vaut janvier 2024 :

```
date_creation source 2024-01 -> PP2401-0001
date_creation = now          -> PP2609-0001
```

Après correctif, clonage d'un plan de prévention daté du 15/01/2024 :

```
Source        : ref=PP1 date_creation=15/01/2024 10:00
En base       : ref=PP2609-0001 date_creation=2026-09-04 12:39:55
Attendu       : PPxxxx avec YYMM=2609
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
