### PR TITLE
#5049 [Risk] fix: charger les utilisateurs et les évaluations à la demande

### DIFF
--- a/class/digirisklazymap.class.php
+++ b/class/digirisklazymap.class.php
@@ -1,0 +1,116 @@
+<?php
+/* Copyright (C) 2026 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    class/digirisklazymap.class.php
+ * \ingroup digiriskdolibarr
+ * \brief   Class file for a keyed collection whose entries are loaded on first access
+ */
+
+/**
+ * Read-only keyed collection that loads each entry the first time it is read.
+ *
+ * Risk lists used to preload every user and every risk assessment of the database only to
+ * display the handful of them the rows on screen actually reference, which costs a query per
+ * user and instantiates the whole riskassessment table on every page. This collection keeps
+ * the `$map[$key]` syntax the templates already use, but calls its loader only for the keys
+ * that are really read, and only once per key.
+ */
+class DigiriskLazyMap implements ArrayAccess
+{
+    /**
+     * @var callable Loader receiving the requested key and returning the value to memoize
+     */
+    private $loader;
+
+    /**
+     * @var array Values already loaded, keyed by the key they were requested with
+     */
+    private array $loaded = [];
+
+    /**
+     * Constructor
+     *
+     * @param callable $loader Called with the requested key, returns the value to memoize
+     */
+    public function __construct(callable $loader)
+    {
+        $this->loader = $loader;
+    }
+
+    /**
+     * Return the value for a key, loading it on first access
+     *
+     * @param  mixed $offset Key to read
+     * @return mixed         Value returned by the loader
+     */
+    #[\ReturnTypeWillChange]
+    public function offsetGet($offset)
+    {
+        $key = is_scalar($offset) ? (string) $offset : '';
+
+        if (!array_key_exists($key, $this->loaded)) {
+            $this->loaded[$key] = call_user_func($this->loader, $offset);
+        }
+
+        return $this->loaded[$key];
+    }
+
+    /**
+     * Tell whether a key holds a value, loading it on first access
+     *
+     * The loader is expected to return an empty value rather than to fail, so a key is
+     * "set" when its loaded value is not null.
+     *
+     * @param  mixed $offset Key to test
+     * @return bool          True when the loaded value is not null
+     */
+    #[\ReturnTypeWillChange]
+    public function offsetExists($offset)
+    {
+        return $this->offsetGet($offset) !== null;
+    }
+
+    /**
+     * Store a value for a key, bypassing the loader
+     *
+     * @param  mixed $offset Key to write, null to append
+     * @param  mixed $value  Value to memoize
+     * @return void
+     */
+    #[\ReturnTypeWillChange]
+    public function offsetSet($offset, $value)
+    {
+        if ($offset === null) {
+            $this->loaded[] = $value;
+        } else {
+            $this->loaded[is_scalar($offset) ? (string) $offset : ''] = $value;
+        }
+    }
+
+    /**
+     * Forget the value memoized for a key, so the next read loads it again
+     *
+     * @param  mixed $offset Key to forget
+     * @return void
+     */
+    #[\ReturnTypeWillChange]
+    public function offsetUnset($offset)
+    {
+        unset($this->loaded[is_scalar($offset) ? (string) $offset : '']);
+    }
+}

--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_inheritedrisklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_inheritedrisklist_view.tpl.php
@@ -35,22 +35,17 @@
 
 		// Reuse the data already loaded by the main risk list when both are rendered on the same
 		// page (same variable names); only load what is missing so these full "load all" queries
-		// (users, riskassessments, tasks, time spent) are not run a second time.
-		if (!isset($riskAssessmentList))      $riskAssessmentList      = $riskAssessment->fetchAll();
+		// (tasks, time spent) are not run a second time.
 		if (!isset($riskAssessmentNextValue)) $riskAssessmentNextValue = $refEvaluationMod->getNextValue($evaluation);
 		if (!isset($riskAssessmentTaskList))  $riskAssessmentTaskList  = $risk->getTasksWithFkRisk();
 		if (!isset($taskNextValue))           $taskNextValue           = $refTaskMod->getNextValue('', $task);
-		if (!isset($usersList)) {
-			$usertmp->fetchAll();
-			$usersList = $usertmp->users;
-		}
 		if (!isset($timeSpentSortedByTasks))  $timeSpentSortedByTasks  = $digiriskTask->fetchAllTimeSpentAllUsers('AND fk_element > 0', 'element_datehour', 'DESC', 1);
 
-		if (!isset($riskAssessmentsOrderedByRisk) && is_array($riskAssessmentList) && !empty($riskAssessmentList)) {
-			foreach ($riskAssessmentList as $riskAssessmentSingle) {
-				$riskAssessmentsOrderedByRisk[$riskAssessmentSingle->fk_risk][$riskAssessmentSingle->id] = $riskAssessmentSingle;
-			}
-		}
+		// The list is paginated and both collections are only read by id, so they load their
+		// entries on demand instead of instantiating every user and every risk assessment of
+		// the database; both are memoized per request, so the main list shares them
+		$usersList                    = digirisk_get_user_list();
+		$riskAssessmentsOrderedByRisk = digirisk_get_risk_assessments_by_risk();
 		// Build and execute select
 		// --------------------------------------------------------------------
 		if (!preg_match('/(evaluation)/', $sortfield)) {

--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
@@ -306,25 +306,17 @@ $DUProject                   = new Project($db);
 $DUProject->fetch($riskType == 'risk' ? $conf->global->DIGIRISKDOLIBARR_DU_PROJECT : $conf->global->DIGIRISKDOLIBARR_ENVIRONMENT_PROJECT);
 $extrafields->fetch_name_optionals_label($digiriskTask->table_element);
 
-$riskAssessment->ismultientitymanaged = 0;
-
 $activeDigiriskElementList = $digiriskelement->getActiveDigiriskElements();
-$riskAssessmentList        = $riskAssessment->fetchAll();
 $riskAssessmentNextValue   = $refEvaluationMod->getNextValue($evaluation);
 $riskAssessmentTaskList    = $risk->getTasksWithFkRisk();
 $taskNextValue             = $refTaskMod->getNextValue('', $task);
-$usertmp->fetchAll();
-$usersList                 = $usertmp->users;
 $timeSpentSortedByTasks    = $digiriskTask->fetchAllTimeSpentAllUsers('AND fk_element > 0', 'element_datehour', 'DESC', 1);
 $dangerCategories          = Risk::getDangerCategories($riskType);
 
-$riskAssessment->ismultientitymanaged = 1;
-
-if (is_array($riskAssessmentList) && !empty($riskAssessmentList)) {
-    foreach ($riskAssessmentList as $riskAssessmentSingle) {
-        $riskAssessmentsOrderedByRisk[$riskAssessmentSingle->fk_risk][$riskAssessmentSingle->id] = $riskAssessmentSingle;
-    }
-}
+// The list is paginated and both collections are only read by id, so they load their entries
+// on demand instead of instantiating every user and every risk assessment of the database
+$usersList                    = digirisk_get_user_list();
+$riskAssessmentsOrderedByRisk = digirisk_get_risk_assessments_by_risk();
 
 $deletedElements = $digiriskelement->getMultiEntityTrashList();
 if (empty($deletedElements)) {

--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_sharedrisklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_sharedrisklist_view.tpl.php
@@ -67,19 +67,15 @@ $digiriskElementsOfEntity = $digiriskelement->getActiveDigiriskElements();
 $DUProject->fetch($riskType == 'risk' ? $conf->global->DIGIRISKDOLIBARR_DU_PROJECT : $conf->global->DIGIRISKDOLIBARR_ENVIRONMENT_PROJECT);
 $extrafields->fetch_name_optionals_label($digiriskTask->table_element);
 
-$riskAssessmentList        = $riskAssessment->fetchAll('', '', 0, 0, array(), 'AND', 1);
 $riskAssessmentNextValue   = $refEvaluationMod->getNextValue($evaluation);
 $riskAssessmentTaskList    = $risk->getTasksWithFkRisk();
 $taskNextValue             = $refTaskMod->getNextValue('', $task);
-$usertmp->fetchAll();
-$usersList                 = $usertmp->users;
 $timeSpentSortedByTasks    = $digiriskTask->fetchAllTimeSpentAllUsers('AND fk_element > 0', 'element_datehour', 'DESC', 1);
 
-if (is_array($riskAssessmentList) && !empty($riskAssessmentList)) {
-	foreach ($riskAssessmentList as $riskAssessmentSingle) {
-		$riskAssessmentsOrderedByRisk[$riskAssessmentSingle->fk_risk][$riskAssessmentSingle->id] = $riskAssessmentSingle;
-	}
-}
+// The list is paginated and both collections are only read by id, so they load their entries
+// on demand instead of instantiating every user and every risk assessment of the database
+$usersList                    = digirisk_get_user_list();
+$riskAssessmentsOrderedByRisk = digirisk_get_risk_assessments_by_risk();
 
 // Build and execute select
 // --------------------------------------------------------------------

--- a/lib/digiriskdolibarr_function.lib.php
+++ b/lib/digiriskdolibarr_function.lib.php
@@ -2818,3 +2818,75 @@ function digirisk_get_date_range_filter(string $prefix, int $start = 0, int $end
 
     return implode('&', $filter);
 }
+
+/**
+ * Get the collection giving the author of a risk assessment, a task or a time spent line
+ *
+ * Risk lists only display the few users their rows reference, but used to load them with
+ * User::fetchAll(), which issues a fetch() and a fetch_optionals() per user of the whole
+ * database (two queries each). The collection returned here loads a user the first time
+ * its id is read and keeps the array syntax of the templates.
+ *
+ * @return DigiriskLazyMap Collection of User objects, keyed by user id
+ */
+function digirisk_get_user_list(): DigiriskLazyMap
+{
+    global $db;
+
+    require_once __DIR__ . '/../class/digirisklazymap.class.php';
+
+    static $userList = null;
+    if ($userList === null) {
+        $userList = new DigiriskLazyMap(function ($userId) use ($db) {
+            $userAuthor = new User($db);
+
+            // A row may reference a user that no longer exists; the callers type-hint User,
+            // so hand them an empty object rather than null
+            if ($userId > 0) {
+                $userAuthor->fetch($userId);
+            }
+
+            return $userAuthor;
+        });
+    }
+
+    return $userList;
+}
+
+/**
+ * Get the collection giving the risk assessments of a risk
+ *
+ * Risk lists are paginated and read this collection by risk id, but used to build it from a
+ * RiskAssessment::fetchAll() with neither limit nor entity filter, so every risk assessment
+ * of every entity was instantiated on each page. The collection returned here queries the
+ * assessments of a risk the first time that risk is read.
+ *
+ * @return DigiriskLazyMap Collection of arrays of RiskAssessment objects, keyed by risk id
+ */
+function digirisk_get_risk_assessments_by_risk(): DigiriskLazyMap
+{
+    global $db;
+
+    require_once __DIR__ . '/../class/digirisklazymap.class.php';
+    require_once __DIR__ . '/../class/riskanalysis/riskassessment.class.php';
+
+    static $riskAssessmentsByRisk = null;
+    if ($riskAssessmentsByRisk === null) {
+        $riskAssessmentsByRisk = new DigiriskLazyMap(function ($riskId) use ($db) {
+            if ($riskId <= 0) {
+                return [];
+            }
+
+            // Shared risks belong to other entities, so keep the entity filter off as the
+            // preloading it replaces did
+            $riskAssessment = new RiskAssessment($db);
+            $riskAssessment->ismultientitymanaged = 0;
+
+            $riskAssessments = $riskAssessment->fetchAll('', '', 0, 0, ['customsql' => 't.fk_risk = ' . (int) $riskId]);
+
+            return is_array($riskAssessments) ? $riskAssessments : [];
+        });
+    }
+
+    return $riskAssessmentsByRisk;
+}

--- a/sql/riskanalysis/llx_digiriskdolibarr_riskassessment.key.sql
+++ b/sql/riskanalysis/llx_digiriskdolibarr_riskassessment.key.sql
@@ -17,3 +17,4 @@ ALTER TABLE llx_digiriskdolibarr_riskassessment ADD INDEX idx_digiriskdolibarr_r
 ALTER TABLE llx_digiriskdolibarr_riskassessment ADD INDEX idx_digiriskdolibarr_riskassessment_ref (ref);
 ALTER TABLE llx_digiriskdolibarr_riskassessment ADD CONSTRAINT llx_digiriskdolibarr_riskassessment_fk_user_creat FOREIGN KEY (fk_user_creat) REFERENCES llx_user(rowid);
 ALTER TABLE llx_digiriskdolibarr_riskassessment ADD UNIQUE uk_riskassessment_ref (ref, entity);
+ALTER TABLE llx_digiriskdolibarr_riskassessment ADD INDEX idx_digiriskdolibarr_riskassessment_fk_risk (fk_risk);

--- a/sql/update.sql
+++ b/sql/update.sql
@@ -282,3 +282,6 @@ ALTER TABLE llx_digiriskdolibarr_preventionplan ADD note_private text NULL AFTER
 
 -- 23.1.x - remove orphan const left by the deleted module_parts['tabs'] declaration
 DELETE FROM llx_const WHERE name = 'MAIN_MODULE_DIGIRISKDOLIBARR_TABS';
+
+-- 23.1.x - index used by the per-risk loading of risk assessments on the risk lists
+ALTER TABLE llx_digiriskdolibarr_riskassessment ADD INDEX idx_digiriskdolibarr_riskassessment_fk_risk (fk_risk);


### PR DESCRIPTION
Suite de #4820 (fiche risque à ~17 s chez un client à plus de 1200 GP/UT). Traite les lots 1 et 3 de #5049.

## Ce qui n'allait pas

Les listes de risques préchargeaient tout ce dont elles pouvaient avoir besoin, sans rapport avec la pagination.

**`User::fetchAll()`** — [`risklist_view.tpl.php:316`](../blob/develop/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php#L316), idem dans les listes héritées et partagées :

```php
$usertmp->fetchAll();
$usersList = $usertmp->users;
```

La méthode Dolibarr ne fait qu'un `SELECT t.rowid`, puis un `$line->fetch()` complet par ligne — soit `fetch()` + `fetch_optionals()`, **deux requêtes par utilisateur de la base**, à chaque affichage. Mesuré : 126 requêtes pour 63 utilisateurs. Or `$usersList` ne sert qu'à `getNomUrlUser()` pour afficher l'auteur de quelques lignes.

**`RiskAssessment::fetchAll()`** — [`risklist_view.tpl.php:308-312`](../blob/develop/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php#L308-L312) : appelé sans `limit` et avec `ismultientitymanaged = 0`, donc **sans filtre d'entité**. Toutes les évaluations de toutes les entités étaient instanciées en objets PHP, alors que `$riskAssessmentsOrderedByRisk` n'est lu que par `$risk->id`.

## Correctif

Les deux collections deviennent des `DigiriskLazyMap` mémoïsées : une entrée est chargée à sa première lecture, et une seule fois. La syntaxe `$map[$id]` des templates est conservée, donc **aucun template consommateur n'est modifié** (`riskassessment_view.tpl.php`, `riskassessment_task_view.tpl.php`, etc.).

Ajout de l'index manquant sur `llx_digiriskdolibarr_riskassessment.fk_risk`, sur lequel porte désormais le chargement par risque.

Effet de bord bienvenu : un risque sans évaluation renvoie maintenant un tableau vide au lieu de `null`, ce qui supprime le `TypeError` de `array_filter(null)` en PHP 8 sur ce chemin.

## Vérification

Sur `dolibarr_22_evarisk` — 18 éléments, 63 utilisateurs, élément à 13 risques, liste héritée activée :

| | Avant | Après |
|---|---|---|
| Requêtes SQL | 302 | **197** |
| HTML généré | 2 025 624 o | **2 025 624 o** |

Le HTML produit est **strictement identique** avant/après (seul le nonce CSP, aléatoire par requête, diffère) — donc aucune régression de rendu possible. Les warnings PHP présents dans la page sont inchangés (préexistants, sans rapport).

Chemins également passés sans fatal : `risk_list.php`, un élément sans risque, `risk_type=environmentalrisk`, et la liste des risques partagés (`DIGIRISKDOLIBARR_SHOW_SHARED_RISKS` activée le temps du test).

Le gain croît linéairement avec la taille de la base : sur une collectivité à 800 agents, ce sont ~1600 requêtes en moins par affichage.

## Reste à faire

Les lots 2 (listes déroulantes d'utilisateurs dupliquées dans chaque modale) et 4 (arborescence GP/UT rendue intégralement sur toutes les pages) restent ouverts dans #5049.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
