### PR TITLE
#5054 [RiskAssessment] fix: warnings PHP 8 et message d'erreur vide à la création de tâche

### DIFF
--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_risk_actions.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_risk_actions.tpl.php
@@ -411,9 +411,11 @@ if ( ! $error && $action == 'addRiskAssessmentTask' && $permissiontoadd) {
 	$task->array_options['options_fk_risk'] = $riskID;
 
 	$result = $task->create($user, true);
-    $task->add_contact($executiveUser, 'TASKEXECUTIVE', 'internal');
 
 	if ($result > 0) {
+		if (!empty($executiveUser)) {
+			$task->add_contact($executiveUser, 'TASKEXECUTIVE', 'internal');
+		}
 		if (!empty($conf->global->DIGIRISKDOLIBARR_MAIN_AGENDA_ACTIONAUTO_TASK_CREATE)) $task->call_trigger('TASK_CREATE', $user);
 		// Creation task OK
 		$urltogo = str_replace('__ID__', $result, $backtopage);
@@ -423,7 +425,7 @@ if ( ! $error && $action == 'addRiskAssessmentTask' && $permissiontoadd) {
 	} else {
 		// Delete task KO
 		header('HTTP/1.1 500 Internal Server Booboo');
-		die(json_encode(array('message' => html_entity_decode($langs->transnoentities($task->errors[0])), 'code' => '1339')));
+		die(json_encode(array('message' => html_entity_decode($langs->transnoentities($task->errorsToString())), 'code' => '1339')));
 	}
 }
 
@@ -481,7 +483,7 @@ if ( ! $error && $action == 'saveRiskAssessmentTask' && $permissiontoadd) {
 	} else {
 		// Delete task KO
 		header('HTTP/1.1 500 Internal Server Booboo');
-		die(json_encode(array('message' => html_entity_decode($langs->transnoentities($task->errors[0])), 'code' => '1338')));
+		die(json_encode(array('message' => html_entity_decode($langs->transnoentities($task->errorsToString())), 'code' => '1338')));
 	}
 }
 

--- a/core/tpl/riskanalysis/riskassessment/digiriskdolibarr_riskassessment_view.tpl.php
+++ b/core/tpl/riskanalysis/riskassessment/digiriskdolibarr_riskassessment_view.tpl.php
@@ -122,7 +122,7 @@ if (is_array($allRiskAssessment) && !empty($allRiskAssessment)) :
 								<div class="risk-evaluation-container risk-evaluation-ref-<?php echo $lastEvaluation->id ?>" value="<?php echo $lastEvaluation->ref ?>">
 									<div class="risk-evaluation-single">
 										<div class="risk-evaluation-cotation" data-scale="<?php echo $lastEvaluation->getEvaluationScale() ?>">
-											<span><?php echo ($lastEvaluation->method == 'standard' ? $defaultCotation[$lastEvaluation->cotation] ?: 0 : $lastEvaluation->cotation); ?></span>
+											<span><?php echo ($lastEvaluation->method == 'standard' ? $defaultCotation[$lastEvaluation->cotation] ?? 0 : $lastEvaluation->cotation); ?></span>
 										</div>
 										<div class="photo riskassessment-photo-<?php echo $lastEvaluation->id; ?>" style="margin:auto">
 											<?php
@@ -385,7 +385,7 @@ $evaluation->method = $lastRiskAssessment->method ?: "standard" ;
 						<div class="risk-evaluation-single-content risk-evaluation-single-content-<?php echo $risk->id ?>">
 							<div class="risk-evaluation-single">
 								<div class="risk-evaluation-cotation risk-evaluation-list" value="<?php echo $risk->id ?>" data-scale="<?php echo $lastRiskAssessment->getEvaluationScale() ?>">
-									<span><?php echo ($lastRiskAssessment->method == 'standard' ? $defaultCotation[$lastRiskAssessment->cotation] ?: 0 : $lastRiskAssessment->cotation); ?></span>
+									<span><?php echo ($lastRiskAssessment->method == 'standard' ? $defaultCotation[$lastRiskAssessment->cotation] ?? 0 : $lastRiskAssessment->cotation); ?></span>
 								</div>
 								<div class="photo riskassessment-photo-<?php echo $lastRiskAssessment->id > 0 ? $lastRiskAssessment->id : 0 ; echo $risk->id > 0 ? ' risk-' . $risk->id : ' risk-new' ?>">
                                     <?php

--- a/core/tpl/riskanalysis/riskassessment/digiriskdolibarr_riskassessment_view_edit_modal.tpl.php
+++ b/core/tpl/riskanalysis/riskassessment/digiriskdolibarr_riskassessment_view_edit_modal.tpl.php
@@ -1,3 +1,8 @@
+<?php
+// $onPhone is set by the calling page (risk_list.php, digiriskelement_risk.php)
+// but this template must not assume it when included from another context
+$onPhone = $onPhone ?? ($conf->browser->layout == 'phone');
+?>
 <!-- RISK EVALUATION EDIT MODAL START-->
 <div class="risk-evaluation-edit-modal" value="<?php echo $lastEvaluation->id ?>">
 	<div class="wpeo-modal modal-risk" id="risk_evaluation_edit<?php echo $lastEvaluation->id ?>" value="<?php echo $risk->id ?>">

--- a/core/tpl/riskanalysis/riskassessment/digiriskdolibarr_riskassessment_view_single.tpl.php
+++ b/core/tpl/riskanalysis/riskassessment/digiriskdolibarr_riskassessment_view_single.tpl.php
@@ -5,7 +5,7 @@
 	<div class="risk-evaluation-single-content risk-evaluation-single-content-<?php echo $risk->id ?>">
 		<div class="risk-evaluation-single risk-evaluation-single-<?php echo $risk->id ?>">
 			<div class="risk-evaluation-cotation risk-evaluation-list modal-open" value="<?php echo $risk->id ?>" data-scale="<?php echo $lastEvaluation->getEvaluationScale() ?>">
-				<span><?php echo ($lastEvaluation->method == 'standard' ? $defaultCotation[$lastEvaluation->cotation] ?: 0 : $lastEvaluation->cotation); ?></span>
+				<span><?php echo ($lastEvaluation->method == 'standard' ? $defaultCotation[$lastEvaluation->cotation] ?? 0 : $lastEvaluation->cotation); ?></span>
 			</div>
 			<div class="photo riskassessment-photo-<?php echo $lastEvaluation->id; ?>" style="margin:auto">
 				<?php


### PR DESCRIPTION
Closes #5054

Suite à l'analyse de #4160, où un utilisateur a perdu du temps sur une popup d'erreur **vide** alors que le vrai message était `Unknown column 'fk_risk' in 'field list'`.

## Message d'erreur vide à la création / modification de tâche

`digiriskdolibarr_risk_actions.tpl.php` renvoyait `$task->errors[0]` au JS. Or `Task::create()` et `insertExtraFields()` ne remplissent que `$this->error` (chaîne) sur échec SQL et **laissent `$this->errors` vide** → `Undefined array key 0` + message vide côté utilisateur.

➡️ `errorsToString()`, qui concatène `error` + `errors` (déjà l'usage dans `actions_digiriskdolibarr.class.php`).

Au passage, `add_contact()` était appelé **même quand `create()` avait échoué**, et même sans responsable sélectionné. Il échouait alors et injectait un `Valeur incorrecte pour le paramètre 1` en tête du message d'erreur. Il est déplacé dans la branche de succès et gardé sur `!empty($executiveUser)`, comme le fait déjà `saveRiskAssessmentTask`.

## `Undefined array key ""` sur la cotation

`$defaultCotation[$xxx->cotation] ?: 0` → `?? 0`. Les valeurs du tableau étant toutes non vides, le comportement est identique, sans le warning. 3 occurrences.

## `Undefined variable $onPhone`

Valeur par défaut dans `digiriskdolibarr_riskassessment_view_edit_modal.tpl.php` au lieu de compter sur la page appelante.

## Tests

Sur Dolibarr 23 en local, avec relevé de `php_error.log` avant/après :

| | avant | après |
|---|---|---|
| `digiriskelement_risk.php` (+ variantes shared / inherited / environnement) | `Undefined array key ""` ligne 125 | aucun warning |
| création de tâche en erreur (date de fin < date de début) | `Valeur incorrecte pour le paramètre 1, La date de fin ne peut pas être antérieure à la date de début` | `La date de fin ne peut pas être antérieure à la date de début` |
| création de tâche nominale | — | 302, aucun warning |

Tâche de test supprimée après coup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)