### PR TITLE
#5081 [Config] Warnings PHP sur les pages de configuration et la fiche accident

### DIFF
--- a/admin/securityconf.php
+++ b/admin/securityconf.php
@@ -144,7 +144,7 @@ $socialResources   = array("TitularsCSE", "AlternatesCSE", "TitularsDP", "Altern
 $maxnumber = count($securityResources) + count($securityConsts);
 
 foreach ($securityConsts as $securityConst) {
-	if (dol_strlen($conf->global->$securityConst) > 0) {
+	if (dol_strlen(getDolGlobalString($securityConst)) > 0) {
 		$counter += 1;
 	}
 }
@@ -496,7 +496,7 @@ print '</td></tr>';
 // * Location of detailed instructions - Emplacement de la consigne détaillée *
 
 print '<tr class="oddeven"><td><label for="emplacementCD">' . $langs->trans("LocationOfDetailedInstructions") . '</label></td><td>';
-$doleditor = new DolEditor('emplacementCD', $conf->global->DIGIRISKDOLIBARR_LOCATION_OF_DETAILED_INSTRUCTION ? $conf->global->DIGIRISKDOLIBARR_LOCATION_OF_DETAILED_INSTRUCTION : '', '', 200, 'dolibarr_details', '', false, true, $conf->global->FCKEDITOR_ENABLE_SOCIETE, ROWS_3, '90%');
+$doleditor = new DolEditor('emplacementCD', getDolGlobalString('DIGIRISKDOLIBARR_LOCATION_OF_DETAILED_INSTRUCTION'), '', 200, 'dolibarr_details', '', false, true, getDolGlobalString('FCKEDITOR_ENABLE_SOCIETE'), ROWS_3, '90%');
 $doleditor->Create();
 print '</td></tr>';
 
@@ -509,28 +509,28 @@ print '<tr class="liste_titre"><th class="titlefield">' . $langs->trans("Society
 // * Description - Emplacement de la consigne détaillée *
 
 print '<tr class="oddeven"><td><label for="description">' . $langs->trans("Description") . '</label></td><td>';
-$doleditor = new DolEditor('description', $conf->global->DIGIRISKDOLIBARR_SOCIETY_DESCRIPTION ? $conf->global->DIGIRISKDOLIBARR_SOCIETY_DESCRIPTION : '', '', 200, 'dolibarr_details', '', false, true, $conf->global->FCKEDITOR_ENABLE_SOCIETE, ROWS_3, '90%');
+$doleditor = new DolEditor('description', getDolGlobalString('DIGIRISKDOLIBARR_SOCIETY_DESCRIPTION'), '', 200, 'dolibarr_details', '', false, true, getDolGlobalString('FCKEDITOR_ENABLE_SOCIETE'), ROWS_3, '90%');
 $doleditor->Create();
 print '</td></tr>';
 
 // * General means at disposal - Moyens généraux mis à disposition *
 
 print '<tr class="oddeven"><td><label for="moyensgeneraux">' . $langs->trans("GeneralMeansAtDisposal") . '</label></td><td>';
-$doleditor = new DolEditor('moyensgeneraux', $conf->global->DIGIRISKDOLIBARR_GENERAL_MEANS ? $conf->global->DIGIRISKDOLIBARR_GENERAL_MEANS : '', '', 200, 'dolibarr_details', '', false, true, $conf->global->FCKEDITOR_ENABLE_SOCIETE, ROWS_3, '90%');
+$doleditor = new DolEditor('moyensgeneraux', getDolGlobalString('DIGIRISKDOLIBARR_GENERAL_MEANS'), '', 200, 'dolibarr_details', '', false, true, getDolGlobalString('FCKEDITOR_ENABLE_SOCIETE'), ROWS_3, '90%');
 $doleditor->Create();
 print '</td></tr>';
 
 // * General instructions - Consignes générales *
 
 print '<tr class="oddeven"><td><label for="consignesgenerales">' . $langs->trans("GeneralInstructions") . '</label></td><td>';
-$doleditor = new DolEditor('consignesgenerales', $conf->global->DIGIRISKDOLIBARR_GENERAL_RULES ? $conf->global->DIGIRISKDOLIBARR_GENERAL_RULES : '', '', 200, 'dolibarr_details', '', false, true, $conf->global->FCKEDITOR_ENABLE_SOCIETE, ROWS_3, '90%');
+$doleditor = new DolEditor('consignesgenerales', getDolGlobalString('DIGIRISKDOLIBARR_GENERAL_RULES'), '', 200, 'dolibarr_details', '', false, true, getDolGlobalString('FCKEDITOR_ENABLE_SOCIETE'), ROWS_3, '90%');
 $doleditor->Create();
 print '</td></tr>';
 
 // * General instructions - Consignes générales *
 
 print '<tr class="oddeven"><td><label for="firstaid">' . $langs->trans("FirstAid") . '</label></td><td>';
-$doleditor = new DolEditor('firstaid', $conf->global->DIGIRISKDOLIBARR_FIRST_AID ? $conf->global->DIGIRISKDOLIBARR_FIRST_AID : '', '', 200, 'dolibarr_details', '', false, true, $conf->global->FCKEDITOR_ENABLE_SOCIETE, ROWS_3, '90%');
+$doleditor = new DolEditor('firstaid', getDolGlobalString('DIGIRISKDOLIBARR_FIRST_AID'), '', 200, 'dolibarr_details', '', false, true, getDolGlobalString('FCKEDITOR_ENABLE_SOCIETE'), ROWS_3, '90%');
 $doleditor->Create();
 print '</td></tr>';
 
@@ -541,7 +541,7 @@ print '<tr class="liste_titre"><th class="titlefield wordbreak">' . $langs->tran
 // * Rules of procedure location - Emplacement du règlement intérieur *
 
 print '<tr class="oddeven"><td><label for="emplacementRI">' . $langs->trans("Location") . '</label></td><td>';
-$doleditor = new DolEditor('emplacementRI', $conf->global->DIGIRISKDOLIBARR_RULES_LOCATION ? $conf->global->DIGIRISKDOLIBARR_RULES_LOCATION : '', '', 200, 'dolibarr_details', '', false, true, $conf->global->FCKEDITOR_ENABLE_SOCIETE, ROWS_3, '90%');
+$doleditor = new DolEditor('emplacementRI', getDolGlobalString('DIGIRISKDOLIBARR_RULES_LOCATION'), '', 200, 'dolibarr_details', '', false, true, getDolGlobalString('FCKEDITOR_ENABLE_SOCIETE'), ROWS_3, '90%');
 $doleditor->Create();
 print '</td></tr>';
 
@@ -552,7 +552,7 @@ print '<tr class="liste_titre"><th class="titlefield wordbreak">' . $langs->tran
 // * Risks evaluation location - Emplacement du Document Unique *
 
 print '<tr class="oddeven"><td><label for="emplacementDU">' . $langs->trans("Location") . '</label></td><td>';
-$doleditor = new DolEditor('emplacementDU', $conf->global->DIGIRISKDOLIBARR_DUER_LOCATION ? $conf->global->DIGIRISKDOLIBARR_DUER_LOCATION : '', '', 200, 'dolibarr_details', '', false, true, $conf->global->FCKEDITOR_ENABLE_SOCIETE, ROWS_3, '90%');
+$doleditor = new DolEditor('emplacementDU', getDolGlobalString('DIGIRISKDOLIBARR_DUER_LOCATION'), '', 200, 'dolibarr_details', '', false, true, getDolGlobalString('FCKEDITOR_ENABLE_SOCIETE'), ROWS_3, '90%');
 $doleditor->Create();
 print '</td></tr>';
 
@@ -563,7 +563,7 @@ print '<tr class="liste_titre"><th class="titlefield wordbreak">' . $langs->tran
 // * Collective Agreement location - Emplacement de la Convention collective *
 
 print '<tr class="oddeven"><td><label for="emplacementCC">' . $langs->trans("Location") . '</label></td><td>';
-$doleditor = new DolEditor('emplacementCC', $conf->global->DIGIRISKDOLIBARR_COLLECTIVE_AGREEMENT_LOCATION ? $conf->global->DIGIRISKDOLIBARR_COLLECTIVE_AGREEMENT_LOCATION : '', '', 200, 'dolibarr_details', '', false, true, $conf->global->FCKEDITOR_ENABLE_SOCIETE, ROWS_3, '90%');
+$doleditor = new DolEditor('emplacementCC', getDolGlobalString('DIGIRISKDOLIBARR_COLLECTIVE_AGREEMENT_LOCATION'), '', 200, 'dolibarr_details', '', false, true, getDolGlobalString('FCKEDITOR_ENABLE_SOCIETE'), ROWS_3, '90%');
 $doleditor->Create();
 print '</td></tr>';
 print '</table>';

--- a/admin/socialconf.php
+++ b/admin/socialconf.php
@@ -126,7 +126,7 @@ $socialConsts    = array("DIGIRISKDOLIBARR_PARTICIPATION_AGREEMENT_INFORMATION_P
 $maxnumber = count($socialResources) + count($socialConsts);
 
 foreach ($socialConsts as $socialConst) {
-	if (dol_strlen($conf->global->$socialConst) > 0 && $conf->global->$socialConst != '--') {
+	if (dol_strlen(getDolGlobalString($socialConst)) > 0 && getDolGlobalString($socialConst) != '--') {
 		$counter += 1;
 	}
 }
@@ -149,8 +149,8 @@ $resources = new DigiriskResources($db);
 
 $allLinks = $resources->fetchDigiriskResources();
 
-$electionDateCSE = $conf->global->DIGIRISKDOLIBARR_CSE_ELECTION_DATE;
-$electionDateDP  = $conf->global->DIGIRISKDOLIBARR_DP_ELECTION_DATE;
+$electionDateCSE = getDolGlobalString('DIGIRISKDOLIBARR_CSE_ELECTION_DATE');
+$electionDateDP  = getDolGlobalString('DIGIRISKDOLIBARR_DP_ELECTION_DATE');
 
 print '<span class="opacitymedium">' . $langs->trans("DigiriskMenu") . "</span><br>\n";
 print "<br>";
@@ -176,7 +176,7 @@ print '<tr class="liste_titre"><th class="titlefield wordbreak">' . $langs->tran
 // * Terms And Conditions - Modalités *
 
 print '<tr class="oddeven"><td><label for="modalites">' . $langs->trans("TermsAndConditions") . '</label></td><td>';
-$doleditor = new DolEditor('modalites', $conf->global->DIGIRISKDOLIBARR_PARTICIPATION_AGREEMENT_INFORMATION_PROCEDURE ? $conf->global->DIGIRISKDOLIBARR_PARTICIPATION_AGREEMENT_INFORMATION_PROCEDURE : '', '', 200, 'dolibarr_details', '', false, true, $conf->global->FCKEDITOR_ENABLE_SOCIETE, ROWS_3, '90%');
+$doleditor = new DolEditor('modalites', getDolGlobalString('DIGIRISKDOLIBARR_PARTICIPATION_AGREEMENT_INFORMATION_PROCEDURE'), '', 200, 'dolibarr_details', '', false, true, getDolGlobalString('FCKEDITOR_ENABLE_SOCIETE'), ROWS_3, '90%');
 $doleditor->Create();
 print '</td></tr>';
 
@@ -191,14 +191,14 @@ print '<tr class="liste_titre"><th class="titlefield wordbreak">' . $langs->tran
 // * Permanent - Permanentes *
 
 print '<tr class="oddeven"><td><label for="permanent">' . $langs->trans("PermanentDerogation") . '</label></td><td>';
-$doleditor = new DolEditor('permanent', $conf->global->DIGIRISKDOLIBARR_DEROGATION_SCHEDULE_PERMANENT ? $conf->global->DIGIRISKDOLIBARR_DEROGATION_SCHEDULE_PERMANENT : '', '', 200, 'dolibarr_details', '', false, true, $conf->global->FCKEDITOR_ENABLE_SOCIETE, ROWS_3, '90%');
+$doleditor = new DolEditor('permanent', getDolGlobalString('DIGIRISKDOLIBARR_DEROGATION_SCHEDULE_PERMANENT'), '', 200, 'dolibarr_details', '', false, true, getDolGlobalString('FCKEDITOR_ENABLE_SOCIETE'), ROWS_3, '90%');
 $doleditor->Create();
 print '</td></tr>';
 
 // * Permanent - Permanentes *
 
 print '<tr class="oddeven"><td><label for="occasional">' . $langs->trans("OccasionalDerogation") . '</label></td><td>';
-$doleditor = new DolEditor('occasional', $conf->global->DIGIRISKDOLIBARR_DEROGATION_SCHEDULE_OCCASIONAL ? $conf->global->DIGIRISKDOLIBARR_DEROGATION_SCHEDULE_OCCASIONAL : '', '', 200, 'dolibarr_details', '', false, true, $conf->global->FCKEDITOR_ENABLE_SOCIETE, ROWS_3, '90%');
+$doleditor = new DolEditor('occasional', getDolGlobalString('DIGIRISKDOLIBARR_DEROGATION_SCHEDULE_OCCASIONAL'), '', 200, 'dolibarr_details', '', false, true, getDolGlobalString('FCKEDITOR_ENABLE_SOCIETE'), ROWS_3, '90%');
 $doleditor->Create();
 print '</td></tr>';
 
@@ -207,11 +207,11 @@ print '</td></tr>';
 */
 
 print '<tr class="liste_titre"><th class="titlefield wordbreak">' . $langs->trans("HarassmentOfficer") . '</th><th>' . $langs->trans("") . '</th></tr>' . "\n";
-$harassmentOfficer = $allLinks['HarassmentOfficer'];
+$harassmentOfficerIds = $allLinks['HarassmentOfficer']->id ?? [];
 print '<tr>';
 print '<td>' . $langs->trans("ActionOnUser") . '</td>';
 print '<td colspan="3" class="maxwidthonsmartphone">';
-print $form->select_dolusers($harassmentOfficer->id, 'HarassmentOfficer', 1, null, 0, '', '', $conf->entity, 0, 0, '(u.statut:=:1)', 0, '', 'minwidth300');
+print $form->select_dolusers($harassmentOfficerIds, 'HarassmentOfficer', 1, null, 0, '', '', $conf->entity, 0, 0, '(u.statut:=:1)', 0, '', 'minwidth300');
 if ( ! GETPOSTISSET('backtopage')) print ' <a href="' . DOL_URL_ROOT . '/user/card.php?action=create&backtopage=' . urlencode($_SERVER["PHP_SELF"] . '?action=create') . '"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans("AddUser") . '"></span></a>';
 print '</td></tr>';
 
@@ -220,11 +220,11 @@ print '</td></tr>';
 */
 
 print '<tr class="liste_titre"><th class="titlefield wordbreak">' . $langs->trans("HarassmentOfficerCSE") . '</th><th>' . $langs->trans("") . '</th></tr>' . "\n";
-$harassmentOfficerCSE = $allLinks['HarassmentOfficerCSE'];
+$harassmentOfficerCSEIds = $allLinks['HarassmentOfficerCSE']->id ?? [];
 print '<tr>';
 print '<td>' . $langs->trans("ActionOnUser") . '</td>';
 print '<td colspan="3" class="maxwidthonsmartphone">';
-print $form->select_dolusers($harassmentOfficerCSE->id, 'HarassmentOfficerCSE', 1, null, 0, '', '', $conf->entity, 0, 0, '(u.statut:=:1)', 0, '', 'minwidth300');
+print $form->select_dolusers($harassmentOfficerCSEIds, 'HarassmentOfficerCSE', 1, null, 0, '', '', $conf->entity, 0, 0, '(u.statut:=:1)', 0, '', 'minwidth300');
 if ( ! GETPOSTISSET('backtopage')) print ' <a href="' . DOL_URL_ROOT . '/user/card.php?action=create&backtopage=' . urlencode($_SERVER["PHP_SELF"] . '?action=create') . '"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans("AddUser") . '"></span></a>';
 print '</td></tr>';
 
@@ -243,14 +243,14 @@ print '</td></tr>';
 // * ESC Titulars - Titulaires CSE *
 
 $userlist 	  = $form->select_dolusers('', '', 0, null, 0, '', '', $conf->entity, 0, 0, '(u.statut:=:1)', 0, '', '', 0, 1);
-$titularsCse = $allLinks['TitularsCSE'];
+$titularsCseIds = $allLinks['TitularsCSE']->id ?? [];
 
 print '<tr>';
 print '<td>' . $form->editfieldkey('Titulars', 'TitularsCSE_id', '', $object, 0) . '</td>';
 print '<td colspan="3" class="maxwidthonsmartphone">';
 
 
-print $form->multiselectarray('TitularsCSE', $userlist, $titularsCse->id, null, null, null, null, "300");
+print $form->multiselectarray('TitularsCSE', $userlist, $titularsCseIds, null, null, null, null, "300");
 
 if ( ! GETPOSTISSET('backtopage')) print ' <a href="' . DOL_URL_ROOT . '/user/card.php?action=create&backtopage=' . urlencode($_SERVER["PHP_SELF"] . '?action=create') . '"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans("AddUser") . '"></span></a>';
 
@@ -259,13 +259,13 @@ print '</td></tr>';
 // * ESC Alternates - Suppléants CSE *
 
 $userlist       = $form->select_dolusers('', '', 0, null, 0, '', '', $conf->entity, 0, 0, '(u.statut:=:1)', 0, '', '', 0, 1);
-$alternatesCse = $allLinks['AlternatesCSE'];
+$alternatesCseIds = $allLinks['AlternatesCSE']->id ?? [];
 
 print '<tr>';
 print '<td>' . $form->editfieldkey('Alternates', 'AlternatesCSE_id', '', $object, 0) . '</td>';
 print '<td colspan="3" class="maxwidthonsmartphone">';
 
-print $form->multiselectarray('AlternatesCSE', $userlist, $alternatesCse->id, null, null, null, null, "300");
+print $form->multiselectarray('AlternatesCSE', $userlist, $alternatesCseIds, null, null, null, null, "300");
 
 if ( ! GETPOSTISSET('backtopage')) print ' <a href="' . DOL_URL_ROOT . '/user/card.php?action=create&backtopage=' . urlencode($_SERVER["PHP_SELF"] . '?action=create') . '"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans("AddUser") . '"></span></a>';
 
@@ -284,13 +284,13 @@ print $form->selectDate(strtotime($electionDateDP) ? $electionDateDP : -1, 'Elec
 // * Staff Representatives Titulars - Titulaires Délégués du Personnel *
 
 $userlist    = $form->select_dolusers('', '', 0, null, 0, '', '', $conf->entity, 0, 0, '(u.statut:=:1)', 0, '', '', 0, 1);
-$titularsDp = $allLinks['TitularsDP'];
+$titularsDpIds = $allLinks['TitularsDP']->id ?? [];
 
 print '<tr>';
 print '<td>' . $form->editfieldkey('Titulars', 'TitularsDP_id', '', $object, 0) . '</td>';
 print '<td colspan="3" class="maxwidthonsmartphone">';
 
-print $form->multiselectarray('TitularsDP', $userlist, $titularsDp->id, null, null, null, null, "300");
+print $form->multiselectarray('TitularsDP', $userlist, $titularsDpIds, null, null, null, null, "300");
 
 if ( ! GETPOSTISSET('backtopage')) print ' <a href="' . DOL_URL_ROOT . '/user/card.php?action=create&backtopage=' . urlencode($_SERVER["PHP_SELF"] . '?action=create') . '"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans("AddUser") . '"></span></a>';
 
@@ -299,13 +299,13 @@ print '</td></tr>';
 // * Staff Representatives Suppléants - Suppléants Délégués du Personnel *
 
 $userlist      = $form->select_dolusers('', '', 0, null, 0, '', '', $conf->entity, 0, 0, '(u.statut:=:1)', 0, '', '', 0, 1);
-$alternatesDp = $allLinks['AlternatesDP'];
+$alternatesDpIds = $allLinks['AlternatesDP']->id ?? [];
 
 print '<tr>';
 print '<td>' . $form->editfieldkey('Alternates', 'AlternatesDP', '', $object, 0) . '</td>';
 print '<td colspan="3" class="maxwidthonsmartphone">';
 
-print $form->multiselectarray('AlternatesDP', $userlist, $alternatesDp->id, null, null, null, null, "300");
+print $form->multiselectarray('AlternatesDP', $userlist, $alternatesDpIds, null, null, null, null, "300");
 
 if ( ! GETPOSTISSET('backtopage')) print ' <a href="' . DOL_URL_ROOT . '/user/card.php?action=create&backtopage=' . urlencode($_SERVER["PHP_SELF"] . '?action=create') . '"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans("AddUser") . '"></span></a>';
 

--- a/class/actions_digiriskdolibarr.class.php
+++ b/class/actions_digiriskdolibarr.class.php
@@ -242,16 +242,16 @@ class ActionsDigiriskdolibarr
 			?>
 			<script src="../custom/digiriskdolibarr/js/digiriskdolibarr.js"></script>
 			<?php
-			if ($conf->global->MAIN_INFO_SOCIETE_COUNTRY == '1:FR:France') {
+			if (getDolGlobalString('MAIN_INFO_SOCIETE_COUNTRY') == '1:FR:France') {
 				require_once __DIR__ . '/../lib/digiriskdolibarr_function.lib.php';
 				$form      = new Form($db);
                 $pictopath = dol_buildpath('/custom/digiriskdolibarr/img/digiriskdolibarr_color.png', 1);
                 $pictoDigirisk = img_picto('', $pictopath, '', 1, 0, 0, '', 'pictoModule');
-				$idcc_form = digirisk_select_dictionary('DIGIRISKDOLIBARR_COLLECTIVE_AGREEMENT_TITLE', 'c_conventions_collectives', 'code', 'libelle', $conf->global->DIGIRISKDOLIBARR_COLLECTIVE_AGREEMENT_TITLE, 1, '', '', 'minwidth100');
-				$pee_input = '<input type="checkbox" name="DIGIRISKDOLIBARR_PEE_ENABLED" '. ($conf->global->DIGIRISKDOLIBARR_PEE_ENABLED ? 'checked' : '') .'>';
-				$perco_input = '<input type="checkbox" name="DIGIRISKDOLIBARR_PERCO_ENABLED" '. ($conf->global->DIGIRISKDOLIBARR_PERCO_ENABLED ? 'checked' : '') .'>';
-				$nbemployees_input = '<input type="number" name="DIGIRISKDOLIBARR_NB_EMPLOYEES" class="minwidth200" value="' . $conf->global->DIGIRISKDOLIBARR_NB_EMPLOYEES . '"' . ($conf->global->DIGIRISKDOLIBARR_MANUAL_INPUT_NB_EMPLOYEES ? '' : 'disabled') . '>';
-				$nbworkedhours_input = '<input type="number" name="DIGIRISKDOLIBARR_NB_WORKED_HOURS" class="minwidth200" value="' . $conf->global->DIGIRISKDOLIBARR_NB_WORKED_HOURS . '"' . ($conf->global->DIGIRISKDOLIBARR_MANUAL_INPUT_NB_WORKED_HOURS ? '' : 'disabled') . '>';
+				$idcc_form = digirisk_select_dictionary('DIGIRISKDOLIBARR_COLLECTIVE_AGREEMENT_TITLE', 'c_conventions_collectives', 'code', 'libelle', getDolGlobalString('DIGIRISKDOLIBARR_COLLECTIVE_AGREEMENT_TITLE'), 1, '', '', 'minwidth100');
+				$pee_input = '<input type="checkbox" name="DIGIRISKDOLIBARR_PEE_ENABLED" '. (getDolGlobalInt('DIGIRISKDOLIBARR_PEE_ENABLED') ? 'checked' : '') .'>';
+				$perco_input = '<input type="checkbox" name="DIGIRISKDOLIBARR_PERCO_ENABLED" '. (getDolGlobalInt('DIGIRISKDOLIBARR_PERCO_ENABLED') ? 'checked' : '') .'>';
+				$nbemployees_input = '<input type="number" name="DIGIRISKDOLIBARR_NB_EMPLOYEES" class="minwidth200" value="' . getDolGlobalString('DIGIRISKDOLIBARR_NB_EMPLOYEES') . '"' . (getDolGlobalInt('DIGIRISKDOLIBARR_MANUAL_INPUT_NB_EMPLOYEES') ? '' : 'disabled') . '>';
+				$nbworkedhours_input = '<input type="number" name="DIGIRISKDOLIBARR_NB_WORKED_HOURS" class="minwidth200" value="' . getDolGlobalString('DIGIRISKDOLIBARR_NB_WORKED_HOURS') . '"' . (getDolGlobalInt('DIGIRISKDOLIBARR_MANUAL_INPUT_NB_WORKED_HOURS') ? '' : 'disabled') . '>';
 				?>
 				<script>
 					let collectiveAgreementDictionary = $('<tr class="oddeven"><td><label for="selectidcc_id"><?php print $pictoDigirisk . $form->textwithpicto($langs->trans('IDCC'), $langs->trans('IDCCTooltip'));?></label></td>');

--- a/core/tpl/accident/digiriskdolibarr_accident_lesion.tpl.php
+++ b/core/tpl/accident/digiriskdolibarr_accident_lesion.tpl.php
@@ -36,21 +36,18 @@ if (!empty($accidentlines) && $accidentlines > 0) {
             print $item->ref;
             print '</td>';
 
-            $coldisplay++;
             //LesionLocalization -- Siège des lésions
             print '<td>';
             print saturne_select_dictionary('lesion_localization', 'c_lesion_localization', 'label', 'label', $item->lesion_localization);
             print '<a href="' . DOL_URL_ROOT . '/admin/dict.php?mainmenu=home" target="_blank" class="wpeo-tooltip-event" aria-label="' . $langs->trans('ConfigDico') . '">' . ' ' . img_picto('', 'globe') . '</a>';
             print '</td>';
 
-            $coldisplay++;
             //LesionNature -- Nature des lésions
             print '<td>';
             print saturne_select_dictionary('lesion_nature', 'c_lesion_nature', 'label', 'label', $item->lesion_nature);
             print '<a href="' . DOL_URL_ROOT . '/admin/dict.php?mainmenu=home" target="_blank" class="wpeo-tooltip-event" aria-label="' . $langs->trans('ConfigDico') . '">' . ' ' . img_picto('', 'globe') . '</a>';
             print '</td>';
 
-            $coldisplay += $colspan;
             print '<td class="center" colspan="' . $colspan . '">';
             print '<input type="submit" class="button" value="' . $langs->trans('Save') . '" name="updateLesion" id="updateLesion">';
             print ' &nbsp; <input type="submit" id ="cancelLesion" class="button" name="cancelLesion" value="' . $langs->trans("Cancel") . '">';
@@ -63,22 +60,18 @@ if (!empty($accidentlines) && $accidentlines > 0) {
             print $item->ref;
             print '</td>';
 
-            $coldisplay++;
             print '<td>';
             print $langs->transnoentities($item->lesion_localization);
             print '</td>';
 
-            $coldisplay++;
             print '<td>';
             print $langs->transnoentities($item->lesion_nature);
             print '</td>';
 
-            $coldisplay += $colspan;
 
             //Actions buttons
             if ($object->status == $object::STATUS_DRAFT) {
                 print '<td class="center">';
-                $coldisplay++;
                 print '<a href="' . $_SERVER["PHP_SELF"] . '?id=' . $id . '&amp;action=editLesion&amp;lineid=' . $item->id . '" style="padding-right: 20px"><i class="fas fa-pencil-alt" style="color: #666"></i></a>';
                 print '<a href="' . $_SERVER["PHP_SELF"] . '?id=' . $id . '&amp;action=deleteLesion&amp;lineid=' . $item->id . '&token='. newToken(). '">';
                 print img_delete();
@@ -107,21 +100,18 @@ if ($object->status == $object::STATUS_DRAFT && $permissiontoadd) {
     print $accidentLesion->getNextNumRef();
     print '</td>';
 
-    $coldisplay++;
     //LesionLocalization -- Siège des lésions
     print '<td>';
     print saturne_select_dictionary('lesion_localization', 'c_lesion_localization', 'label');
     print '<a href="' . DOL_URL_ROOT . '/admin/dict.php?mainmenu=home" target="_blank" class="wpeo-tooltip-event" aria-label="' . $langs->trans('ConfigDico') . '">' . ' ' . img_picto('', 'globe') . '</a>';
     print '</td>';
 
-    $coldisplay++;
     //LesionNature -- Nature des lésions
     print '<td>';
     print saturne_select_dictionary('lesion_nature', 'c_lesion_nature', 'label');
     print '<a href="' . DOL_URL_ROOT . '/admin/dict.php?mainmenu=home" target="_blank" class="wpeo-tooltip-event" aria-label="' . $langs->trans('ConfigDico') . '">' . ' ' . img_picto('', 'globe') . '</a>';
     print '</td>';
 
-    $coldisplay += $colspan;
     print '<td class="center" colspan="' . $colspan . '">';
     print '<input type="submit" class="button" value="' . $langs->trans('Add') . '" name="addline" id="addline">';
     print '</td>';

--- a/view/accident/accident_card.php
+++ b/view/accident/accident_card.php
@@ -1240,27 +1240,22 @@ if ((empty($action) || ($action != 'create' && $action != 'edit'))) {
                     print $item->ref;
                     print '</td>';
 
-                    $coldisplay++;
                     print '<td>';
                     print '<input type="number" name="workstop_days" class="minwidth150" min="0" value="' . $item->workstop_days . '">';
                     print '</td>';
 
-                    $coldisplay++;
                     print '<td>';
                     print $form->selectDate($item->date_start_workstop, 'datestart', 1, 1, 0, '', 1);
                     print '</td>';
 
-                    $coldisplay++;
                     print '<td>';
                     print $form->selectDate($item->date_end_workstop, 'dateend', 1, 1, 0, '', 1);
                     print '</td>';
 
-                    $coldisplay++;
                     print '<td>';
                     print '<input name="declarationLink" value="'. (GETPOST('declarationLink') ?: $item->declaration_link) .'">';
                     print '</td>';
 
-                    $coldisplay += $colspan;
                     print '<td class="center" colspan="' . $colspan . '">';
                     print '<input type="submit" class="button" value="' . $langs->trans('Save') . '" name="updateLine" id="updateLine">';
                     print ' &nbsp; <input type="submit" id ="cancelLine" class="button" name="cancelLine" value="' . $langs->trans("Cancel") . '">';
@@ -1273,33 +1268,27 @@ if ((empty($action) || ($action != 'create' && $action != 'edit'))) {
                     print $item->ref;
                     print '</td>';
 
-                    $coldisplay++;
                     print '<td>';
                     print $item->workstop_days;
                     print '</td>';
 
-                    $coldisplay++;
                     print '<td>';
                     print dol_print_date($item->date_start_workstop, 'dayhour');
                     print '</td>';
 
-                    $coldisplay++;
                     print '<td>';
                     print dol_print_date($item->date_end_workstop, 'dayhour');
                     print '</td>';
 
-                    $coldisplay++;
                     print '<td>';
                     $is_link = dol_is_url($item->declaration_link);
                     print ($is_link ? '<a target="_blank" href="'. $item->declaration_link .'">' : '') . $item->declaration_link . ($is_link ? '</a>' : '') ;
                     print '</td>';
 
-                    $coldisplay += $colspan;
 
                     //Actions buttons
                     if ($object->status == Accident::STATUS_DRAFT) {
                         print '<td class="center">';
-                        $coldisplay++;
                         print '<a href="' . $_SERVER["PHP_SELF"] . '?id=' . $id . '&amp;action=editline&amp;lineid=' . $item->id . '" style="padding-right: 20px"><i class="fas fa-pencil-alt" style="color: #666"></i></a>';
                         print '<a href="' . $_SERVER["PHP_SELF"] . '?id=' . $id . '&amp;action=deleteline&amp;lineid=' . $item->id . '&amp;token=' . newToken() . '">';
                         print img_delete();
@@ -1328,27 +1317,22 @@ if ((empty($action) || ($action != 'create' && $action != 'edit'))) {
 			print $objectline->getNextNumRef();
 			print '</td>';
 
-			$coldisplay++;
 			print '<td>';
 			print '<input type="number" name="workstop_days" class="minwidth150" min="0" value="">';
 			print '</td>';
 
-			$coldisplay++;
 			print '<td>';
 			print $form->selectDate(dol_now('tzuser'), 'datestart', 1, 1, 0, '', 1);
 			print '</td>';
 
-			$coldisplay++;
 			print '<td>';
 			print $form->selectDate(dol_now('tzuser'), 'dateend', 1, 1, 0, '', 1);
 			print '</td>';
 
-			$coldisplay++;
 			print '<td class="maxwidth100">';
 			print '<input name="declarationLink" id="declarationLink" value="'. GETPOST('declarationLink') . '">';
 			print '</td>';
 
-			$coldisplay += $colspan;
 			print '<td class="center" colspan="' . $colspan . '">';
 			print '<input type="submit" class="button" value="' . $langs->trans('Add') . '" name="addline" id="addline">';
 			print '</td>';


### PR DESCRIPTION
Closes #5081

Suite de #5080 : le même écran, mais cette fois les warnings du corps de page. Trois familles de lectures sans garde, toutes visibles dès que `display_errors` est actif.

## Constantes lues sur `$conf->global`

`$conf->global->UNE_CONSTANTE` émet `Undefined property: stdClass::$...` tant que la constante n'est pas enregistrée. Remplacé par `getDolGlobalString()` / `getDolGlobalInt()` dans `admin/securityconf.php`, `admin/socialconf.php` et le bloc du hook `admincompany` de `class/actions_digiriskdolibarr.class.php`, qui produisait le même warning sur `DIGIRISKDOLIBARR_COLLECTIVE_AGREEMENT_TITLE`.

## Ressources de la page Social

```php
$titularsCse = $allLinks['TitularsCSE'];   // clé absente
… $titularsCse->id                          // puis ->id sur null
```

Huit warnings sur toute installation où les représentants du personnel ne sont pas encore saisis. Les six ressources de la page sont maintenant lues avec un repli sur un tableau vide.

## `$coldisplay`

Vestige des gabarits de lignes de Dolibarr, où il sert de colspan. Ici il était incrémenté vingt-six fois entre `core/tpl/accident/digiriskdolibarr_accident_lesion.tpl.php` et `view/accident/accident_card.php` **sans jamais être lu**, et le premier incrément portait sur une variable inexistante. Code mort supprimé.

## Tests

`display_errors` actif, avant / après :

| Page | Avant | Après |
|---|---|---|
| `admin/securityconf.php` | 2 warnings (+1 du hook) | aucun |
| `admin/socialconf.php` | 9 warnings | aucun |
| `view/accident/accident_card.php` | 1 warning | aucun |
| `view/accident/accident_metadata.php` | aucun | aucun |

Non-régression vérifiée : les huit éditeurs de la page Sécurité portent toujours leurs valeurs et le champ Description s'enregistre puis se relit ; les six sélections de la page Social sont identiques après un aller-retour d'enregistrement ; le tableau des lésions de la fiche accident s'affiche toujours ; les champs IDCC, PEE, PERCO injectés par le hook sont toujours présents sur `admin/company.php`. Aucune erreur JS sur ces pages.

Hors périmètre, repéré au passage : `view/firepermit/firepermit_card.php` ligne 980 appelle `getNomUrl()` sur le retour de `fetchResourcesFromObject()`, qui vaut `0` quand aucune société extérieure n'est liée — la page part alors en *fatal error* au lieu d'afficher un message. Reproductible avec un identifiant de permis inexistant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)