### PR TITLE
#4216 [Dashboard] fix: lien de telechargement du DU sur l'entite courante

### DIFF
--- a/class/digiriskdolibarrdocuments/riskassessmentdocument.class.php
+++ b/class/digiriskdolibarrdocuments/riskassessmentdocument.class.php
@@ -272,7 +272,9 @@ class RiskAssessmentDocument extends DigiriskDocuments
      */
     public function getGenerationDateInfos(array $moreParam = []): array
     {
-        global $langs;
+        global $conf, $langs;
+
+        $entity = (int) ($moreParam['entity'] ?? $conf->entity);
 
         $filter                  = ['customsql' => 't.type = "' . $this->element . '"' . ($moreParam['filter'] ?? '')];
         $riskAssessmentDocuments = $this->fetchAll('desc', 't.rowid', 1, 0, $filter);
@@ -302,8 +304,8 @@ class RiskAssessmentDocument extends DigiriskDocuments
             $array['delaygeneratedate'] = 'N/A';
         }
 
-        $array['moreContent']  = $this->showUrlOfLastGeneratedDocument($this->module, $this->element, 'odt', 'fontawesome_fa-file-word_far_#0D8AFF', $moreParam['entity'] ?? 1);
-        $array['moreContent'] .= $this->showUrlOfLastGeneratedDocument($this->module, $this->element, 'pdf', 'fontawesome_fa-file-pdf_far_#FB4B54', $moreParam['entity'] ?? 1);
+        $array['moreContent']  = $this->showUrlOfLastGeneratedDocument($this->module, $this->element, 'odt', 'fontawesome_fa-file-word_far_#0D8AFF', $entity);
+        $array['moreContent'] .= $this->showUrlOfLastGeneratedDocument($this->module, $this->element, 'pdf', 'fontawesome_fa-file-pdf_far_#FB4B54', $entity);
         return $array;
     }
 }


### PR DESCRIPTION
Closes #4216

## Problème

`RiskAssessmentDocument::load_dashboard()` appelle `getGenerationDateInfos()` sans paramètre, et l'entité retombait sur un défaut codé en dur à `1` :

```php
$this->showUrlOfLastGeneratedDocument(..., $moreParam['entity'] ?? 1);
```

Le widget « Document unique » du dashboard cherchait donc toujours le dernier fichier dans `documents/digiriskdolibarr/riskassessmentdocument` et générait une URL `document.php?...&entity=1`, quelle que soit l'entité courante.

En multicompany, sur une entité > 1 : le widget affiche « Dernière génération : N/A » (le `fetchAll` filtre bien par entité) **et malgré tout un lien de téléchargement pointant sur le DU de l'entité 1**. `document.php` sert alors le document d'une autre entité, ou renvoie `Le fichier %s n'existe pas` — le navigateur télécharge un `document.htm` de ~75 octets au lieu du PDF/ODT, exactement le symptôme de la capture de l'issue.

Seul digiboard passait correctement `$moreParam['entity']` : le paramètre n'avait été ajouté que pour lui (Saturne#1102).

## Correctif

L'entité par défaut devient `$conf->entity`. Digiboard, qui passe déjà `$moreParam['entity']` explicitement pour son tableau multi-entités, n'est pas impacté.

Le défaut `int $entity = 1` côté Saturne est corrigé en parallèle dans Evarisk/Saturne#1547.

## Tests

Script CLI forçant `$conf->entity` puis appelant le chemin `load_dashboard()` :

| entité | avant | après |
|---|---|---|
| 1 | `...DU107_Industrie_standard.odt&entity=1` | inchangé |
| 2 | `...DU107_Industrie_standard.odt&entity=1` (DU de l'entité 1) | `...DU3_Entreprise_tertiaire.odt&entity=2` |
| 5 | `...DU107_Industrie_standard.odt&entity=1` (DU de l'entité 1) | aucun lien (pas de document) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)