### PR TITLE
#3702 [RiskAssessmentDocument] fix: vrais messages d'erreur lors de la génération de l'archive ZIP

### DIFF
--- a/class/digiriskdolibarrdocuments/riskassessmentdocument.class.php
+++ b/class/digiriskdolibarrdocuments/riskassessmentdocument.class.php
@@ -107,9 +107,20 @@ class RiskAssessmentDocument extends DigiriskDocuments
 		return $jsonFormatted;
 	}
 
+    /**
+     * Generate a ZIP archive with the risk assessment document and all the groupment/workunit documents
+     *
+     * @param  array     $moreparams  More parameters (digiriskElement, uploadDir, user)
+     * @param  Translate $outputLangs Lang object to use for output
+     * @param  int       $hideDetails Do not show line details
+     * @param  int       $hideDesc    Do not show desc
+     * @param  int       $hideRef     Do not show ref
+     * @return int                    0 if archive generation is disabled, 1 if OK, -1 if KO
+     * @throws Exception
+     */
     public function generateArchiveWithDigiriskElementDocuments($moreparams, $outputLangs, $hideDetails, $hideDesc, $hideRef)
     {
-        global $user;
+        global $langs, $user;
 
         if (!getDolGlobalInt('DIGIRISKDOLIBARR_GENERATE_ARCHIVE_WITH_DIGIRISKELEMENT_DOCUMENTS')) {
             return 0;
@@ -117,7 +128,7 @@ class RiskAssessmentDocument extends DigiriskDocuments
 
         $digiriskElements = $moreparams['digiriskElement']->fetchDigiriskElementFlat(0);
         if (!is_array($digiriskElements) || empty($digiriskElements)) {
-            $this->error = 'error1';
+            $this->error = $langs->trans('ErrorFailToFetchDigiriskElements');
             return -1;
         }
 
@@ -127,31 +138,32 @@ class RiskAssessmentDocument extends DigiriskDocuments
         $zipPath  = $uploadDir . '/' . $fileName;
         $result   = dol_mkdir($zipPath);
         if ($result < 0) {
-            $this->error = 'error2';
+            $this->error = $langs->trans('ErrorCanNotCreateDir', $zipPath);
             return -1;
         }
 
         $result = dol_copy($uploadDir . '/' . $this->last_main_doc, $zipPath . '/' . $this->last_main_doc);
         if ($result < 0) {
-            $this->error = 'error3';
+            $this->error = $langs->trans('ErrorFailToCopyFile', $uploadDir . '/' . $this->last_main_doc, $zipPath . '/' . $this->last_main_doc);
             return -1;
         }
 
         if (file_exists($uploadDir . '/' . $fileName . '.pdf')) {
             $result = dol_copy($uploadDir . '/' . $fileName . '.pdf', $zipPath . '/' . $fileName . '.pdf');
             if ($result < 0) {
-                $this->error = 'error3';
+                $this->error = $langs->trans('ErrorFailToCopyFile', $uploadDir . '/' . $fileName . '.pdf', $zipPath . '/' . $fileName . '.pdf');
                 return -1;
             }
         }
 
-        $digiriskElementObjects = ['groupment', 'workunit'];
+        $digiriskElementObjects        = ['groupment', 'workunit'];
+        $digiriskElementDocumentLabels = ['groupment' => 'GroupmentDocument', 'workunit' => 'WorkUnitDocument'];
         foreach ($digiriskElementObjects as $digiriskElementObject) {
             $digiriskElementDocumentPaths[$digiriskElementObject] = $moreparams['uploadDir'] . '/' . $digiriskElementObject . 'document';
 
             $modelLists[$digiriskElementObject] = saturne_get_list_of_models($this->db, $digiriskElementObject . 'document');
             if (!is_array($modelLists[$digiriskElementObject]) || empty($modelLists[$digiriskElementObject])) {
-                $this->error = 'error4';
+                $this->error = $langs->trans('ErrorNoDocumentModelFound', $langs->transnoentities($digiriskElementDocumentLabels[$digiriskElementObject]));
                 return -1;
             }
 
@@ -171,7 +183,7 @@ class RiskAssessmentDocument extends DigiriskDocuments
             $digiriskElementDocumentZipPaths[$digiriskElementObject] = $zipPath . '/' . $digiriskElementObject . 'document';
             $result                                                  = dol_mkdir($digiriskElementDocumentZipPaths[$digiriskElementObject]);
             if ($result < 0) {
-                $this->error = 'error2';
+                $this->error = $langs->trans('ErrorCanNotCreateDir', $digiriskElementDocumentZipPaths[$digiriskElementObject]);
                 return -1;
             }
         }
@@ -187,14 +199,16 @@ class RiskAssessmentDocument extends DigiriskDocuments
 
             $result = $digiriskElementDocument->generateDocument($model[$digiriskElementSingle['object']->element_type], $outputLangs, $hideDetails, $hideDesc, $hideRef, $moreParams);
             if ($result < 0) {
-                $this->error = 'error5';
+                // Only the document object knows the underlying cause (numbering conflict, missing ODT template, ...)
+                $this->error  = $langs->trans('ErrorFailToGenerateDigiriskElementDocument', $digiriskElementSingle['object']->ref . ' - ' . $digiriskElementSingle['object']->label);
+                $this->errors = array_filter(array_merge([$digiriskElementDocument->error], (array) $digiriskElementDocument->errors));
                 return -1;
             }
 
             $digiriskElementDocumentPath = $digiriskElementDocumentPaths[$digiriskElementSingle['object']->element_type] . '/' . $digiriskElementSingle['object']->ref;
             $result                      = dol_copy($digiriskElementDocumentPath . '/' . $digiriskElementDocument->last_main_doc, $digiriskElementDocumentZipPaths[$digiriskElementSingle['object']->element_type] . '/' . $digiriskElementDocument->last_main_doc);
             if ($result < 0) {
-                $this->error = 'error3';
+                $this->error = $langs->trans('ErrorFailToCopyFile', $digiriskElementDocumentPath . '/' . $digiriskElementDocument->last_main_doc, $digiriskElementDocumentZipPaths[$digiriskElementSingle['object']->element_type] . '/' . $digiriskElementDocument->last_main_doc);
                 return -1;
             }
 
@@ -202,7 +216,7 @@ class RiskAssessmentDocument extends DigiriskDocuments
             if (file_exists($digiriskElementDocumentPath . '/' . $fileName . '.pdf')) {
                 $result = dol_copy($digiriskElementDocumentPath . '/' . $fileName . '.pdf', $digiriskElementDocumentZipPaths[$digiriskElementSingle['object']->element_type] . '/' . $fileName . '.pdf');
                 if ($result < 0) {
-                    $this->error = 'error3';
+                    $this->error = $langs->trans('ErrorFailToCopyFile', $digiriskElementDocumentPath . '/' . $fileName . '.pdf', $digiriskElementDocumentZipPaths[$digiriskElementSingle['object']->element_type] . '/' . $fileName . '.pdf');
                     return -1;
                 }
             }

--- a/langs/en_US/digiriskdolibarr.lang
+++ b/langs/en_US/digiriskdolibarr.lang
@@ -458,3 +458,10 @@ MobilePPEmailTemplateInt = Email template for the exterior company attendants
 SelectAllSharedRisksOfElement              = Select all the risks of this element
 SelectAllSharedRiskenvironmentalsOfElement = Select all the environmental risks of this element
 SelectAllSharedRiskSignsOfElement          = Select all the signages of this element
+
+# Risk assessment document archive errors - issue #3702
+GroupmentDocument                          = Groupment sheet
+WorkUnitDocument                           = Work unit sheet
+ErrorFailToFetchDigiriskElements           = Error: unable to fetch the groupments and work units to include in the ZIP archive
+ErrorNoDocumentModelFound                  = Error: no document model available for <b>%s</b>
+ErrorFailToGenerateDigiriskElementDocument = Error: generation of the <b>%s</b> document failed, it is missing from the ZIP archive

--- a/langs/fr_FR/digiriskdolibarr.lang
+++ b/langs/fr_FR/digiriskdolibarr.lang
@@ -810,6 +810,9 @@ RiskAssessmentDocumentImportantNote                       = Notes importantes :<
 GenerateZipArchiveWithDigiriskElementDocuments            = Génération d'une archive ZIP avec le Document Unique
 GenerateZipArchiveWithDigiriskElementDocumentsDescription = Génération automatique d'une archive ZIP contenant le Document Unique et toutes les fiches de poste lors de la génération du Document Unique
 RiskAssessmentDocumentDescription                         = Plan d'action Document Unique
+ErrorFailToFetchDigiriskElements                          = Erreur : impossible de récupérer les groupements et unités de travail à inclure dans l'archive ZIP
+ErrorNoDocumentModelFound                                 = Erreur : aucun modèle de document disponible pour <b>%s</b>
+ErrorFailToGenerateDigiriskElementDocument                = Erreur : la génération du document de <b>%s</b> a échoué, il est absent de l'archive ZIP
 
 # Boxes - Widget
 NextGenerateDate  = Prochain génération


### PR DESCRIPTION
Closes #3702

## Problème

`RiskAssessmentDocument::generateArchiveWithDigiriskElementDocuments()` remontait les codes bruts `error1` à `error5`, affichés tels quels par `setEventMessages()` : l'utilisateur voyait « error5 » sans savoir quel document avait échoué ni pourquoi. C'est la deuxième partie de #3702 (« message d'erreur lors de la génération DUERP pour prévenir que les autres documents n'ont pas pu être regénérés »).

La cause d'origine du bug — le compteur des modèles de numérotation custom qui bouclait dès la 10e référence et renvoyait une référence déjà utilisée — est corrigée dans Evarisk/Saturne#1553.

## Correctif

| avant | après (fr_FR) |
|---|---|
| `error1` | Erreur : impossible de récupérer les groupements et unités de travail à inclure dans l'archive ZIP |
| `error2` | Impossible de créer le répertoire `%s` |
| `error3` | Échec de la copie du fichier '**%s**' en '**%s**' |
| `error4` | Erreur : aucun modèle de document disponible pour **%s** |
| `error5` | Erreur : la génération du document de **%s** a échoué, il est absent de l'archive ZIP |

- `error2` et `error3` réutilisent les clés Dolibarr existantes `ErrorCanNotCreateDir` et `ErrorFailToCopyFile` — seules trois clés sont ajoutées au module.
- Pour `error5`, le message nomme l'élément concerné (ref + libellé) et l'erreur réelle du document (`ErrorCreateObject`, template ODT manquant, ...) est propagée dans `$this->errors`, donc affichée en second message.
- `GroupmentDocument` et `WorkUnitDocument` manquaient en `en_US` : sans elles le nouveau message anglais affichait la clé brute.
- Docblock ajouté sur la méthode, qui n'en avait pas.

## Tests

- Les cinq messages se résolvent correctement en `fr_FR` et en `en_US`, substitutions comprises
- Appel réel de la méthode avec une arborescence vide : retourne `-1` avec « Erreur : impossible de récupérer les groupements et unités de travail à inclure dans l'archive ZIP » au lieu de `error1`
- `php -l` OK ; plus aucun code d'erreur brut de ce type dans le module

🤖 Generated with [Claude Code](https://claude.com/claude-code)