### PR TITLE
#5083 [FirePermit][PreventionPlan] Fiches en erreur fatale sans société extérieure liée

### DIFF
--- a/class/actions_digiriskdolibarr.class.php
+++ b/class/actions_digiriskdolibarr.class.php
@@ -1554,8 +1554,8 @@ class ActionsDigiriskdolibarr
 
             $digiriskResources = new DigiriskResources($this->db);
 
-            $extSociety  = $digiriskResources->fetchResourcesFromObject('ExtSociety', $object);
-            $moreHtmlRef = $langs->trans('ExtSociety') . ' : ' . $extSociety->getNomUrl(1);
+            $extSociety  = $digiriskResources->fetchSingleResourceFromObject('ExtSociety', $object);
+            $moreHtmlRef = $langs->trans('ExtSociety') . ' : ' . ($extSociety !== null ? $extSociety->getNomUrl(1) : $langs->trans('None'));
 
             $this->resprints = $moreHtmlRef;
         }

--- a/class/digiriskresources.class.php
+++ b/class/digiriskresources.class.php
@@ -282,6 +282,31 @@ class DigiriskResources extends SaturneObject
 	}
 
     /**
+     * Fetch the single resource linked to an object, as an object.
+     *
+     * fetchResourcesFromObject() rend l'objet resolu pour une seule ligne, un tableau a deux
+     * niveaux pour plusieurs, l'entier 0 quand il n'y en a aucune et -1 sur erreur : tout
+     * appelant qui dereference son retour part en erreur fatale des que la ressource n'est pas
+     * renseignee. Cette methode rend toujours un objet ou null.
+     *
+     * @param  string       $ref    Resource reference (ExtSociety, LabourInspector, ...)
+     * @param  CommonObject $object Linked object
+     * @return object|null          Resolved resource, null when there is none
+     */
+    public function fetchSingleResourceFromObject(string $ref, $object)
+    {
+        $resource = $this->fetchResourcesFromObject($ref, $object);
+
+        if (is_array($resource)) {
+            // Le tableau est indexe par reference puis par identifiant de ressource
+            $resourcesForRef = $resource[$ref] ?? reset($resource);
+            $resource        = is_array($resourcesForRef) ? reset($resourcesForRef) : $resourcesForRef;
+        }
+
+        return is_object($resource) ? $resource : null;
+    }
+
+    /**
      * Fetch the identifiers linked to an object for one resource reference.
      *
      * fetchResourcesFromObject() renvoie tantot un objet, tantot un tableau, tantot un entier

--- a/view/firepermit/firepermit_card.php
+++ b/view/firepermit/firepermit_card.php
@@ -777,8 +777,16 @@ if (($id || $ref) && $action == 'edit') {
 
 	print dol_get_fiche_head();
 
+	// Sans ressource liee, fetchResourcesFromObject() rend l'entier 0 : le normaliser en tableau
+	// evite un avertissement a chaque lecture de cle ci-dessous
 	$objectResources   = $digiriskresources->fetchResourcesFromObject('', $object);
+	if (!is_array($objectResources)) {
+		$objectResources = [];
+	}
 	$objectSignatories = $signatory->fetchSignatory('', $object->id, 'firepermit');
+	if (!is_array($objectSignatories)) {
+		$objectSignatories = [];
+	}
 
 	print '<table class="border centpercent tableforfieldedit firepermit-table">' . "\n";
 
@@ -808,7 +816,7 @@ if (($id || $ref) && $action == 'edit') {
 	print '</td></tr>';
 
 	//Maitre d'oeuvre
-	$masterWorker = is_array($objectSignatories['MasterWorker']) ? array_shift($objectSignatories['MasterWorker'])->element_id : '';
+	$masterWorker = is_array($objectSignatories['MasterWorker'] ?? null) ? array_shift($objectSignatories['MasterWorker'])->element_id : '';
 	$userlist     = $form->select_dolusers($masterWorker, '', 1, null, 0, '', '', 0, 0, 0, '(u.statut:=:1)', 0, '', 'minwidth100imp widthcentpercentminusxx maxwidth400', 0, 1);
 	print '<tr>';
 	print '<td class="fieldrequired minwidth400" style="width:10%">' . img_picto('', 'user') . ' ' . $form->editfieldkey('MasterWorker', 'MaitreOeuvre_id', '', $object, 0) . '</td>';
@@ -828,32 +836,37 @@ if (($id || $ref) && $action == 'edit') {
 	if ( ! empty($user->socid)) {
 		print $form->select_company($user->socid, 'ext_society', '', 1, 1, 0, $events, 0, 'minwidth100imp widthcentpercentminusxx maxwidth400');
 	} else {
-		$extSocietyId = is_array($objectResources['ExtSociety']) ? array_shift($objectResources['ExtSociety'])->id : '';
+		$extSocietyId = is_array($objectResources['ExtSociety'] ?? null) ? array_shift($objectResources['ExtSociety'])->id : '';
 		print $form->select_company($extSocietyId, 'ext_society', '', 'SelectThirdParty', 1, 0, $events, 0, 'minwidth100imp widthcentpercentminusxx maxwidth400');
 	}
 	print ' <a href="' . DOL_URL_ROOT . '/societe/card.php?action=create&backtopage=' . urlencode($_SERVER["PHP_SELF"] . '?action=create') . '" target="_blank"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans("AddThirdParty") . '"></span></a>';
 	print '</td></tr>';
 
-	$extSocietyResponsibleId = is_array($objectSignatories['ExtSocietyResponsible']) ? array_shift($objectSignatories['ExtSocietyResponsible'])->element_id : GETPOST('ext_society_responsible');
+	$extSocietyResponsibleId = is_array($objectSignatories['ExtSocietyResponsible'] ?? null) ? array_shift($objectSignatories['ExtSocietyResponsible'])->element_id : GETPOST('ext_society_responsible');
 
 	if ($extSocietyResponsibleId > 0) {
 		$contact->fetch($extSocietyResponsibleId);
 	}
 
 	//External responsible -- Responsable de la société extérieure
-	$extSociety = $digiriskresources->fetchResourcesFromObject('ExtSociety', $object);
+	$extSociety   = $digiriskresources->fetchSingleResourceFromObject('ExtSociety', $object);
+	$extSocietyId = $extSociety !== null ? $extSociety->id : 0;
 	print '<tr class="oddeven"><td class="fieldrequired minwidth400">';
 	$htmltext = img_picto('', 'address') . ' ' . $langs->trans("ExtSocietyResponsible");
 	print $htmltext;
 	print '</td><td>';
-	print $form->selectcontacts($extSociety->id, dol_strlen($contact->email) ? $extSocietyResponsibleId : -1, 'ext_society_responsible', '', 0, '', 1, 'minwidth100imp widthcentpercentminusxx maxwidth400');
-    print '<a href="' . DOL_URL_ROOT . '/contact/card.php?action=create' . (empty($extSociety->id) ? '' : '&socid=' . $extSociety->id) .'&backtopage=' . urlencode($_SERVER["PHP_SELF"] . '?action=create&ext_society='. (empty($extSociety->id) ? '' : $extSociety->id)) . '" target="_blank"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans("AddContact") . '"></span></a>';
+	print $form->selectcontacts($extSocietyId, dol_strlen($contact->email) ? $extSocietyResponsibleId : -1, 'ext_society_responsible', '', 0, '', 1, 'minwidth100imp widthcentpercentminusxx maxwidth400');
+    print '<a href="' . DOL_URL_ROOT . '/contact/card.php?action=create' . (empty($extSocietyId) ? '' : '&socid=' . $extSocietyId) .'&backtopage=' . urlencode($_SERVER["PHP_SELF"] . '?action=create&ext_society='. (empty($extSocietyId) ? '' : $extSocietyId)) . '" target="_blank"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans("AddContact") . '"></span></a>';
     print '</td></tr>';
 
-	if (is_array($objectResources['LabourInspector']) && $objectResources['LabourInspector'] > 0) {
+	// Les deux ressources ne sont pas toujours renseignees : les initialiser evite de lire une
+	// propriete sur une variable inexistante dans les selecteurs ci-dessous
+	$labourInspectorSociety   = null;
+	$labourInspector_assigned = null;
+	if (is_array($objectResources['LabourInspector'] ?? null) && !empty($objectResources['LabourInspector'])) {
 		$labourInspectorSociety = array_shift($objectResources['LabourInspector']);
 	}
-	if (is_array($objectResources['LabourInspectorAssigned']) && $objectResources['LabourInspectorAssigned'] > 0) {
+	if (is_array($objectResources['LabourInspectorAssigned'] ?? null) && !empty($objectResources['LabourInspectorAssigned'])) {
 		$labourInspector_assigned = array_shift($objectResources['LabourInspectorAssigned']);
 	}
 	//Labour inspector Society -- Entreprise Inspecteur du travail
@@ -863,24 +876,28 @@ if (($id || $ref) && $action == 'edit') {
 	print '<td>';
 	$events    = array();
 	$events[1] = array('method' => 'getContacts', 'url' => dol_buildpath('/custom/digiriskdolibarr/core/ajax/contacts.php?showempty=1', 1), 'htmlname' => 'labour_inspector_contact', 'params' => array('add-customer-contact' => 'disabled'));
-	print $form->select_company($labourInspectorSociety->id, 'labour_inspector', '', 'SelectThirdParty', 1, 0, $events, 0, 'minwidth100imp widthcentpercentminusxx maxwidth400');
+	print $form->select_company($labourInspectorSociety !== null ? $labourInspectorSociety->id : '', 'labour_inspector', '', 'SelectThirdParty', 1, 0, $events, 0, 'minwidth100imp widthcentpercentminusxx maxwidth400');
 	print ' <a href="' . DOL_URL_ROOT . '/societe/card.php?action=create&backtopage=' . urlencode($_SERVER["PHP_SELF"] . '?action=create') . '" target="_blank"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans("AddThirdParty") . '"></span></a>';
 	print '<a href="' . DOL_URL_ROOT . '/custom/digiriskdolibarr/admin/securityconf.php' . '" target="_blank">' . $langs->trans("ConfigureLabourInspector") . '</a>';
 	print '</td></tr>';
 
-	$labourInspectorContact = ! empty($digiriskresources->fetchResourcesFromObject('LabourInspectorAssigned', $object)) ? $digiriskresources->fetchResourcesFromObject('LabourInspectorAssigned', $object) : GETPOST('labour_inspector_contact');
+	// A defaut de ressource enregistree, le contact vient du formulaire : c'est un identifiant,
+	// pas un objet, d'ou la lecture de l'identifiant plutot que de la propriete
+	$labourInspectorContact   = $digiriskresources->fetchSingleResourceFromObject('LabourInspectorAssigned', $object);
+	$labourInspectorContactId = $labourInspectorContact !== null ? $labourInspectorContact->id : GETPOSTINT('labour_inspector_contact');
 
-	if ($labourInspectorContact->id > 0) {
-		$contact->fetch($labourInspectorContact->id);
+	if ($labourInspectorContactId > 0) {
+		$contact->fetch($labourInspectorContactId);
 	}
 
 	//Labour inspector -- Inspecteur du travail
-	$labourInspectorSociety = $digiriskresources->fetchResourcesFromObject('LabourInspector', $object);
+	$labourInspectorSociety   = $digiriskresources->fetchSingleResourceFromObject('LabourInspector', $object);
+	$labourInspectorSocietyId = $labourInspectorSociety !== null ? $labourInspectorSociety->id : -1;
 	print '<tr><td class="fieldrequired minwidth400">';
 	$htmltext = img_picto('', 'address') . ' ' . $langs->trans("LabourInspector");
 	print $htmltext;
 	print '</td><td>';
-	print $form->selectcontacts($labourInspectorSociety->id, dol_strlen($contact->email) ? $labourInspectorContact->id : -1, 'labour_inspector_contact', '', 0, '', 1, 'minwidth100imp widthcentpercentminusxx maxwidth400');
+	print $form->selectcontacts($labourInspectorSocietyId, dol_strlen($contact->email) ? $labourInspectorContactId : -1, 'labour_inspector_contact', '', 0, '', 1, 'minwidth100imp widthcentpercentminusxx maxwidth400');
 	print '</td></tr>';
 
 	//FK PREVENTION PLAN
@@ -976,8 +993,14 @@ if ((empty($action) || ($action != 'create' && $action != 'edit'))) {
 	saturne_get_fiche_head($object, 'card', $title);
 
     // External Society -- Société extérieure
-    $extSociety  = $digiriskresources->fetchResourcesFromObject('ExtSociety', $object);
-    $moreHtmlRef = $langs->trans('ExtSociety') . ' : ' . $extSociety->getNomUrl(1) . '<br>';
+    $extSociety  = $digiriskresources->fetchSingleResourceFromObject('ExtSociety', $object);
+    $moreHtmlRef = $langs->trans('ExtSociety') . ' : ' . ($extSociety !== null ? $extSociety->getNomUrl(1) : $langs->trans('None')) . '<br>';
+
+	if ($conf->browser->layout == 'phone') {
+		$onPhone = 1;
+	} else {
+		$onPhone = 0;
+	}
 
 	saturne_banner_tab($object, 'id', '', 1, 'rowid', 'ref', $moreHtmlRef);
 
@@ -1032,8 +1055,8 @@ if ((empty($action) || ($action != 'create' && $action != 'edit'))) {
 	print $langs->trans("LabourInspectorSociety");
 	print '</td>';
 	print '<td>';
-	$labourInspector = $digiriskresources->fetchResourcesFromObject('LabourInspector', $object);
-	if ($labourInspector > 0) {
+	$labourInspector = $digiriskresources->fetchSingleResourceFromObject('LabourInspector', $object);
+	if ($labourInspector !== null) {
 		print $labourInspector->getNomUrl(1);
 	}
 	print '</td></tr>';
@@ -1043,8 +1066,8 @@ if ((empty($action) || ($action != 'create' && $action != 'edit'))) {
 	print $langs->trans("LabourInspector");
 	print '</td>';
 	print '<td>';
-	$labourInspectorContact = $digiriskresources->fetchResourcesFromObject('LabourInspectorAssigned', $object);
-	if ($labourInspectorContact > 0) {
+	$labourInspectorContact = $digiriskresources->fetchSingleResourceFromObject('LabourInspectorAssigned', $object);
+	if ($labourInspectorContact !== null) {
 		print $labourInspectorContact->getNomUrl(1);
 	}
 	print '</td></tr>';
@@ -1192,12 +1215,10 @@ if ((empty($action) || ($action != 'create' && $action != 'edit'))) {
 					print $digiriskelement->getNomUrl(1, 'blank', 0, '', -1, 1);
 					print '</td>';
 
-					$coldisplay++;
 					print '<td>';
 					print $item->description;
 					print '</td>';
 
-					$coldisplay++;
 					print '<td class="center">'; ?>
 					<div class="table-cell table-50 cell-risk" data-title="Risque">
 						<div class="wpeo-dropdown dropdown-large category-danger padding wpeo-tooltip-event"
@@ -1210,12 +1231,10 @@ if ((empty($action) || ($action != 'create' && $action != 'edit'))) {
 					<?php
 					print '</td>';
 
-					$coldisplay++;
 					print '<td>';
 					print $item->prevention_method;
 					print '</td>';
 
-					$coldisplay += $colspan;
 
 					print '<td class="center">';
 					print '-';
@@ -1297,12 +1316,10 @@ if ((empty($action) || ($action != 'create' && $action != 'edit'))) {
 					print $digiriskelementtmp->selectDigiriskElementList($item->fk_element, 'fk_element', ['customsql' => ' t.rowid NOT IN (' . implode(',', $deletedElements) . ')'], 0, 0,[], 0, 0, 'minwidth200 maxwidth300', 0, false, 1);
 					print '</td>';
 
-					$coldisplay++;
 					print '<td>';
 					print '<textarea name="actionsdescription" class="minwidth150" cols="50" rows="' . ROWS_2 . '">' . $item->description . '</textarea>' . "\n";
 					print '</td>';
 
-					$coldisplay++;
 					print '<td  class="center">'; ?>
 					<div class="wpeo-dropdown dropdown-large dropdown-grid category-danger padding">
 						<div class="dropdown-toggle dropdown-add-button button-cotation">
@@ -1335,12 +1352,10 @@ if ((empty($action) || ($action != 'create' && $action != 'edit'))) {
 					<?php
 					print '</td>';
 
-					$coldisplay++;
 					print '<td>';
 					print '<textarea name="used_equipment" class="minwidth150" cols="50" rows="' . ROWS_2 . '">' . $item->used_equipment . '</textarea>' . "\n";
 					print '</td>';
 
-					$coldisplay += $colspan;
 					print '<td class="center" colspan="' . $colspan . '">';
 					print '<input type="submit" class="button" value="' . $langs->trans('Save') . '" name="updateLine" id="updateLine">';
 					print ' &nbsp; <input type="submit" id ="cancelLine" class="button" name="cancelLine" value="' . $langs->trans("Cancel") . '">';
@@ -1361,12 +1376,10 @@ if ((empty($action) || ($action != 'create' && $action != 'edit'))) {
 					print $digiriskelement->getNomUrl(1, 'blank', 0, '', -1, 1);
 					print '</td>';
 
-					$coldisplay++;
 					print '<td>';
 					print $item->description;
 					print '</td>';
 
-					$coldisplay++;
 					print '<td class="center">'; ?>
 					<div class="table-cell table-50 cell-risk" data-title="Risque">
 						<div class="wpeo-dropdown dropdown-large category-danger padding wpeo-tooltip-event"
@@ -1379,17 +1392,14 @@ if ((empty($action) || ($action != 'create' && $action != 'edit'))) {
 					<?php
 					print '</td>';
 
-					$coldisplay++;
 					print '<td>';
 					print $item->used_equipment;
 					print '</td>';
 
-					$coldisplay += $colspan;
 
 					//Actions buttons
 					if ($object->status == 1) {
 						print '<td class="center">';
-						$coldisplay++;
 						print '<a href="' . $_SERVER["PHP_SELF"] . '?id=' . $id . '&action=editline&lineid=' . $item->id . '" style="padding-right: 20px"><i class="fas fa-pencil-alt" style="color: #666"></i></a>';
 						print '<a href="' . $_SERVER["PHP_SELF"] . '?id=' . $id . '&action=deleteline&lineid=' . $item->id . '&token=' . newToken() . '">';
 						print img_delete();
@@ -1424,12 +1434,10 @@ if ((empty($action) || ($action != 'create' && $action != 'edit'))) {
 			print $digiriskelementtmp->selectDigiriskElementList('', 'fk_element', ['customsql' => ' t.rowid NOT IN (' . implode(',', $deletedElements) . ')'], 0, 0, array(), 0, 0, 'minwidth200 maxwidth300', 0, false, 1);
 			print '</td>';
 
-			$coldisplay++;
 			print '<td>';
 			print '<textarea name="actionsdescription" class="minwidth150" cols="50" rows="' . ROWS_2 . '">' . ('') . '</textarea>' . "\n";
 			print '</td>';
 
-			$coldisplay++;
 			print '<td class="center">'; ?>
 			<div class="wpeo-dropdown dropdown-large dropdown-grid category-danger padding">
 				<input class="input-hidden-danger" type="hidden" name="risk_category_id" value="undefined"/>
@@ -1458,12 +1466,10 @@ if ((empty($action) || ($action != 'create' && $action != 'edit'))) {
 			<?php
 			print '</td>';
 
-			$coldisplay++;
 			print '<td>';
 			print '<textarea name="used_equipment" class="minwidth150" cols="50" rows="' . ROWS_2 . '">' . ('') . '</textarea>' . "\n";
 			print '</td>';
 
-			$coldisplay += $colspan;
 			print '<td class="center" colspan="' . $colspan . '">';
 			print '<input type="submit" class="button" value="' . $langs->trans('Add') . '" name="addline" id="addline">';
 			print '</td>';
@@ -1527,10 +1533,12 @@ if ((empty($action) || ($action != 'create' && $action != 'edit'))) {
 	print '</div></div></div>';
 
 	// Presend form
-	$labourInspector   = $digiriskresources->fetchResourcesFromObject('LabourInspector', $object);
-	$labourInspectorId = $labourInspector->id;
-	$thirdparty->fetch($labourInspectorId);
-	$object->thirdparty = $thirdparty;
+	$labourInspector   = $digiriskresources->fetchSingleResourceFromObject('LabourInspector', $object);
+	$labourInspectorId = $labourInspector !== null ? $labourInspector->id : 0;
+	if ($labourInspectorId > 0) {
+		$thirdparty->fetch($labourInspectorId);
+		$object->thirdparty = $thirdparty;
+	}
 
 	$modelmail    = 'firepermit';
 	$defaulttopic = 'Information';
@@ -1601,7 +1609,7 @@ if ((empty($action) || ($action != 'create' && $action != 'edit'))) {
         // Fill list of recipient with email inside <>.
         $liste = [];
 
-        $labourInspectorContact = $digiriskresources->fetchResourcesFromObject('LabourInspectorAssigned', $object);
+        $labourInspectorContact = $digiriskresources->fetchSingleResourceFromObject('LabourInspectorAssigned', $object);
 
         if (!empty($conf->global->MAIN_MAIL_ENABLED_USER_DEST_SELECT)) {
             $listeuser = [];
@@ -1628,7 +1636,7 @@ if ((empty($action) || ($action != 'create' && $action != 'edit'))) {
             }
         }
 
-        if (!array_key_exists($labourInspectorContact->id, $liste)) {
+        if (is_object($labourInspectorContact) && !empty($labourInspectorContact->id) && !array_key_exists($labourInspectorContact->id, $liste)) {
             $liste[$labourInspectorContact->id] = $labourInspectorContact->firstname . ' ' . $labourInspectorContact->lastname . (!empty($labourInspectorContact->email) ? ' <' . $labourInspectorContact->email . '>' : '');
         }
 

--- a/view/firepermit/firepermit_list.php
+++ b/view/firepermit/firepermit_list.php
@@ -478,12 +478,15 @@ while ($i < ($limit ? min($num, $limit) : $num)) {
 						$element = $signatory->fetchSignatory('MasterWorker', $object->id, 'firepermit');
 						if (is_array($element)) {
 							$element = array_shift($element);
-							$usertmp->fetch($element->element_id);
-							print $usertmp->getNomUrl(1);
+							// array_shift() rend null quand la liste est vide : le signataire peut manquer
+							if (is_object($element)) {
+								$usertmp->fetch($element->element_id);
+								print $usertmp->getNomUrl(1);
+							}
 						}
 					} elseif ($resource['label'] == 'ExtSociety') {
-						$extSociety = $digiriskresources->fetchResourcesFromObject('ExtSociety', $object);
-						if ($extSociety > 0) {
+						$extSociety = $digiriskresources->fetchSingleResourceFromObject('ExtSociety', $object);
+						if ($extSociety !== null) {
 							print $extSociety->getNomUrl(1);
 						}
 					}
@@ -491,8 +494,11 @@ while ($i < ($limit ? min($num, $limit) : $num)) {
 						$element = $signatory->fetchSignatory('ExtSocietyResponsible', $object->id, 'firepermit');
 						if (is_array($element)) {
 							$element = array_shift($element);
-							$contact->fetch($element->element_id);
-							print $contact->getNomUrl(1);
+							// array_shift() rend null quand la liste est vide : le signataire peut manquer
+							if (is_object($element)) {
+								$contact->fetch($element->element_id);
+								print $contact->getNomUrl(1);
+							}
 						}
 					}
 					if ($resource['label'] == 'ExtSocietyAttendant') {

--- a/view/preventionplan/preventionplan_card.php
+++ b/view/preventionplan/preventionplan_card.php
@@ -884,8 +884,16 @@ if (($id || $ref) && $action == 'edit') {
 
 	print dol_get_fiche_head();
 
+	// Sans ressource liee, fetchResourcesFromObject() rend l'entier 0 : le normaliser en tableau
+	// evite un avertissement a chaque lecture de cle ci-dessous
 	$objectResources   = $digiriskresources->fetchResourcesFromObject('', $object);
+	if (!is_array($objectResources)) {
+		$objectResources = [];
+	}
 	$objectSignatories = $signatory->fetchSignatory('', $object->id, 'preventionplan');
+	if (!is_array($objectSignatories)) {
+		$objectSignatories = [];
+	}
 
 	print '<table class="border centpercent tableforfieldedit  preventionplan-table">' . "\n";
 
@@ -915,7 +923,7 @@ if (($id || $ref) && $action == 'edit') {
 	print '</td></tr>';
 
 	//Maitre d'oeuvre
-	$masterWorker  = is_array($objectSignatories['MasterWorker']) ? array_shift($objectSignatories['MasterWorker'])->element_id : '';
+	$masterWorker  = is_array($objectSignatories['MasterWorker'] ?? null) ? array_shift($objectSignatories['MasterWorker'])->element_id : '';
 	$userlist      = $form->select_dolusers($masterWorker, '', 1, null, 0, '', '', 0, 0, 0, '(u.statut:=:1)', 0, '', 'minwidth100imp widthcentpercentminusxx maxwidth400', 0, 1);
 	print '<tr>';
 	print '<td class="fieldrequired minwidth400" style="width:10%">' . img_picto('', 'user') . ' ' . $form->editfieldkey('MasterWorker', 'MasterWorker_id', '', $object, 0) . '</td>';
@@ -935,25 +943,26 @@ if (($id || $ref) && $action == 'edit') {
 	if ( ! empty($user->socid)) {
 		print $form->select_company($user->socid, 'ext_society', '', 1, 1, 0, $events, 0, 'minwidth100imp widthcentpercentminusxx maxwidth400');
 	} else {
-		$extSocietyId = is_array($objectResources['ExtSociety']) ? array_shift($objectResources['ExtSociety'])->id : '';
+		$extSocietyId = is_array($objectResources['ExtSociety'] ?? null) ? array_shift($objectResources['ExtSociety'])->id : '';
 		print $form->select_company($extSocietyId, 'ext_society', '', 'SelectThirdParty', 1, 0, $events, 0, 'minwidth100imp widthcentpercentminusxx maxwidth400');
 	}
 	print ' <a href="' . DOL_URL_ROOT . '/societe/card.php?action=create&backtopage=' . urlencode($_SERVER["PHP_SELF"] . '?action=create') . '" target="_blank"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans("AddThirdParty") . '"></span></a>';
 	print '</td></tr>';
-	$extSocietyResponsibleId = is_array($objectSignatories['ExtSocietyResponsible']) ? array_shift($objectSignatories['ExtSocietyResponsible'])->element_id : GETPOST('ext_society_responsible');
+	$extSocietyResponsibleId = is_array($objectSignatories['ExtSocietyResponsible'] ?? null) ? array_shift($objectSignatories['ExtSocietyResponsible'])->element_id : GETPOST('ext_society_responsible');
 
 	if ($extSocietyResponsibleId > 0) {
 		$contact->fetch($extSocietyResponsibleId);
 	}
 
 	//External responsible -- Responsable de la société extérieure
-	$extSociety = $digiriskresources->fetchResourcesFromObject('ExtSociety', $object);
+	$extSociety   = $digiriskresources->fetchSingleResourceFromObject('ExtSociety', $object);
+	$extSocietyId = $extSociety !== null ? $extSociety->id : 0;
 	print '<tr class="oddeven"><td class="fieldrequired minwidth400">';
 	$htmltext = img_picto('', 'address') . ' ' . $langs->trans("ExtSocietyResponsible");
 	print $htmltext;
 	print '</td><td>';
-	print $form->selectcontacts($extSociety->id, dol_strlen($contact->email) ? $extSocietyResponsibleId : -1, 'ext_society_responsible', '', 0, '', 1, 'minwidth100imp widthcentpercentminusxx maxwidth400');
-    print '<a href="' . DOL_URL_ROOT . '/contact/card.php?action=create' . (empty($extSociety->id) ? '' : '&socid=' . $extSociety->id) .'&backtopage=' . urlencode($_SERVER["PHP_SELF"] . '?action=create&ext_society='. (empty($extSociety->id) ? '' : $extSociety->id)) . '" target="_blank"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans("AddContact") . '"></span></a>';
+	print $form->selectcontacts($extSocietyId, dol_strlen($contact->email) ? $extSocietyResponsibleId : -1, 'ext_society_responsible', '', 0, '', 1, 'minwidth100imp widthcentpercentminusxx maxwidth400');
+    print '<a href="' . DOL_URL_ROOT . '/contact/card.php?action=create' . (empty($extSocietyId) ? '' : '&socid=' . $extSocietyId) .'&backtopage=' . urlencode($_SERVER["PHP_SELF"] . '?action=create&ext_society='. (empty($extSocietyId) ? '' : $extSocietyId)) . '" target="_blank"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans("AddContact") . '"></span></a>';
     print '</td></tr>';
 
 	// CSSCT Intervention
@@ -986,10 +995,14 @@ if (($id || $ref) && $action == 'edit') {
 	$doleditor->Create();
 	print '</td></tr>';
 
-	if (is_array($objectResources['LabourInspector']) && $objectResources['LabourInspector'] > 0) {
+	// Les deux ressources ne sont pas toujours renseignees : les initialiser evite de lire une
+	// propriete sur une variable inexistante dans les selecteurs ci-dessous
+	$labourInspectorSociety   = null;
+	$labourInspector_assigned = null;
+	if (is_array($objectResources['LabourInspector'] ?? null) && !empty($objectResources['LabourInspector'])) {
 		$labourInspectorSociety = array_shift($objectResources['LabourInspector']);
 	}
-	if (is_array($objectResources['LabourInspectorAssigned']) && $objectResources['LabourInspectorAssigned'] > 0) {
+	if (is_array($objectResources['LabourInspectorAssigned'] ?? null) && !empty($objectResources['LabourInspectorAssigned'])) {
 		$labourInspector_assigned = array_shift($objectResources['LabourInspectorAssigned']);
 	}
 	//Labour inspector Society -- Entreprise Inspecteur du travail
@@ -999,20 +1012,24 @@ if (($id || $ref) && $action == 'edit') {
 	print '<td>';
 	$events    = array();
 	$events[1] = array('method' => 'getContacts', 'url' => dol_buildpath('/custom/digiriskdolibarr/core/ajax/contacts.php?showempty=1', 1), 'htmlname' => 'labour_inspector_contact', 'params' => array('add-customer-contact' => 'disabled'));
-	print $form->select_company($labourInspectorSociety->id, 'labour_inspector', '', 'SelectThirdParty', 1, 0, $events, 0, 'minwidth100imp widthcentpercentminusxx maxwidth400');
+	print $form->select_company($labourInspectorSociety !== null ? $labourInspectorSociety->id : '', 'labour_inspector', '', 'SelectThirdParty', 1, 0, $events, 0, 'minwidth100imp widthcentpercentminusxx maxwidth400');
 	print ' <a href="' . DOL_URL_ROOT . '/societe/card.php?action=create&backtopage=' . urlencode($_SERVER["PHP_SELF"] . '?action=create') . '" target="_blank"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans("AddThirdParty") . '"></span></a>';
 	print '<a href="' . DOL_URL_ROOT . '/custom/digiriskdolibarr/admin/securityconf.php' . '" target="_blank">' . $langs->trans("ConfigureLabourInspector") . '</a>';
 	print '</td></tr>';
 
-	$labourInspectorContact = ! empty($digiriskresources->fetchResourcesFromObject('LabourInspectorAssigned', $object)) ? $digiriskresources->fetchResourcesFromObject('LabourInspectorAssigned', $object) : GETPOST('labour_inspector_contact');
+	// A defaut de ressource enregistree, le contact vient du formulaire : c'est un identifiant,
+	// pas un objet, d'ou la lecture de l'identifiant plutot que de la propriete
+	$labourInspectorContact   = $digiriskresources->fetchSingleResourceFromObject('LabourInspectorAssigned', $object);
+	$labourInspectorContactId = $labourInspectorContact !== null ? $labourInspectorContact->id : GETPOSTINT('labour_inspector_contact');
 
 	//Labour inspector -- Inspecteur du travail
-	$labourInspectorSociety = $digiriskresources->fetchResourcesFromObject('LabourInspector', $object);
+	$labourInspectorSociety   = $digiriskresources->fetchSingleResourceFromObject('LabourInspector', $object);
+	$labourInspectorSocietyId = $labourInspectorSociety !== null ? $labourInspectorSociety->id : -1;
 	print '<tr><td class="fieldrequired minwidth400">';
 	$htmltext = img_picto('', 'address') . ' ' . $langs->trans("LabourInspector");
 	print $htmltext;
 	print '</td><td>';
-	print $form->selectcontacts($labourInspectorSociety->id, dol_strlen($contact->email) ? $labourInspectorContact->id : -1, 'labour_inspector_contact', '', 0, '', 1, 'minwidth100imp widthcentpercentminusxx maxwidth400');
+	print $form->selectcontacts($labourInspectorSocietyId, dol_strlen($contact->email) ? $labourInspectorContactId : -1, 'labour_inspector_contact', '', 0, '', 1, 'minwidth100imp widthcentpercentminusxx maxwidth400');
 	print '</td></tr>';
 
     // Tags-Categories
@@ -1104,8 +1121,8 @@ if ((empty($action) || ($action != 'create' && $action != 'edit'))) {
 	saturne_get_fiche_head($object, 'card', $title);
 
     // External Society -- Société extérieure
-    $extSociety  = $digiriskresources->fetchResourcesFromObject('ExtSociety', $object);
-    $moreHtmlRef = $langs->trans('ExtSociety') . ' : ' . $extSociety->getNomUrl(1) . '<br>';
+    $extSociety  = $digiriskresources->fetchSingleResourceFromObject('ExtSociety', $object);
+    $moreHtmlRef = $langs->trans('ExtSociety') . ' : ' . ($extSociety !== null ? $extSociety->getNomUrl(1) : $langs->trans('None')) . '<br>';
 
 	if ($conf->browser->layout == 'phone') {
 		$onPhone = 1;
@@ -1187,8 +1204,8 @@ if ((empty($action) || ($action != 'create' && $action != 'edit'))) {
 	print $langs->trans("LabourInspectorSociety");
 	print '</td>';
 	print '<td>';
-	$labourInspector = $digiriskresources->fetchResourcesFromObject('LabourInspector', $object);
-	if ($labourInspector > 0) {
+	$labourInspector = $digiriskresources->fetchSingleResourceFromObject('LabourInspector', $object);
+	if ($labourInspector !== null) {
 		print $labourInspector->getNomUrl(1);
 	}
 	print '</td></tr>';
@@ -1198,8 +1215,8 @@ if ((empty($action) || ($action != 'create' && $action != 'edit'))) {
 	print $langs->trans("LabourInspector");
 	print '</td>';
 	print '<td>';
-	$labourInspectorContact = $digiriskresources->fetchResourcesFromObject('LabourInspectorAssigned', $object);
-	if ($labourInspectorContact > 0) {
+	$labourInspectorContact = $digiriskresources->fetchSingleResourceFromObject('LabourInspectorAssigned', $object);
+	if ($labourInspectorContact !== null) {
 		print $labourInspectorContact->getNomUrl(1);
 	}
 	print '</td></tr>';
@@ -1873,7 +1890,7 @@ print '<input type="hidden" name="fk_element" value="0">';
         // Fill list of recipient with email inside <>.
         $liste = [];
 
-        $labourInspectorContact = $digiriskresources->fetchResourcesFromObject('LabourInspectorAssigned', $object);
+        $labourInspectorContact = $digiriskresources->fetchSingleResourceFromObject('LabourInspectorAssigned', $object);
 
         if (!empty($conf->global->MAIN_MAIL_ENABLED_USER_DEST_SELECT)) {
             $listeuser = [];

--- a/view/preventionplan/preventionplan_list.php
+++ b/view/preventionplan/preventionplan_list.php
@@ -526,12 +526,15 @@ while ($i < ($limit ? min($num, $limit) : $num)) {
 						$element = $signatory->fetchSignatory('MasterWorker', $object->id, 'preventionplan');
 						if (is_array($element) && !empty($element)) {
 							$element = array_shift($element);
-							$usertmp->fetch($element->element_id);
-							print $usertmp->getNomUrl(1);
+							// array_shift() rend null quand la liste est vide : le signataire peut manquer
+							if (is_object($element)) {
+								$usertmp->fetch($element->element_id);
+								print $usertmp->getNomUrl(1);
+							}
 						}
 					} elseif ($resource['label'] == 'ExtSociety') {
-						$extSociety = $digiriskresources->fetchResourcesFromObject('ExtSociety', $object);
-						if ($extSociety > 0) {
+						$extSociety = $digiriskresources->fetchSingleResourceFromObject('ExtSociety', $object);
+						if ($extSociety !== null) {
 							print $extSociety->getNomUrl(1);
 						}
 					}
@@ -539,8 +542,11 @@ while ($i < ($limit ? min($num, $limit) : $num)) {
 						$element = $signatory->fetchSignatory('ExtSocietyResponsible', $object->id, 'preventionplan');
 						if (is_array($element) && !empty($element)) {
 							$element = array_shift($element);
-							$contact->fetch($element->element_id);
-							print $contact->getNomUrl(1);
+							// array_shift() rend null quand la liste est vide : le signataire peut manquer
+							if (is_object($element)) {
+								$contact->fetch($element->element_id);
+								print $contact->getNomUrl(1);
+							}
 						}
 					}
 					if ($resource['label'] == 'ExtSocietyAttendant') {


### PR DESCRIPTION
Closes #5083

## Le problème

`DigiriskResources::fetchResourcesFromObject()` a un retour polymorphe : l'objet résolu pour une seule ligne, un tableau à deux niveaux pour plusieurs, l'entier `0` quand il n'y en a aucune, `-1` sur erreur. Trois appelants le déréférençaient directement :

```php
$extSociety  = $digiriskresources->fetchResourcesFromObject('ExtSociety', $object);
$moreHtmlRef = $langs->trans('ExtSociety') . ' : ' . $extSociety->getNomUrl(1) . '<br>';
```

Dès que la ressource n'est pas renseignée, `Call to a member function getNomUrl() on int` : **la fiche entière ne s'affiche plus**. Reproduit sur un permis de feu réel créé sans société extérieure, pas seulement sur un identifiant inexistant.

## Le correctif

Nouvelle méthode `fetchSingleResourceFromObject()`, qui rend toujours un objet ou `null`, sur le modèle de `fetchResourcesIdsFromObject()` ajoutée en #4715. Les fiches et listes permis de feu et plan de prévention, ainsi que le hook de bannière, passent par elle.

Corrigé dans la foulée, même origine :

- les gardes existantes testaient ce retour **numériquement** (`if ($extSociety > 0)`), ce qui émet en PHP 8 `Notice: Object of class Societe could not be converted to int` dès que la ressource existe ;
- `$objectResources` et `$objectSignatories` sont lus par clé dans le formulaire d'édition sans vérifier que ce sont bien des tableaux ;
- `$labourInspectorSociety` n'était définie que dans un `if`, mais lue inconditionnellement par le sélecteur de société ;
- `array_shift()` rend `null` sur une liste vide, avant lecture de `->element_id` dans les deux listes.

## Tests

`display_errors` actif, sur un permis de feu **sans aucune ressource liée** et sur un plan de prévention dont **toutes** les ressources sont renseignées :

| Page | Avant | Après |
|---|---|---|
| Fiche permis de feu | **Fatal error** | RAS |
| Fiche permis de feu, édition | 6 warnings | RAS |
| Liste permis de feu | 2 warnings | RAS |
| Fiche plan de prévention (+ édition, liste) | RAS | RAS |

Non-régression sur les données complètes : bannière, corps de fiche, les quatre sélecteurs du formulaire d'édition (`ext_society`, `ext_society_responsible`, `labour_inspector`, `labour_inspector_contact`) et la liste rendent **exactement le même contenu** qu'avant le correctif.

Hors périmètre, toujours présent : `firepermit_card.php` avec un identifiant inexistant part en `FirePermit::LibStatut(): Argument #1 ($status) must be of type int, null given` — l'objet n'est pas chargé et la page continue quand même. C'est un contrôle d'existence manquant, pas le retour des ressources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)