### PR TITLE
#5057 [Risk] fix: fuites de données entre entités sur les risques et signalisations partagés

### DIFF
--- a/class/digiriskelement.class.php
+++ b/class/digiriskelement.class.php
@@ -220,7 +220,7 @@ class DigiriskElement extends SaturneObject
         }
 
         $array['shared']['digiriskElements'] = [];
-        if ($moreParam['tmparray']['showSharedRisk_nocheck']) {
+        if (!empty($moreParam['tmparray']['showSharedRisk_nocheck'])) {
             $array['shared']['digiriskElements'] = $this->fetchDigiriskElementFlat(0, [], 'shared');
         }
 

--- a/class/riskanalysis/risk.class.php
+++ b/class/riskanalysis/risk.class.php
@@ -238,7 +238,7 @@ class Risk extends SaturneObject
             $array['shared']['riskByRiskAssessmentLevels']    = [];
         }
 
-        if (isset($moreParam['tmparray']['showSharedRisk_nocheck']) && $moreParam['tmparray']['showSharedRisk_nocheck'] === true) {
+        if (!empty($moreParam['tmparray']['showSharedRisk_nocheck'])) {
             $array['shared']['risks'] = saturne_fetch_all_object_type('Risk', 'DESC', 'riskAssessmentCotation', 0, 0, ['customsql' => $filter], 'AND', false, true, false, $sharedJoin, [], $sharedSelect, $sharedMoreSelects);
             if (!is_array($array['shared']['risks']) || empty($array['shared']['risks'])) {
                 $array['shared']['risks']                         = [];
@@ -338,8 +338,6 @@ class Risk extends SaturneObject
 	 */
 	public function fetchRisksOrderedByCotation($parent_id, $get_children_data = false, $get_parents_data = false, $get_shared_data = false, $moreParams = [])
 	{
-        global $conf;
-
 		$object         = new DigiriskElement($this->db);
 		$risk           = new Risk($this->db);
         $riskAssessment = new RiskAssessment($this->db);
@@ -360,11 +358,22 @@ class Risk extends SaturneObject
 			}
 		}
 
+		$risksOrderedByDigiriskElement = [];
+
+		// Entity management is disabled above when shared risks are requested, so $riskList holds the risks of every entity of the database
+		// Only the risks carried by a digirisk element visible from the current entity belong to this listing
+		$visibleDigiriskElements = is_array($objects) ? $objects : [];
+		if ($get_shared_data && is_array($activeDigiriskElements)) {
+			$visibleDigiriskElements += $activeDigiriskElements;
+		}
+
 		if (is_array($riskList) && !empty($riskList)) {
 			foreach ($riskList as $riskSingle) {
-				$riskSingle->lastEvaluation                               = $riskAssessmentsOrderedByRisk[$riskSingle->id];
-				$riskSingle->appliedOn                                    = $riskSingle->fk_element;
-				$risksOrderedByDigiriskElement[$riskSingle->fk_element][] = $riskSingle;
+				$riskSingle->lastEvaluation = $riskAssessmentsOrderedByRisk[$riskSingle->id] ?? null;
+				$riskSingle->appliedOn      = $riskSingle->fk_element;
+				if (isset($visibleDigiriskElements[$riskSingle->fk_element])) {
+					$risksOrderedByDigiriskElement[$riskSingle->fk_element][] = $riskSingle;
+				}
 			}
 		}
 		$risks = [];
@@ -403,12 +412,10 @@ class Risk extends SaturneObject
 				// RISKS parent children.
 				if ( !empty($children_ids)) {
 					foreach ($children_ids as $child_id) {
-						if (is_array($risksOrderedByDigiriskElement[$child_id]) && !empty($risksOrderedByDigiriskElement[$child_id])) {
-                            foreach ($risksOrderedByDigiriskElement[$child_id] as $riskOfChildDigiriskElement) {
-                                if ($riskOfChildDigiriskElement->entity == $conf->entity) {
-                                    $risks[] = $riskOfChildDigiriskElement;
-                                }
-                            }
+						// The entity scope is already applied when $risksOrderedByDigiriskElement is built
+						// Filtering again on $risk->entity dropped every children risk on a mono entity install, where the entity field is unset from $fields
+						if (!empty($risksOrderedByDigiriskElement[$child_id]) && is_array($risksOrderedByDigiriskElement[$child_id])) {
+							$risks = array_merge($risks, $risksOrderedByDigiriskElement[$child_id]);
 						}
 					}
 				}

--- a/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/riskassessmentdocument/doc_riskassessmentdocument_odt.modules.php
+++ b/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/riskassessmentdocument/doc_riskassessmentdocument_odt.modules.php
@@ -589,6 +589,32 @@ class doc_riskassessmentdocument_odt extends ModeleODTDigiriskDolibarrDocument
     }
 
     /**
+     * Keep the shared digirisk elements carrying a risk shared with the current entity, and their parents
+     *
+     * @param  array $sharedDigiriskElements Flat shared digirisk elements (element ID => ['object' => DigiriskElement, 'depth' => int])
+     * @param  array $sharedRisks            Risks of the other entities linked to a digirisk element of the current entity
+     * @return array                         Filtered flat digirisk elements, in their original order
+     */
+    private static function filterSharedDigiriskElements(array $sharedDigiriskElements, array $sharedRisks): array
+    {
+        if (empty($sharedDigiriskElements) || empty($sharedRisks)) {
+            return [];
+        }
+
+        $sharedDigiriskElementIDs = [];
+        foreach ($sharedRisks as $sharedRisk) {
+            // Parents are kept too, otherwise the shared organisation is printed with holes in its tree
+            $digiriskElementID = $sharedRisk->fk_element;
+            while ($digiriskElementID > 0 && isset($sharedDigiriskElements[$digiriskElementID]) && !isset($sharedDigiriskElementIDs[$digiriskElementID])) {
+                $sharedDigiriskElementIDs[$digiriskElementID] = $digiriskElementID;
+                $digiriskElementID                            = $sharedDigiriskElements[$digiriskElementID]['object']->fk_parent;
+            }
+        }
+
+        return array_intersect_key($sharedDigiriskElements, $sharedDigiriskElementIDs);
+    }
+
+    /**
      * Fill all odt tags for segments lines
      *
      * @param  Odf       $odfHandler  Object builder odf library
@@ -615,9 +641,10 @@ class doc_riskassessmentdocument_odt extends ModeleODTDigiriskDolibarrDocument
             $moreParam['digiriskElements'] = $loadDigiriskElementInfos[$moreParam['entity']]['digiriskElements'];
             static::setRiskAssessmentDocumentByEntity($odfHandler, $outputLangs, $moreParam, $loadRiskAssessmentDocumentInfos);
 
-            if ($moreParam['tmparray']['showSharedRisk_nocheck']) {
+            if (!empty($moreParam['tmparray']['showSharedRisk_nocheck'])) {
                 $moreParam['entity']           = 'shared';
-                $moreParam['digiriskElements'] = $loadDigiriskElementInfos[$moreParam['entity']]['digiriskElements'];
+                // Sharing digirisk elements between entities makes every element of the other entities visible, only those carrying a shared risk belong to this document
+                $moreParam['digiriskElements'] = static::filterSharedDigiriskElements($loadDigiriskElementInfos[$moreParam['entity']]['digiriskElements'], $loadRiskAssessmentDocumentInfos[$moreParam['entity']]['risks']);
                 static::setRiskAssessmentDocumentByEntity($odfHandler, $outputLangs, $moreParam, $loadRiskAssessmentDocumentInfos);
             }
 

--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_sharedrisklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_sharedrisklist_view.tpl.php
@@ -101,6 +101,8 @@ if ( ! preg_match('/(evaluation)/', $sortfield)) {
 	$sql                                                                                                                                          .= " LEFT JOIN " . MAIN_DB_PREFIX . $digiriskelement->table_element . " as e on (r.fk_element = e.rowid)";
 	$sql                                                                                                                                          .= " INNER JOIN " . MAIN_DB_PREFIX . 'element_element' . " as el on (r.rowid = el.fk_source)";
 	if (is_array($extrafields->attributes[$risk->table_element]['label']) && count($extrafields->attributes[$risk->table_element]['label'])) $sql .= " LEFT JOIN " . MAIN_DB_PREFIX . $risk->table_element . "_extrafields as ef on (r.rowid = ef.fk_object)";
+	// Every filter below is appended with AND: without this WHERE they would be attached to the extrafields LEFT JOIN ON clause and stop filtering anything
+	$sql .= " WHERE 1 = 1";
 
 	if ( ! $allRisks) {
 		$sql .= " AND el.fk_target = " . $id;
@@ -215,8 +217,9 @@ if ( ! preg_match('/(evaluation)/', $sortfield)) {
 	$sql 																																					  .= " LEFT JOIN " . MAIN_DB_PREFIX . $digiriskelement->table_element . " as e on (r.fk_element = e.rowid)";
 	if (isset($extrafields->attributes[$evaluation->table_element]) &&
         is_array($extrafields->attributes[$evaluation->table_element]['label']) && count($extrafields->attributes[$evaluation->table_element]['label'])) $sql .= " LEFT JOIN " . MAIN_DB_PREFIX . $evaluation->table_element . "_extrafields as ef on (evaluation.rowid = ef.fk_object)";
-	//if ($evaluation->ismultientitymanaged == 1) $sql                                                                                                          .= " WHERE evaluation.entity IN (" . getEntity($evaluation->element) . ")";
-	else $sql                                                                                                                                                 .= " WHERE 1 = 1";
+	// The entity filter cannot apply here: risk assessments of shared risks belong to the entity that owns them
+	// Every filter below is appended with AND: without this WHERE they would be attached to the extrafields LEFT JOIN ON clause and stop filtering anything
+	$sql .= " WHERE 1 = 1";
 	$sql                                                                                                                                                      .= " AND evaluation.status = 1";
 
 	if ( ! $allRisks) {

--- a/core/tpl/riskanalysis/risksign/digiriskdolibarr_sharedrisksignlist_view.tpl.php
+++ b/core/tpl/riskanalysis/risksign/digiriskdolibarr_sharedrisksignlist_view.tpl.php
@@ -74,9 +74,8 @@ $sql                                                                            
 $sql                                                                                                                                          		  .= " LEFT JOIN " . MAIN_DB_PREFIX . $digiriskelement->table_element . " as e on (t.fk_element = e.rowid)";
 $sql                                                                                                                                         		  .= " INNER JOIN " . MAIN_DB_PREFIX . 'element_element' . " as el on (t.rowid = el.fk_source)";
 if (is_array($extrafields->attributes[$risksign->table_element]['label'] ?? null) && count($extrafields->attributes[$risksign->table_element]['label'])) $sql .= " LEFT JOIN " . MAIN_DB_PREFIX . $risksign->table_element . "_extrafields as ef on (t.rowid = ef.fk_object)";
-//if ($risksign->ismultientitymanaged == 1) $sql                                                                                                        .= " WHERE t.entity IN (" . getEntity($risksign->element) . ")";
-//else $sql                                                                                                                                             .= " WHERE 1 = 1";
-//$sql                                                                                                                                                  .= " AND fk_element = " . $id;
+// Every filter below is appended with AND: without this WHERE they would be attached to the extrafields LEFT JOIN ON clause and stop filtering anything
+$sql .= " WHERE 1 = 1";
 if ( ! $allRisks) {
 	$sql .= " AND el.fk_target = " . $id;
 	$sql .= " AND el.sourcetype = 'digiriskdolibarr_risksign'";


### PR DESCRIPTION
Corrige les fuites de données entre entités et les gardes inopérantes repérées en analysant #4174.

## 1. Filtres SQL perdus sur les listes partagées — #5057

`digiriskdolibarr_sharedrisksignlist_view.tpl.php` et `digiriskdolibarr_sharedrisklist_view.tpl.php` construisaient leur requête **sans `WHERE`** : tous les filtres (`el.fk_target`, `el.sourcetype`, `t.entity`, filtres de recherche) étaient concaténés juste après un `LEFT JOIN ..._extrafields` ajouté conditionnellement. Dès qu'un module déclare un extrafield sur l'objet — **DigiQuali** (`qc_frequency`) et **EasyURL** (`easy_url_all_link`) le font sur `digiriskdolibarr_risksign` — les `AND` atterrissaient dans le `ON` du LEFT JOIN et ne filtraient plus rien.

Mesuré sur une base multi-entités (entité courante 2, élément 19, `getEntity('risksign') = 1,2`) :

| Variante | Lignes |
|---|---|
| Requête actuelle | **101** signalisations, **6 entités** |
| Avec un vrai `WHERE` | **0** |

La liste des risques partagés a la même structure ; elle n'est aujourd'hui sauvée que parce que le template réinstancie `$extrafields` et ne charge que ceux des tâches. Les deux sont corrigées.

## 2. Risques des sous-éléments écartés — #5061

`SaturneObject::__construct()` désactive le champ `entity` quand multicompany n'est pas activé, donc `fetchAll()` renvoie `entity = null`. La garde ajoutée en 21.0.0 par #4138 (`$risk->entity == $conf->entity`, soit `null == 1` → faux en PHP 8) écartait **tous** les risques enfants sur une instance mono-entité.

Base locale, 61 risques validés :

| Appel | Avant | Après |
|---|---|---|
| `fetchRisksOrderedByCotation(0, true, false, false)` | `-1` | 61 risques |
| `fetchRisksOrderedByCotation(1, true, true, false)` | 6 lignes | 53 lignes |

Le périmètre entité est maintenant appliqué une seule fois, à l'indexation par élément : seuls les risques portés par un élément visible depuis l'entité courante sont retenus. Cela couvre aussi la raison d'être de la garde de #4138 — `$riskList` est chargé sans gestion d'entité quand les risques partagés sont demandés, donc avec les risques de **toutes** les entités de la base, y compris celles qui ne sont pas partagées.

## 3. Section partagée du DUER — #5058

Le partage des éléments rend visibles tous les GP/UT des autres entités : la section partagée du DUER les listait tous, alors que les tableaux de risques de la même section sont filtrés sur les liens `element_element`. Seuls les éléments portant un risque effectivement partagé, et leurs parents, sont conservés.

**Changement visible dans le document généré** : les GP/UT partagés sans risque importé disparaissent des segments `sharedDigiriskElements` et `sharedRiskByRiskAssessmentCotations`.

## Robustesse

- `loadRiskInfos()` testait `showSharedRisk_nocheck` avec `=== true` d'un côté et `empty()` de l'autre : avec une valeur vraie non booléenne, `$array['shared']` restait indéfini et `array_merge()` était fatal en PHP 8.
- `loadDigiriskElementInfos()` accédait à `$moreParam['tmparray']` sans garde, alors que `doc_auditreportdocument_odt` appelle la méthode avant de le renseigner.
- Warnings « Undefined array key » supprimés sur `$riskAssessmentsOrderedByRisk` et `$risksOrderedByDigiriskElement`.

## Tests

- Rejeu SQL des requêtes partagées sur une base multi-entités réelle (17 entités, partage digiriskelement/risk/risksign activé) : 101 → 0 lignes pour les signalisations, et la requête du DUER ne renvoie bien que les 2 risques réellement importés dans l'entité 2.
- `filterSharedDigiriskElements()` : 6 cas couverts (branche simple, deux branches, risque sur la racine, aucun risque partagé, risque hors liste, aucun élément partagé) — tous verts.
- `fetchRisksOrderedByCotation()` et `loadRiskInfos()` / `loadDigiriskElementInfos()` rejoués sur la base locale mono-entité : plus aucun warning, `tmparray` absent, `false`, `true` et `1` donnent le résultat attendu.
- `php -l` sur les 5 fichiers.

Non testé : la génération complète d'un DUER sur une instance multicompany, faute d'environnement multi-entités exécutable en local.

Closes #5057
Closes #5058
Closes #5061

🤖 Generated with [Claude Code](https://claude.com/claude-code)
