### PR TITLE
#5049 [Arborescence] fix: pas de title sur la vignette 40x40 des GP/UT

### DIFF
--- a/lib/digiriskdolibarr_function.lib.php
+++ b/lib/digiriskdolibarr_function.lib.php
@@ -427,7 +427,7 @@ function display_recurse_tree($digiriskElementTree, $i = 1)
                 <span class="open-media-gallery add-media modal-open photo-container digirisk-element-photo-<?php echo $obj->id; ?>" value="0">
                     <input type="hidden" class="modal-options" data-modal-to-open="media_gallery" data-from-id="<?php echo $obj->id; ?>" data-from-type="<?php echo $type; ?>" data-from-subtype="photo" data-from-subdir="" data-photo-class="digirisk-element-photo-<?php echo $obj->id; ?>"/>
                     <?php
-                    $mediaOutput = saturne_show_medias_linked('digiriskdolibarr', $conf->digiriskdolibarr->multidir_output[$conf->entity] . '/' . $type . '/' . $obj->ref, 'small', 1, 0, 0, 0, 40, 40, 1, 0, 0, $type . '/' . $obj->ref, $obj, 'photo', 0, 0, 1, 1, 'cursorpointer');
+                    $mediaOutput = saturne_show_medias_linked('digiriskdolibarr', $conf->digiriskdolibarr->multidir_output[$conf->entity] . '/' . $type . '/' . $obj->ref, 'small', 1, 0, 0, 0, 40, 40, 1, 1, 0, $type . '/' . $obj->ref, $obj, 'photo', 0, 0, 1, 1, 'cursorpointer');
                     if (strpos($mediaOutput, 'nophoto.png') !== false) {
                         print '<svg class="nophoto-placeholder" width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg"><rect width="40" height="40" rx="6" fill="#f0f0f0"/><path d="M20 16a3 3 0 100 6 3 3 0 000-6z" fill="#bbb"/><path d="M14 13h3l1.5-2h3l1.5 2h3a2 2 0 012 2v10a2 2 0 01-2 2H14a2 2 0 01-2-2V15a2 2 0 012-2z" stroke="#bbb" stroke-width="1.5" fill="none"/></svg>';
                     } else {
@@ -501,7 +501,7 @@ function display_recurse_tree_organization($digiriskElementTree, $i = 1, $riskIn
 
                         <div class="photo-container">
                             <?php
-                            $mediaOutput = saturne_show_medias_linked('digiriskdolibarr', $conf->digiriskdolibarr->multidir_output[$conf->entity] . '/' . $obj->element_type . '/' . $obj->ref, 'small', 1, 0, 0, 0, 40, 40, 1, 0, 0, $obj->element_type . '/' . $obj->ref, $obj, 'photo', 0, 0, 1, 1, 'cursorpointer');
+                            $mediaOutput = saturne_show_medias_linked('digiriskdolibarr', $conf->digiriskdolibarr->multidir_output[$conf->entity] . '/' . $obj->element_type . '/' . $obj->ref, 'small', 1, 0, 0, 0, 40, 40, 1, 1, 0, $obj->element_type . '/' . $obj->ref, $obj, 'photo', 0, 0, 1, 1, 'cursorpointer');
                             if (strpos($mediaOutput, 'nophoto.png') !== false) {
                                 print '<svg class="nophoto-placeholder" width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg"><rect width="40" height="40" rx="6" fill="#f0f0f0"/><path d="M20 16a3 3 0 100 6 3 3 0 000-6z" fill="#bbb"/><path d="M14 13h3l1.5-2h3l1.5 2h3a2 2 0 012 2v10a2 2 0 01-2 2H14a2 2 0 01-2-2V15a2 2 0 012-2z" stroke="#bbb" stroke-width="1.5" fill="none"/></svg>';
                             } else {


### PR DESCRIPTION
Lot 4 de #5049 (partie médias), issu de #4820. Pendant Digirisk de Evarisk/Saturne#1549.

## Pourquoi

`digirisk_header()` rend le panneau de navigation GP/UT sur **toutes** les pages Digirisk, et appelle `saturne_show_medias_linked()` une fois par élément pour la vignette 40×40.

Composer l'attribut `title` d'un média fait lire l'en-tête de l'original **et** celui de la vignette. À 1200 GP/UT — le profil du client de #4820 — ce sont 2400 lectures de fichier par page, pour une infobulle « File: … - Size: 40x27 - OriginalSize: 900x600 » qui n'apporte rien sur une vignette de navigation.

Les deux appels de l'arborescence passent donc `$notitle = 1`.

## Mesure

Avec Evarisk/Saturne#1549, sur 1200 éléments ayant chacun une photo et sa vignette :

| | avant | après |
|---|---|---|
| Rendu des médias de l'arborescence | 777 ms | **187 ms** |

Le HTML de l'arborescence diminue aussi, le `title` n'étant plus émis.

## Vérification

Au navigateur : la vignette est servie depuis `thumbs/…_mini.jpg`, porte `loading="lazy"`, n'a plus de `title`, n'est pas cassée, et la modale « Bibliothèque de médias » s'ouvre toujours depuis la vignette (16 médias listés). Aucune erreur JS.

## Reste du lot 4

Le poste le plus lourd n'est pas traité ici : l'arborescence est rendue **intégralement** sur chaque page, soit **2 966 octets par élément — 3,4 Mo de HTML à 1200 GP/UT**, branches repliées comprises. Le chargement paresseux des branches est un rework à part, détaillé dans #5049.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
