### PR TITLE
#5065 [ProjectDocument] feat: modèle du PAPRIPACT choisi via la config des documents

### DIFF
--- a/class/actions_digiriskdolibarr.class.php
+++ b/class/actions_digiriskdolibarr.class.php
@@ -777,7 +777,8 @@ class ActionsDigiriskdolibarr
 
             require __DIR__ . '/../../saturne/core/tpl/documents/documents_action.tpl.php';
         } else if (strpos($parameters['context'], 'projectcard') !== false) {
-            if ($action == 'builddoc' && GETPOST('model') == 'papripact_a3_paysage_projectdocument') {
+            // The model is the one set as default on the documents configuration page, PAPRIPACT when none is
+            if ($action == 'builddoc' && GETPOST('model') == getDolGlobalString('DIGIRISKDOLIBARR_PROJECTDOCUMENT_DEFAULT_MODEL', 'papripact_a3_paysage_projectdocument')) {
                 require_once __DIR__ . '/digiriskdolibarrdocuments/projectdocument.class.php';
 
                 $document = new ProjectDocument($this->db);

--- a/core/modules/modDigiriskDolibarr.class.php
+++ b/core/modules/modDigiriskDolibarr.class.php
@@ -860,6 +860,7 @@ class modDigiriskdolibarr extends DolibarrModules
 
 			// CONST PROJECT DOCUMENT
 			$i++ => ['DIGIRISKDOLIBARR_PROJECTDOCUMENT_ADDON', 'chaine', 'mod_projectdocument_standard', '', 0, 'current'],
+			$i++ => ['DIGIRISKDOLIBARR_PROJECTDOCUMENT_DEFAULT_MODEL', 'chaine', 'papripact_a3_paysage_projectdocument', '', 0, 'current'],
 			$i++ => ['DIGIRISKDOLIBARR_PROJECTDOCUMENT_DISPLAY_RISKASSESSMENT_COLOR', 'integer', 1, '', 0, 'current'],
 
 			// GENERAL CONSTS

--- a/core/tpl/actionplan/actionplan_export_buttons.tpl.php
+++ b/core/tpl/actionplan/actionplan_export_buttons.tpl.php
@@ -48,7 +48,7 @@ $exportAction = $_SERVER['PHP_SELF'] . '?view=' . urlencode($view);
         <form method="POST" action="<?php echo $exportAction; ?>" class="ap-export-form">
             <input type="hidden" name="token" value="<?php echo newToken(); ?>">
             <input type="hidden" name="action" value="builddoc">
-            <input type="hidden" name="model" value="papripact_a3_paysage_projectdocument">
+            <input type="hidden" name="model" value="<?php echo dol_escape_htmltag(getDolGlobalString('DIGIRISKDOLIBARR_PROJECTDOCUMENT_DEFAULT_MODEL', 'papripact_a3_paysage_projectdocument')); ?>">
             <?php echo digiriskActionPlanFilterHiddenInputs($actionPlanFilters); ?>
             <button type="submit" class="ap-export-btn" title="<?php echo dol_escape_htmltag($langs->trans('ActionPlanExportA3')); ?>">
                 <i class="fas fa-download"></i>

--- a/view/digiriskstandard/actionplan_list.php
+++ b/view/digiriskstandard/actionplan_list.php
@@ -535,7 +535,8 @@ if ($action == 'removeTaskCategory' && !empty(GETPOSTINT('task_id'))) {
 }
 
 // Action to generate and download the PAPRIPACT in A3 landscape format
-if ($action == 'builddoc' && GETPOST('model', 'alpha') == 'papripact_a3_paysage_projectdocument' && $user->hasRight('projet', 'creer')) {
+// The model is the one set as default on the documents configuration page, PAPRIPACT when none is
+if ($action == 'builddoc' && GETPOST('model', 'alpha') == getDolGlobalString('DIGIRISKDOLIBARR_PROJECTDOCUMENT_DEFAULT_MODEL', 'papripact_a3_paysage_projectdocument') && $user->hasRight('projet', 'creer')) {
     require_once DOL_DOCUMENT_ROOT . '/projet/class/project.class.php';
     require_once __DIR__ . '/../../class/digiriskdolibarrdocuments/projectdocument.class.php';
 


### PR DESCRIPTION
Closes #5065

## Problème

L'étoile « Défaut » du bloc **Projet**, sur la page de configuration des documents, écrit bien `DIGIRISKDOLIBARR_PROJECTDOCUMENT_DEFAULT_MODEL` (action `setdoc` de la page générique Saturne), mais personne ne lisait cette constante : les trois points d'entrée du document projet comparaient le modèle demandé à `papripact_a3_paysage_projectdocument` écrit en dur. Un modèle personnalisé mis par défaut n'était donc jamais utilisé.

## Correction

Les trois points d'entrée lisent la constante, avec le PAPRIPACT A3 en valeur de repli :

| Fichier | Rôle |
|---|---|
| `core/tpl/actionplan/actionplan_export_buttons.tpl.php` | champ caché `model` du formulaire d'export (échappé avec `dol_escape_htmltag`) |
| `view/digiriskstandard/actionplan_list.php` | traitement de l'action `builddoc` de la liste |
| `class/actions_digiriskdolibarr.class.php` | hook `builddoc` de la fiche projet |

La constante est ajoutée aux `const` du descripteur de module pour les nouvelles activations. Le repli de `getDolGlobalString()` couvre les installations existantes : aucun script de mise à jour n'est nécessaire, et le comportement par défaut est strictement inchangé.

Les `addDocumentModel()` / `delDocumentModel()` du descripteur gardent le nom en dur : ils enregistrent le modèle, ils ne le sélectionnent pas.

## Tests

`php -l` sur les 4 fichiers modifiés, puis scénario joué au navigateur (Playwright) sur une instance locale, plan d'action en vue Kanban :

1. constante à `papripact_a3_paysage_projectdocument` → le champ caché `model` du bouton A3 porte cette valeur ;
2. constante forcée à une valeur factice → le champ caché suit la constante, ce qui prouve que la valeur n'est plus en dur ;
3. retour à la valeur réelle, clic sur le bouton A3 → PAPRIPACT généré et téléchargé (PDF de 258 Ko), aucune erreur JS en console.

Le hook de la fiche projet n'a pas été rejoué au navigateur : la modification y est identique aux deux autres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
