### PR TITLE
#5079 [Config] Jauge d'avancement invisible quand display_errors est actif

### DIFF
--- a/admin/securityconf.php
+++ b/admin/securityconf.php
@@ -149,7 +149,7 @@ foreach ($securityConsts as $securityConst) {
 	}
 }
 foreach ($securityResources as $securityResource) {
-	if ( ! empty($allLinks[$securityResource] && $allLinks[$securityResource]->id[0] > 0)) {
+	if (!empty($allLinks[$securityResource]->id[0])) {
 		$counter += 1;
 	}
 }

--- a/admin/socialconf.php
+++ b/admin/socialconf.php
@@ -131,7 +131,7 @@ foreach ($socialConsts as $socialConst) {
 	}
 }
 foreach ($socialResources as $socialResource) {
-	if ( ! empty($allLinks[$socialResource] && $allLinks[$socialResource]->id[0] > 0)) {
+	if (!empty($allLinks[$socialResource]->id[0])) {
 		$counter += 1;
 	}
 }

--- a/core/tpl/digiriskdolibarr_configuration_gauge_view.tpl.php
+++ b/core/tpl/digiriskdolibarr_configuration_gauge_view.tpl.php
@@ -1,3 +1,29 @@
+<?php
+/**
+ * \file    core/tpl/digiriskdolibarr_configuration_gauge_view.tpl.php
+ * \ingroup digiriskdolibarr
+ * \brief   Template page for the configuration advancement gauge
+ */
+
+/**
+ * The following vars must be defined:
+ * Variables : $counter, $maxnumber
+ * Optional  : $kCounter (gauge suffix), $morecssGauge, $move_title_gauge
+ */
+
+// Aucune page appelante ne fournit ces variables : sans valeur par defaut, PHP emet un warning
+// pour chacune et, display_errors actif, son HTML est ecrit dans le <script> ci-dessous, qui
+// devient invalide. La jauge n'est alors jamais dessinee
+$morecssGauge     = $morecssGauge ?? '';
+$move_title_gauge = $move_title_gauge ?? 0;
+
+// Le suffixe rend uniques l'identifiant du canevas et les const du script : deux jauges sur une
+// meme page redeclareraient les memes const et le script s'arreterait
+if (!isset($kCounter)) {
+    $GLOBALS['digiriskGaugeCounter'] = ($GLOBALS['digiriskGaugeCounter'] ?? 0) + 1;
+    $kCounter                        = $GLOBALS['digiriskGaugeCounter'];
+}
+?>
 <div class="chart-container <?php echo $morecssGauge ?>" style=" width:50px">
 	<div class="wpeo-gridlayout grid-2">
 		<canvas class="" id="advancementGauge<?php echo $kCounter?>" width="40" height="40" style="width:50px !important"></canvas>


### PR DESCRIPTION
Closes #5079

## Le problème

`core/tpl/digiriskdolibarr_configuration_gauge_view.tpl.php` lit `$kCounter`, `$morecssGauge` et `$move_title_gauge` : aucune de ses quatre pages appelantes ne définit `$kCounter`, et les deux pages de configuration n'en définissent aucune des trois.

`display_errors` actif, le HTML du warning est écrit **à l'intérieur** de la balise `<script>` de la jauge — celle-ci devient invalide (`Missing initializer in const declaration`) et la jauge n'est jamais dessinée.

## Le correctif

Les trois variables prennent leur valeur par défaut dans le gabarit lui-même, puisque c'est lui qui les consomme. `$kCounter` reçoit un numéro unique par jauge quand l'appelant n'en fournit pas : les identifiants du canevas et les `const` du script restent distincts, ce qui prévient le cas de deux jauges sur une même page.

Au passage, dans le même écran : le compteur de progression de `admin/securityconf.php` et `admin/socialconf.php` lisait `$allLinks[$ref]` sans vérifier la présence de la clé, d'où un warning pour chaque ressource pas encore configurée. Le symptôme est apparu avec l'ajout de `PreventionOfficer` en #4715. Le test s'écrivait par ailleurs `!empty($a && $b)`, parenthèses mal placées : `empty()` s'appliquait à l'expression booléenne entière.

## Tests

Les quatre pages qui affichent la jauge, `display_errors` actif :

| Page | Erreurs JS | Jauge dessinée | Warnings du gabarit |
|---|---|---|---|
| `admin/securityconf.php` | aucune | ✅ | aucun |
| `admin/socialconf.php` | aucune | ✅ | aucun |
| `view/accident/accident_card.php` | aucune | ✅ | aucun |
| `view/accident/accident_metadata.php` | aucune | ✅ | aucun |

![Jauge à nouveau dessinée](https://raw.githubusercontent.com/nicolas-eoxia/digiriskdolibarr/assets/5079-screenshots/.shots/gauge_fixed.png)

Restent, hors périmètre de cette PR, des warnings sans effet sur l'affichage : `$conf->global->DIGIRISKDOLIBARR_SOCIETY_DESCRIPTION` non défini sur la page Sécurité, les clés `TitularsCSE` / `AlternatesCSE` / `TitularsDP` / `AlternatesDP` et un `Attempt to read property "id" on null` dans le corps de la page Social, et `$coldisplay` sur la fiche accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)