### PR TITLE
#5059 [Risk] fix: libellés bruts sur les listes de risques d'un type personnalisé

### DIFF
--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_inheritedrisklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_inheritedrisklist_view.tpl.php
@@ -299,7 +299,7 @@
 	$arrayofmassactions = [];
     $massactionbutton   = $form->selectMassAction('', $arrayofmassactions);
 
-	$title = $langs->trans('DigiriskElementInherited' . ucfirst($riskType) . 'sList');
+	$title = digirisk_trans_risk_type('DigiriskElementInherited', $riskType, 'sList');
 	print_barre_liste($title, $page, $_SERVER["PHP_SELF"], $param, $sortfield, $sortorder, $massactionbutton, $num, $nbtotalofrecords, 'digiriskdolibarr_color.png@digiriskdolibarr', 0, '', '', $limit, 0, 0, 1);
 
 	include DOL_DOCUMENT_ROOT . '/core/tpl/massactions_pre.tpl.php';

--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
@@ -598,7 +598,7 @@ $massactionbutton = $form->selectMassAction('', $arrayofmassactions);
 
         // Bouton importer des risques partagés : icône seule + texte en tooltip, à côté des boutons d'ajout (id conservé pour déclencher la popup de confirmation)
         if (!empty($conf->global->DIGIRISKDOLIBARR_SHOW_SHARED_RISKS)) {
-            $newcardbutton .= '<div class="import-shared-risks wpeo-button button-square-40 button-secondary wpeo-tooltip-event" id="actionButtonImportSharedRisks" style="margin-left: 10px;" aria-label="' . $langs->trans('ImportShared' . ucfirst($riskType) . 's') . '" value="' . $object->id . '">';
+            $newcardbutton .= '<div class="import-shared-risks wpeo-button button-square-40 button-secondary wpeo-tooltip-event" id="actionButtonImportSharedRisks" style="margin-left: 10px;" aria-label="' . digirisk_trans_risk_type('ImportShared', $riskType, 's') . '" value="' . $object->id . '">';
             $newcardbutton .= '<i class="fas fa-file-import button-icon"></i>';
             $newcardbutton .= '</div>';
         }
@@ -614,7 +614,7 @@ $massactionbutton = $form->selectMassAction('', $arrayofmassactions);
             <div class="modal-container wpeo-modal-event">
                 <!-- Modal-Header -->
                 <div class="modal-header" style="align-items: center; display: flex;">
-                    <h2 class="modal-title" style="flex: 1;"><?php print $langs->trans('Add' . ucfirst($riskType) . 'Title') . ' ' . $refRiskMod->getNextValue($risk); ?></h2>
+                    <h2 class="modal-title" style="flex: 1;"><?php print digirisk_trans_risk_type('Add', $riskType, 'Title') . ' ' . $refRiskMod->getNextValue($risk); ?></h2>
                     <?php if ($permissiontoadd) : ?>
                         <div class="risk-create wpeo-button button-primary button-disable modal-close" style="margin-right: 15px; margin-bottom: 0;">
                             <span><i class="fas fa-plus"></i>  <?php echo $langs->trans('AddRiskButton'); ?></span>
@@ -854,7 +854,7 @@ $massactionbutton = $form->selectMassAction('', $arrayofmassactions);
     </div>
 <?php endif; ?>
     <input type="hidden" id="dol_url_root" value="<?php echo DOL_URL_ROOT; ?>">
-<?php $title = $langs->trans('DigiriskElement' . ucfirst($riskType) . 'sList');
+<?php $title = digirisk_trans_risk_type('DigiriskElement', $riskType, 'sList');
 print '<div class="div-title-and-table-responsive">';
 print_barre_liste($title, $page, $_SERVER["PHP_SELF"], $param, $sortfield, $sortorder, $massactionbutton, $num, $nbtotalofrecords, $risk->picto, 0, $newcardbutton ?? '', '', $limit, 0, 0, 1);
 

--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_sharedrisklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_sharedrisklist_view.tpl.php
@@ -330,7 +330,7 @@ include DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_list_search_param.tpl.php';
 $arrayofmassactions = [];
 $massactionbutton   = $form->selectMassAction('', $arrayofmassactions);
 
-$title = $langs->trans('DigiriskElementShared' . ucfirst($riskType) . 'sList');
+$title = digirisk_trans_risk_type('DigiriskElementShared', $riskType, 'sList');
 print_barre_liste($title, $page, $_SERVER["PHP_SELF"], $param, $sortfield, $sortorder, $massactionbutton, $num, $nbtotalofrecords, 'digiriskdolibarr_color.png@digiriskdolibarr', 0, '', '', $limit, 0, 0, 1);
 
 include DOL_DOCUMENT_ROOT . '/core/tpl/massactions_pre.tpl.php';

--- a/lib/digiriskdolibarr_function.lib.php
+++ b/lib/digiriskdolibarr_function.lib.php
@@ -326,6 +326,30 @@ function flatten_tree($tree)
 }
 
 /**
+ * Translate a label built from a risk type, falling back on the generic risk label
+ *
+ * Risk types other than risk and riskenvironmental are brought by other modules and have no
+ * translation of their own here, the derived key would be printed raw
+ *
+ * @param  string $keyPrefix Key part before the risk type (DigiriskElementShared, ImportShared, Add, ...)
+ * @param  string $riskType  Risk type (risk, riskenvironmental or a type brought by another module)
+ * @param  string $keySuffix Key part after the risk type (sList, s, Title, ...)
+ * @return string            Translated label
+ */
+function digirisk_trans_risk_type(string $keyPrefix, string $riskType, string $keySuffix = ''): string
+{
+    global $langs;
+
+    $key   = $keyPrefix . ucfirst($riskType) . $keySuffix;
+    $label = $langs->trans($key);
+    if ($label != $key) {
+        return $label;
+    }
+
+    return $langs->trans($keyPrefix . 'Risk' . $keySuffix);
+}
+
+/**
  * Render the label of a GP/UT tree row, inline-editable when the user can write.
  *
  * Relies on the generic Saturne contentEditable mechanism (js/modules/contentEditable.js +

--- a/view/digiriskelement/digiriskelement_risk.php
+++ b/view/digiriskelement/digiriskelement_risk.php
@@ -232,7 +232,7 @@ if (empty($reshook)) {
  */
 
 $form    = new Form($db);
-$title   = $langs->trans(ucfirst($riskType) . 's');
+$title   = digirisk_trans_risk_type('', $riskType, 's');
 $helpUrl = 'FR:Module_Digirisk#.C3.89valuation_des_Risques';
 
 // classforhorizontalscrolloftabs constrains #id-right width so the wide risk list table
@@ -258,7 +258,7 @@ if ($sharedrisks) {
 
 		$allrisks = $risk->fetchAll('ASC', 'fk_element', 0, 0, array('customsql' => 'status > 0 AND type = "' . $riskType . '" AND entity NOT IN (' . $conf->entity . ') AND fk_element > 0'));
 		$formquestionimportsharedrisks = array(
-			'text' => '<i class="fas fa-circle-info"></i>' . $langs->trans('ConfirmImportShared' . ucfirst($riskType) . 's'),
+			'text' => '<i class="fas fa-circle-info"></i>' . digirisk_trans_risk_type('ConfirmImportShared', $riskType, 's'),
 		);
 
         $evaluation->ismultientitymanaged = 0;
@@ -358,7 +358,7 @@ if ($sharedrisks) {
 			}
 
 		}
-		$formconfirm .= digiriskformconfirm($_SERVER["PHP_SELF"] . '?id=' . $object->id . '&risk_type=' . $riskType, $langs->trans('ImportShared' . ucfirst($riskType) . 's'), '', 'confirm_import_shared_risks', $formquestionimportsharedrisks, 'yes', 'actionButtonImportSharedRisks', 800, 800);
+		$formconfirm .= digiriskformconfirm($_SERVER["PHP_SELF"] . '?id=' . $object->id . '&risk_type=' . $riskType, digirisk_trans_risk_type('ImportShared', $riskType, 's'), '', 'confirm_import_shared_risks', $formquestionimportsharedrisks, 'yes', 'actionButtonImportSharedRisks', 800, 800);
 	}
 
 	// Call Hook formConfirm

--- a/view/digiriskelement/risk_list.php
+++ b/view/digiriskelement/risk_list.php
@@ -242,7 +242,7 @@ if (empty($reshook)) {
 
 $form = new Form($db);
 
-$title    = $langs->trans(ucfirst($riskType) . 's');
+$title    = digirisk_trans_risk_type('', $riskType, 's');
 $helpUrl = 'FR:Module_Digirisk#.C3.89valuation_des_Risques';
 
 if (empty($noheader)) saturne_header(1,'', $title, $helpUrl);


### PR DESCRIPTION
Les titres et boutons des listes de risques sont construits dynamiquement à partir du type de risque : `DigiriskElement{Type}sList`, `DigiriskElementShared{Type}sList`, `DigiriskElementInherited{Type}sList`, `ImportShared{Type}s`, `ConfirmImportShared{Type}s`, `Add{Type}Title`, `{Type}s`.

Seuls `risk` et `riskenvironmental` ont leurs clés dans les fichiers de langue. Un type apporté par un autre module affiche donc la clé brute, comme sur la capture de #4174 : `DigiriskElementStandardsList`, `DigiriskElementSharedStandardsList`, `IMPORTSHAREDSTANDARDS`.

`digirisk_trans_risk_type($keyPrefix, $riskType, $keySuffix)` compose la clé, et bascule sur le libellé générique du risque quand elle n'est pas traduite. Les 9 appels concernés passent par le helper.

## Tests

| Appel | Résultat |
|---|---|
| `('DigiriskElementShared', 'risk', 'sList')` | Liste des risques partagés |
| `('DigiriskElementShared', 'riskenvironmental', 'sList')` | Liste des risques partagés environnementaux |
| `('DigiriskElementShared', 'standard', 'sList')` | Liste des risques partagés |
| `('ImportShared', 'standard', 's')` | Importer des risques partagés |
| `('DigiriskElementInherited', 'standard', 'sList')` | Liste des risques hérités |
| `('Add', 'standard', 'Title')` | Ajout du risque |
| `('', 'risk', 's')` / `('', 'standard', 's')` | Risques |

`php -l` sur les 6 fichiers.

Closes #5059

🤖 Generated with [Claude Code](https://claude.com/claude-code)
