### PR TITLE
#5073 [i18n] feat: restaure la configuration Transifex du module

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,8 @@
+[main]
+host = https://app.transifex.com
+
+[o:evarisk:p:digirisk:r:digiriskdolibarr]
+file_filter = langs/<lang>/digiriskdolibarr.lang
+source_file = langs/fr_FR/digiriskdolibarr.lang
+source_lang = fr_FR
+type = MOZILLAPROPERTIES


### PR DESCRIPTION
Concerne #5073 — laissée en **brouillon** tant que l'organisation Transifex n'est pas confirmée.

## Ce que fait cette PR

Elle restaure `.tx/config`, disparu du dépôt : plus rien ne relie aujourd'hui les fichiers de langue du module à un projet de traduction.

```ini
[o:evarisk:p:digirisk:r:digiriskdolibarr]
file_filter = langs/<lang>/digiriskdolibarr.lang
source_file = langs/fr_FR/digiriskdolibarr.lang
source_lang = fr_FR
type        = MOZILLAPROPERTIES
```

`source_lang` reste `fr_FR` : les libellés du module sont écrits en français, c'est bien la source. À noter que ReedCRM, lui, déclare `en_US` comme source — les deux modules ne se ressemblent pas sur ce point, et c'est normal.

## Pourquoi elle est en brouillon

**L'organisation est à confirmer.** Cette configuration, qui est celle utilisée historiquement par Digirisk, pointe sur `o:evarisk:p:digirisk`. Or le seul module Evarisk encore câblé à Transifex aujourd'hui, ReedCRM, utilise `o:eoxia-1`. Il faut quelqu'un ayant accès au compte Transifex pour dire lequel des deux est le bon, et si le projet `digirisk` existe encore.

Tant que ce point n'est pas tranché, fusionner ne ferait qu'ajouter un fichier de configuration pointant peut-être dans le vide.

## Ce que cette PR ne fait pas

Elle ne traduit rien. L'écart réel — 414 clés traduites sur 1864 — reste entier, et il ne se comble pas par un fichier de configuration. Le détail de l'analyse, notamment pourquoi l'export Transifex de 2025 qui traînait n'était pas exploitable, est dans #5073.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
