### PR TITLE
#5073 [i18n] add: complete en_US and seven new language files

### DIFF
--- a/langs/de_DE/digiriskdolibarr.lang
+++ b/langs/de_DE/digiriskdolibarr.lang
@@ -1,0 +1,2387 @@
+# Copyright (C) 2021-2023 EVARISK <technique@evarisk.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#
+# Allgemein
+#
+
+# Module label 'ModuleDigiriskdolibarrName'
+ModuleDigiriskdolibarrName = Digirisk
+
+# Module description 'ModuleDigiriskdolibarrDesc'
+ModuleDigiriskdolibarrDesc = Digirisk für Dolibarr
+
+# Fehlendes Saturne-Modul
+SaturneModuleMissing = Das Modul Saturne wird von Digirisk benötigt. Laden Sie es kostenlos im Dolistore (https://dolistore.com/en/modules/1906-Saturne.html) herunter und installieren Sie es, bevor Sie Digirisk aktivieren.
+
+# Spalte der Tutorial-Bilder auf den Konfigurationsseiten
+TutoImage = Bild
+
+#
+# Administrationsseite
+#
+
+# Daten
+DigiriskdolibarrSetup       = Konfiguration des Moduls Digirisk
+DigiriskdolibarrSetupPage        = Konfigurationsseite des Moduls Digirisk
+AgendaModuleRequired        = Um die Nachvollziehbarkeit der Aktionen in Digirisk zu gewährleisten, stellen Sie sicher, dass das Modul Termine aktiviert ist
+DigiriskDolibarrDescription = Digirisk für Dolibarr
+HowToSetupOtherModules      = Für weitere Funktionen in Digirisk können Sie zahlreiche Module aktivieren (Lieferantenverwaltung, Rechnungen usw.) über diesen Link:
+ConfigMyModules             = Konfiguration der Module
+AvoidLogoProblems              = Um Probleme mit Logos in den erzeugten Dokumenten zu vermeiden, beachten Sie bitte diese Konfigurationshinweise:
+LogoHelpLink                = https://wiki.dolibarr.org/index.php?title=Premiers_paramétrages
+SecurityConfiguration       = Konfiguration der Sicherheitsdaten
+SocialConfiguration          = Konfiguration der Sozialdaten
+Uncompleted                     = Nicht ausgefüllt
+DigiriskData                 = Konfigurierbare Daten von Digirisk
+DigiriskManagement          = Weiterleitung nach der Anmeldung
+DigiriskDescription          = Standardmäßig auf die Digirisk-Startseite weiterleiten statt auf die von Dolibarr.
+HowToSetupIHM                   = Für weitere Möglichkeiten zur Darstellung von Dolibarr (Konfiguration des Hintergrundbilds usw.) können Sie diesen Link aufrufen:
+ConfigIHM                    = Konfiguration der Darstellung
+ConfigDico                     = Zur Konfigurationsseite der Wörterbücher wechseln
+LinkedProject               = Verknüpftes Projekt
+DigiriskUpdate                  = Aktualisierung von Digirisk:
+Security                       = Sicherheit
+HowToSharedElement          = Weitere Informationen zur Konfiguration der geteilten Elemente finden Sie unter diesem Link:
+
+HowToSharedElementLink        = https://wiki.dolibarr.org/index.php?title=Module_Digirisk#Configuration
+ConfigSharedElement         = Konfiguration der geteilten Elemente (Risiken/Kennzeichnungen)
+DisabledSharedElement       = Option deaktiviert, weil Multi-Company nicht aktiviert ist oder die Konfiguration der geteilten Elemente (Risiken/Kennzeichnungen) nicht durchgeführt wurde
+DigiriskEventAutoDesc       = Legen Sie hier die Ereignisse fest, für die Digirisk automatisch einen Eintrag im Kalender erstellt. Jedes Ereignis enthält die Informationen zur durchgeführten Aktion.
+DigiriskActionsEvents       = Ereignisse, für die Digirisk automatisch einen Eintrag im Kalender anlegen soll.
+DigiriskDolibarr            = Digirisk
+Create                      = Anlegen
+
+# Ticket
+MultiCompanyTicketPublicInterfaceConfig = Konfiguration der öffentlichen Ticket-Schnittstelle für mehrere Mandanten
+Subtitle                                = Untertitel
+
+# DigiriskElement
+DigiriskElementDepthGraph            = Tiefe in den Diagrammen der Digirisk-Elemente
+DigiriskElementDepthGraphDescription = Diese Option legt die Tiefe in den Diagrammen der Digirisk-Elemente fest <br> Standard: Stufe 1
+
+# WHSRegister = Arbeitsschutzregister
+TicketsPublicInterfaceConfig         = Konfiguration der öffentlichen Ticket-Schnittstelle
+WHSRegister                          = Arbeitsschutzregister
+CurrentTicketPublicInterfaceURL      = URL der öffentlichen Ticket-Schnittstelle
+MulticompanyTicketPublicInterfaceURL = URL der öffentlichen Ticket-Schnittstelle für mehrere Mandanten
+OriginURL                            = Ursprungs-URL
+ShortURL                             = Kurz-URL
+ExternalURL                          = Externe URL
+AddExtraField                        = Zusatzfeld anlegen
+IfEmptyVisibleAllCategories          = Wenn leer, in allen Kategorien sichtbar
+
+# DigiQuali Sheet - Vorlagen
+LinkDigiriskdolibarr_digiriskstandard                 = Verknüpfung mit den Hauptentitäten von Digirisk Standard aktivieren
+LinkDigiriskdolibarr_digiriskstandardDescription      = Ermöglicht die Verknüpfung der Digirisk-Standardentitäten mit den Vorlagen
+LinkDigiriskdolibarr_digiriskelement                  = Verknüpfung mit den Gruppierungen und Arbeitseinheiten aktivieren
+LinkDigiriskdolibarr_digiriskelementDescription       = Ermöglicht die Verknüpfung der Gruppierungen und Arbeitseinheiten mit den Vorlagen
+LinkDigiriskdolibarr_risk                             = Verknüpfung mit den Risiken aktivieren
+LinkDigiriskdolibarr_riskDescription                  = Ermöglicht die Verknüpfung der Risiken mit den Vorlagen
+LinkDigiriskdolibarr_riskassessment                   = Verknüpfung mit den Bewertungen aktivieren
+LinkDigiriskdolibarr_riskassessmentDescription        = Ermöglicht die Verknüpfung der Bewertungen mit den Vorlagen
+LinkDigiriskdolibarr_evaluator                        = Verknüpfung mit den Bewertern aktivieren
+LinkDigiriskdolibarr_evaluatorDescription             = Ermöglicht die Verknüpfung der Bewerter mit den Vorlagen
+LinkDigiriskdolibarr_risksign                         = Verknüpfung mit den Kennzeichnungen aktivieren
+LinkDigiriskdolibarr_risksignDescription              = Ermöglicht die Verknüpfung der Kennzeichnungen mit den Vorlagen
+LinkDigiriskdolibarr_preventionplan                   = Verknüpfung mit den Präventionsplänen aktivieren
+LinkDigiriskdolibarr_preventionplanDescription        = Ermöglicht die Verknüpfung der Präventionspläne mit den Vorlagen
+LinkDigiriskdolibarr_firepermit                       = Verknüpfung mit den Feuererlaubnisscheinen aktivieren
+LinkDigiriskdolibarr_firepermitDescription            = Ermöglicht die Verknüpfung der Feuererlaubnisscheine mit den Vorlagen
+LinkDigiriskdolibarr_accident                         = Verknüpfung mit den Unfällen aktivieren
+LinkDigiriskdolibarr_accidentDescription              = Ermöglicht die Verknüpfung der Unfälle mit den Vorlagen
+LinkDigiriskdolibarr_accidentinvestigation            = Verknüpfung mit den Unfalluntersuchungen aktivieren
+LinkDigiriskdolibarr_accidentinvestigationDescription = Ermöglicht die Verknüpfung der Untersuchungen mit den Vorlagen
+
+#
+# DigiriskDolibarr
+#
+
+# Berechtigung
+LireDigirisk                 = Digirisk-Übersicht einsehen
+ReadDigirisk                 = Digirisk-Übersicht einsehen (Lesen)
+YouDontHaveTheRightToSeeThis = Sie haben keine Berechtigung, die Gruppierungen und Arbeitseinheiten zu sehen
+CanNotDoThis                 = Sie haben keine Berechtigung, dies zu tun
+EnableDigiriskdolibarr       = Bitte aktivieren Sie das Modul DigiriskDolibarr, um auf diese Seite zuzugreifen
+
+# Daten
+DigiriskMenu          = Fügen Sie Informationen zu Ihrem Unternehmen/Ihrer Organisation hinzu. Klicken Sie unten auf der Seite auf "Speichern", um sie zu sichern
+DigiriskConfigSociety = Konfiguration des Unternehmens
+PermissionDenied      = Zugriff verweigert
+AddUser               = Benutzer anlegen
+StartDate             = Startdatum
+EndDate               = Enddatum
+NoPhoneNumber         = Keine Telefonnummer
+HasBeenCreatedF       = wurde angelegt
+HasBeenCreatedM       = wurde angelegt
+HasNotBeenCreatedF    = wurde nicht angelegt
+HasNotBeenCreatedM    = wurde nicht angelegt
+YourDocuments         = Dokumente
+NoData                = k. A.
+HasBeenEditedF        = wurde bearbeitet
+HasBeenEditedM        = wurde bearbeitet
+HasNotBeenEditedF     = wurde nicht bearbeitet
+HasNotBeenEditedM     = wurde nicht bearbeitet
+
+HasBeenDeletedF    = wurde gelöscht
+HasBeenDeletedM    = wurde gelöscht
+HasNotBeenDeletedF = wurde nicht gelöscht
+HasNotBeenDeletedM = wurde nicht gelöscht
+
+DigiriskUserGroup                 = Digirisk - Benutzer
+DigiriskUserGroupDescription      = Die Digirisk-Benutzergruppe hat die Berechtigung, die Digirisk-Objekte einzusehen und zu bearbeiten
+DigiriskAdminUserGroup            = DigiRisk - Administratoren
+DigiriskAdminUserGroupDescription = Die Administratorgruppe hat alle Berechtigungen für DigiRisk und die erforderlichen Module
+DigiriskReaderGroup               = DigiRisk - Leser
+DigiriskReaderGroupDescription    = Die Lesergruppe hat alle Leseberechtigungen für DigiRisk und die erforderlichen Module
+
+ContractType              = Vertragsart
+Apprentice/Student        = Auszubildender/Schüler
+Interim                   = Leiharbeitnehmer
+ProfessionalQualification = Berufliche Qualifikation
+DigiriskDocumentation     = Dokumentation von Digirisk
+
+SelectUser               = Benutzer auswählen
+LabourInspectorFirstName = Gewerbe-
+LabourInspectorLastName  = aufsicht
+LabourInspector          = Gewerbeaufsicht
+LabourInspectorSociety   = Partner Gewerbeaufsicht
+LabourInspectorAssigned  = Gewerbeaufsicht
+
+SocieteSchedules = Öffnungszeiten des Unternehmens
+weekDayDefault   = Siehe Website
+weekEndDefault   = Geschlossen Geschlossen
+
+#
+# DigriskDocuments - Digirisk-Dokumente
+#
+
+# Daten
+DigiriskDocuments              = Digirisk-Dokument
+Responsible                    = Verantwortlicher
+ContactsAction                 = Kontakte der Aktion
+PERCOTooltip                   = Wenn Ihr Unternehmen über einen PERCO-Sparplan verfügt, aktivieren Sie dieses Kästchen
+PEETooltip                     = Wenn Ihr Unternehmen über einen PEE-Sparplan verfügt, aktivieren Sie dieses Kästchen
+ShowPictoName                  = Namen des Gefahrenpiktogramms anzeigen
+ShowPictoNameDescription       = Den Namen des Gefahrenpiktogramms des Risikos in den Dokumenten anzeigen <br> Nützlich, wenn die Tabelle in eine Tabellenkalkulation übernommen werden soll
+RiskAssessmentColor            = Farbe der Bewertungen
+RiskAssessmentColorDescription = Zeigt die Farbe der Bewertungen im Dokument Papripact-A3-Querformat an
+
+#
+# LegalDisplay - Gesetzlicher Aushang
+#
+
+# Berechtigung
+LegalDisplaysMin = Gesetzliche Aushänge
+
+# Daten
+LegalDisplay             = Gesetzlicher Aushang
+Legaldisplay             = Gesetzlicher Aushang
+HowToSetDataLegalDisplay = Um die Daten für den gesetzlichen Aushang zu konfigurieren, gehen Sie zu Start - Konfiguration - Unternehmen/Organisation - Sicherheit
+
+LegalDisplayDocumentGenerated       = Erzeugung des gesetzlichen Aushangs
+LabourDoctor                        = Betriebsarzt
+LabourInspector                     = Gewerbeaufsicht
+FireBrigade                         = Feuerwehr
+AllEmergencies                      = Alle Notfälle
+RightsDefender                      = Bürgerbeauftragter
+PoisonControlCenter                 = Giftnotrufzentrale
+Police                              = Polizeinotruf
+SafetyInstructions                  = Sicherheitsanweisungen
+ResponsibleToNotify                 = Zu benachrichtigender Verantwortlicher
+PreventionOfficers                  = Präventionsverantwortliche
+PreventionOfficer                   = Präventionsverantwortlicher
+LocationOfDetailedInstructions      = Ort der ausführlichen Anweisung
+LocationOfDetailedInstructionsValue = Keine ausführliche Anweisung an diesem Standort
+FirstAid                            = Erste Hilfe
+FirstAidValue                       = <h2>Liste der am Standort anwesenden Ersthelfer (Name, Unternehmen, Telefon)</h2><br><br>Jedes Team muss so zusammengesetzt sein, dass jedem Teammitglied unter allen Umständen Erste Hilfe geleistet werden kann.<br />Die Ersthelfer müssen eindeutig gekennzeichnet und allen bekannt sein.<h2>Verhalten im Falle eines Unfalls</h2><br><br><h3>Leichter Unfall</h3><br><ul><li> - Versorgung durch die Ersthelfer</li><br><li> - Vorhandensein eines Verbandkastens</li></ul><br><br>Jede Maschine ist mit mindestens einem Verbandkasten ausgestattet, mit dem leichte Verletzungen versorgt werden können.<br><br><h3>Schwerer Unfall</h3><br><ul><li> - Den am Standort anwesenden Ersthelfer verständigen</li><br><li> - Das Notfallverfahren auslösen</li><br><li> - Den Verantwortlichen des Einsatzbetriebs informieren, Betriebsbereitschaft rund um die Uhr</li><br><li> - Im Falle eines Unfalls Kontakt aufnehmen</li></ul><br><br>Der Einsatzbetrieb führt die Notrufnummern im Anhang auf. <br />
+AddPhoneNumber                      = Dem Benutzer eine Telefonnummer hinzufügen
+ConfigureLabourInspector            = Eine Gewerbeaufsicht konfigurieren
+SocietyAdditionalDetails            = Ergänzende Informationen zum Unternehmen
+GeneralMeansAtDisposal              = Bereitgestellte allgemeine Mittel
+GeneralMeansAtDisposalValue         = <h2>Bereitgestellte Rettungsmittel</h2><br><ul><li> - Sanitätsraum</li><br><li> - Unsere Ersthelfer sind an ihren Helmen und ihrer Arbeitskleidung mit dem Ersthelfer-Abzeichen gekennzeichnet</li><br><li> - Verbandkästen für leichte Unfälle sind an jedem Standort verfügbar</li></ul><br><br><h2>Anweisungen bei leichten Unfällen</h2><br><ul><li> - Den nächstgelegenen Ersthelfer kontaktieren</li><br><li> - Versorgung mit dem bereitgestellten Verbandkasten</li><br><li> - Meldung am Standort:</li></ul><br><br><h2>Anweisungen im Falle eines Unfalls</h2><br><ul><li> - Feuerwehr: 18</li><br><li> - Rettungsdienst: 15</li><br><li> - Polizei und Gendarmerie: 17</li><br><li> - Europäische Notrufnummer: 112</li></ul><br><br><h2>Anweisungen im Brandfall</h2><br>Gehen Sie im Brandfall in dieser Reihenfolge vor:<br><ol><li> - Den Alarm auslösen.</li><br><li> - Das Feuer (sofern es nicht zu groß ist) mit einem Feuerlöscher bekämpfen.</li><br><li> - Ist das Feuer nach dem Einsatz eines einzigen Feuerlöschers nicht erloschen oder bereits zu groß, die Feuerwehr verständigen.</li><br><li> - Türen und Fenster schließen, bevor Sie die Räume verlassen.</li><br><li> - Die ausgebildeten Teams um Hilfe bitten.</li><br></ol>
+GeneralInstructions                 = Allgemeine Anweisungen
+GeneralInstructionsValue            = <h2>Alle Anlagen</h2><br><br><p>Rauchen, Feuer machen oder die Verwendung offener Flammen ist in und auf den Anlagen strengstens untersagt.<br />Erfordert der Einsatz die Verwendung einer offenen Flamme (Schweißarbeiten usw.), muss zwingend ein Feuererlaubnisschein ausgestellt werden (siehe Beispiel in Anhang 9.5).<br />Grundsätzlich ist der Zugang zu den Anlagen für Unbefugte untersagt.<br />Jeder Beteiligte muss seine Befähigungsnachweise und Schulungsbescheinigungen mit sich führen. Er muss sie am Standort auf Verlangen des Einsatzbetriebs vorzeigen können.</p><br><br><h2>Befähigungen</h2><br>Jede beteiligte Person muss eine Kopie der folgenden Befähigungsnachweise besitzen:<br><ul><li> - Elektrotechnische Befähigung entsprechend den auszuführenden Arbeiten</li><br><li> - Schulungsbescheinigung oder Befähigung für Höhenarbeiten und Höhenrettung</li></ul><br>Und in der Lage sein, sie auf einfache Anforderung des Einsatzbetriebs, des Einsatz- bzw. Bauleiters oder eines vereidigten Aufsichtsbeamten vorzulegen<br><br><h2>Persönliche Schutzausrüstung</h2><br>Jede beteiligte Person muss je nach Art der ausgeführten Arbeiten und den in der Gefährdungsbeurteilung festgelegten Schutzmaßnahmen über die folgende persönliche Schutzausrüstung verfügen können.<br><br><h3>Verschiedene Arbeiten</h3><br><ul><li> - Für Höhenarbeiten ausgelegter Helm (EN397) mit Kinnriemen und/oder mit elektrischer Isolierung (elektrische Umgebung)</li><br><li> - Sicherheitsschuhe</li><br><li> - Gehörschutz, falls erforderlich</li><br><li> - Sonstiges (bitte angeben): je nach ausgeführten Arbeiten und den damit verbundenen Risiken.</li></ul><br><br><h3>Elektrische Arbeiten</h3><br><ul><li> - Isoliermatte oder Isolierschemel</li><br><li> - Der Spannungsebene angepasste Handschuhe</li><br><li> - Helme für elektrische Arbeiten mit Gesichtsschutz (EN166)</li><br><li> - Vorgeschriebene PSA für Arbeiten an Mittelspannung (UTE C 18-510)</li></ul><br><br><h3>Sonstiges</h3><br>Hinweis: Die Fremdfirmen müssen ihren Beschäftigten die oben genannte PSA zur Verfügung stellen. In den Übergabestationen befinden sich ein Schemel und eine Rettungsstange.<br><br><h3>Höhenarbeiten</h3><br><ul><li> - Vorgeschriebene PSA (Auffanggurt, Helm, 2 Verbindungsmittel mit Falldämpfer oder Y-Verbindungsmittel, Karabiner, Höhensicherungsgerät usw.) mit gültiger Prüfung</li><br><li> - Automatisches Rettungssystem:</li><br><li> - Anzahl: 1 Rettungsset (ausgelegt für 2 Personen)</li><li>Ort: in der Arbeitsbühne</li><br><li> - Denken Sie an ein zusätzliches Rettungsset, wenn sich mehr als zwei Personen in der Arbeitsbühne befinden</li><br><li> - Sonstiges (bitte angeben): verwendetes Höhensicherungsgerät: HACA mit der Referenz 0529 7103 (Brustbefestigung am Auffanggurt)</li></ul><br><br>Die Höhensicherungsgeräte müssen mit dem festen Sicherungssystem der Maschinen kompatibel sein. Die Höhensicherungsgeräte müssen der neuesten Norm entsprechen und die ergänzenden Prüfungen (Zusatzprüfungen CNB/P/11.073 vom 13.10.2010) erfolgreich bestanden haben, die durch die Stellungnahme des französischen Arbeitsministeriums vom 28. September 2010 vorgeschrieben sind, um die Konformität mit den Anforderungen der Richtlinie 89/686/EWG zu gewährleisten.
+RulesOfProcedure                    = Betriebsordnung
+RulesOfProcedureValue               = Verfügbar am gesetzlich vorgeschriebenen Aushang im Pausenraum
+CollectiveAgreement                 = Tarifverträge
+CollectiveAgreementValue            = Verfügbar auf der Website der Regierung:<br /><a href="https://www.service-public.fr/particuliers/vosdroits/F78" target="_blank">https://www.service-public.fr/particuliers/vosdroits/F78</a>
+legaldisplay.odt                    = Gesetzlicher Aushang
+legaldisplay_custom.odt             = Individueller gesetzlicher Aushang
+
+#
+# InformationsSharing - Informationsverbreitung
+#
+
+# Berechtigung
+InformationsSharingsMin = Informationsverbreitungen
+
+# Daten
+InformationsSharing                  = Informationsverbreitung
+Informationssharing                  = Informationsverbreitung
+InformationsSharingDocumentGenerated = Erzeugung der Informationsverbreitung
+HowToSetDataInformationsSharing      = Um die Daten zur Informationsverbreitung zu konfigurieren, gehen Sie zu Start - Konfiguration - Unternehmen/Organisation - Soziales
+ConfigureSecurityAndSocialData       = Die Unternehmensdaten konfigurieren
+LastMainDoc                          = Zuletzt erzeugtes Dokument
+
+ParticipationAgreement      = Vereinbarungen zur Gewinnbeteiligung
+ParticipationAgreementValue = Ja, alle Mitarbeiter mit einem laufenden unbefristeten oder befristeten Arbeitsvertrag mit dem Unternehmen können unabhängig von dessen Art an der Gewinnbeteiligung teilhaben.<br />Es ist jedoch eine Mindestbetriebszugehörigkeit erforderlich: 6 Monate im Unternehmen.<br />Zur Ermittlung der erforderlichen Betriebszugehörigkeit werden alle Arbeitsverträge berücksichtigt, die im Berechnungszeitraum und in den 12 vorangegangenen Monaten erfüllt wurden.<br />Die Betriebszugehörigkeit wird zum Abschlussstichtag des betreffenden Geschäftsjahres oder zum Austrittsdatum bei Vertragsbeendigung im laufenden Geschäftsjahr bewertet.
+TermsAndConditions          = Modalitäten
+
+ESC                  = Sozial- und Wirtschaftsausschuss
+StaffRepresentatives = Personalvertreter
+ElectionDate         = Wahldatum
+ElectionDateCSE      = Wahldatum des Sozial- und Wirtschaftsausschusses
+ElectionDateDP       = Wahldatum der Personalvertreter
+
+Titulars                       = Ordentliche Mitglieder
+Alternates                     = Stellvertreter
+informationssharing.odt        = Informationsverbreitung
+informationssharing_custom.odt = Individuelle Informationsverbreitung
+ActionOnUser                   = Betroffener Benutzer
+HarassmentOfficer              = Beauftragter für Belästigung
+HarassmentOfficerCSE           = Beauftragter für Belästigung des Sozial- und Wirtschaftsausschusses
+ExceptionsToWorkingHours       = Ausnahmen von den Arbeitszeiten
+PermanentDerogation            = Dauerhafte Ausnahme
+PermanentDerogationValue       = Nein
+OccasionalDerogation           = Gelegentliche Ausnahme
+OccasionalDerogationValue      = Ja
+
+
+#
+# PreventionPlan - Präventionsplan
+#
+
+# Berechtigung
+PreventionPlansMin = Präventionspläne
+
+# Daten
+
+PreventionPlan                                        = Präventionsplan
+Preventionplan                                        = Präventionsplan
+ThePreventionplan                                     = der Präventionsplan
+PreventionPlanDocument                                = Präventionsplan
+Preventionplandocument                                = Präventionsplan
+PreventionPlanDocumentGenerated                       = Erzeugung des Präventionsplans
+PreventionPlanList                                    = Liste der Präventionspläne
+PreventionPlanLine                                    = Risiko/Risiken
+PreventionPlanLineCreated                             = Anlegen eines Risikos im Präventionsplan
+PreventionPlanLineModified                            = Änderung eines Risikos im Präventionsplan
+PreventionPlanLineDeleted                             = Löschen eines Risikos im Präventionsplan
+NewPreventionPlan                                     = Neuer Präventionsplan
+PriorVisit                                            = Gemeinsame Vorbegehung
+PriorVisitYesNo                                       = Vorbegehung durchgeführt
+PriorVisitText                                        = Notiz zur Begehung
+CSSCTIntervention                                     = Beteiligung des Arbeitsschutzausschusses
+CSSCTInterventionText                                 = Beteiligung des Arbeitsschutzausschusses?
+MasterWorker                                          = Verantwortlicher des Einsatzbetriebs
+MasterWorker                                          = Verantwortlicher des Einsatzbetriebs
+ExtSociety                                            = Fremdfirma
+ExtSocietyResponsible                                 = Verantwortlicher der Fremdfirma
+ExtSocietyResponsible                                 = Verantwortlicher der Fremdfirma
+ExtSocietyAttendant                                   = Beschäftigter der Fremdfirma
+ActionsDescription                                    = Beschreibung der Tätigkeiten
+INRSRisk                                              = Risiko (INRS)
+PreventionMethod                                      = Präventionsmittel
+PreventionplanSchedules                               = Zeiten des Präventionsplans
+Attendants                                            = Teilnehmer
+ModifyPreventionPlan                                  = Präventionsplan bearbeiten
+ActionsDescriptionTooltip                             = Beschreibung der vom Beschäftigten ausgeführten Tätigkeiten
+INRSRiskTooltip                                       = Liste der Risikokategorien aus dem Referenzwerk des INRS
+PreventionMethodTooltip                               = Präventionsmittel, das zur Begrenzung des Risikos umzusetzen ist
+LockPreventionPlan                                    = Präventionsplan sperren
+ConfirmLockPreventionPlan                             = Möchten Sie den Präventionsplan wirklich sperren?<br>Diese Sperre friert die Daten und die Dokumenterzeugung ein.
+AllSignatoriesMustHaveSigned                          = Alle Teilnehmer müssen unterschrieben haben, um das Objekt zu sperren
+ValidatePreventionPlan                                = Präventionsplan freigeben
+ConfirmValidatePreventionPlan                         = Möchten Sie den Präventionsplan wirklich freigeben? <br> Die Freigabe ermöglicht den Teilnehmern die Unterzeichnung des Dokuments, <b> verhindert aber das Hinzufügen neuer Teilnehmer sowie die Änderung des Präventionsplans </b>.
+ReOpenPreventionPlan                                  = Präventionsplan erneut öffnen
+ConfirmReOpenPreventionPlan                           = Möchten Sie den Präventionsplan wirklich erneut öffnen? Das erneute Öffnen ermöglicht die Änderung des Präventionsplans und das Hinzufügen neuer Teilnehmer, <b>alle Unterschriften des Dokuments gehen dabei jedoch verloren</b>.
+PreventionPlanRiskList                                = Liste der Risiken des Präventionsplans
+ActionsPreventionPlanRisk                             = Aktionen
+PreventionPlanDescription                             = Projekt der Präventionspläne
+PriorVisitDate                                        = Datum der gemeinsamen Vorbegehung
+AddPreventionPlanLine                                 = Risiko hinzugefügt
+UpdatePreventionPlanLine                              = Risiko aktualisiert
+DeletePreventionPlanLine                              = Risiko gelöscht
+PreventionPlanDet                                     = Risiko des Präventionsplans
+Preventionplandet                                     = Risiko des Präventionsplans
+PreventionPlanMessage                                 = zum Präventionsplan
+PreventionPlanMustBeValidated                         = Der Präventionsplan muss freigegeben sein, um ihn erneut öffnen zu können
+PreventionPlanMustBeInProgress                        = Der Präventionsplan muss laufend sein, um auf diese Funktion zuzugreifen
+PreventionPlanMustBeInProgressToValidate              = Der Präventionsplan ist bereits freigegeben
+CSEMustBeAlerted3DaysBeforeVisit                      = Der Sozial- und Wirtschaftsausschuss muss 3 Tage vor der gemeinsamen Vorbegehung informiert werden (Art. R. 4514-1 1°, R. 4514-3 und R. 4514-9 des französischen Arbeitsgesetzbuchs)
+PreventionPlanData                                    = Daten des Präventionsplans
+MasterWorkerDescription                               = Der standardmäßig als Verantwortlicher des Einsatzbetriebs verwendete Benutzer
+NoPreventionPlanRisk                                  = Kein Risiko im Präventionsplan
+NoPreventionPlanLinked                                = Kein verknüpfter Präventionsplan
+PreventionPlanLinked                                  = Verknüpfter Präventionsplan
+PreventionPlanManagement                              = Verwaltung der Präventionspläne
+PPRProject                                            = Mit den Präventionsplänen verknüpftes Projekt
+NewLabelForClonePreventionPlan                        = Bezeichnung des neuen Präventionsplans
+ClonePreventionPlanRisk                               = Risiken des Präventionsplans klonen
+CloneAttendantsPreventionPlan                         = Teilnehmer des Präventionsplans klonen
+CloneSchedulePreventionPlan                           = Zeiten des Präventionsplans klonen
+ConfirmClonePreventionPlan                            = Möchten Sie den Präventionsplan <b> %s </b> wirklich klonen?
+preventionplandocument.odt                            = Präventionsplan
+preventionplandocument_custom.odt                     = Individueller Präventionsplan
+ErrorThirdPartyHasAtLeastOneChildOfTypePreventionPlan = Der Partner ist mit mindestens einem untergeordneten Element vom Typ Präventionsplan verknüpft:
+ErrorContactHasAtLeastOneChildOfTypePreventionPlan    = Der Kontakt ist mit mindestens einem untergeordneten Element vom Typ Präventionsplan verknüpft:
+ConfirmDeletePreventionPlan                           = Möchten Sie diesen Präventionsplan wirklich löschen?
+PreventionPlanRole                                    = Die Rollen des Präventionsplans
+
+# E-Mail
+PreventionPlanLabel   = Zusammenfassung des Präventionsplans
+PreventionPlanSubject = E-Mail zum Präventionsplan
+PreventionPlanContent = Anbei finden Sie das ODT-Dokument des Präventionsplans.
+
+# Trigger
+PreventionPlanCreated          = Anlegen eines Präventionsplans
+PreventionPlanModified         = Änderung eines Präventionsplans
+PreventionPlanDeleted          = Löschen eines Präventionsplans
+PreventionPlanInProgress       = Erneutes Öffnen des Präventionsplans
+PreventionPlanPendingSignature = Präventionsplan wartet auf Unterschrift
+PreventionPlanLocked           = Sperren des Präventionsplans
+PreventionPlanArchived         = Archivierung des Präventionsplans
+PreventionPlanSentByMail       = Versand des Präventionsplans per E-Mail
+
+#
+# FirePermit - Feuererlaubnisschein
+#
+
+# Berechtigung
+FirePermitMin  = Feuererlaubnisschein
+FirePermitsMin = Feuererlaubnisscheine
+
+# Daten
+NewFirePermit                                     = Neuer Feuererlaubnisschein
+ModifyFirePermit                                  = Feuererlaubnisschein bearbeiten
+FirePermitList                                    = Liste der Feuererlaubnisscheine
+FirePermit                                        = Feuererlaubnisschein
+Firepermit                                        = Feuererlaubnisschein
+TheFirepermit                                     = der Feuererlaubnisschein
+FirePermitDocument                                = Feuererlaubnisschein
+Firepermitdocument                                = Feuererlaubnisschein
+FirePermitDocumentGenerated                       = Erzeugung des Feuererlaubnisscheins
+FirePermitCreated                                 = Anlegen eines Feuererlaubnisscheins
+FirePermitModified                                = Änderung eines Feuererlaubnisscheins
+FirePermitDeleted                                 = Löschen eines Feuererlaubnisscheins
+FirePermitInProgress                              = Erneutes Öffnen des Feuererlaubnisscheins
+FirePermitPendingSignature                        = Feuererlaubnisschein wartet auf Unterschrift
+FirePermitLocked                                  = Sperren des Feuererlaubnisscheins
+FirePermitArchived                                = Archivierung des Feuererlaubnisscheins
+FirePermitSignatureAddAttendant                   = Teilnehmer zum Feuererlaubnisschein hinzugefügt
+FirePermitSentByMail                              = Versand des Feuererlaubnisscheins per E-Mail
+FirePermitLine                                    = Risiko/Risiken
+FirePermitDet                                     = Risiko des Feuererlaubnisscheins
+Firepermitdet                                     = Risiko des Feuererlaubnisscheins
+FirePermitLineCreated                             = Anlegen eines Risikos im Feuererlaubnisschein
+FirePermitLineModified                            = Änderung eines Risikos im Feuererlaubnisschein
+FirePermitLineDeleted                             = Löschen eines Risikos im Feuererlaubnisschein
+FirePermitRiskList                                = Liste der Risiken des Feuererlaubnisscheins
+AddFirePermitLine                                 = Risiko hinzugefügt
+UpdateFirePermitLine                              = Risiko aktualisiert
+DeleteFirePermitLine                              = Risiko gelöscht
+FirePermitMessage                                 = zum Feuererlaubnisschein
+UsedMaterialTooltip                               = Zur Begrenzung des Risikos zu verwendende Ausrüstung
+ActionsFirePermitRisk                             = Aktionen
+ConfirmValidateFirePermit                         = Möchten Sie den Feuererlaubnisschein wirklich freigeben? <br> Die Freigabe ermöglicht den Teilnehmern die Unterzeichnung des Dokuments, <b> verhindert aber das Hinzufügen neuer Teilnehmer sowie die Änderung des Feuererlaubnisscheins </b>.
+ConfirmReOpenFirePermit                           = Möchten Sie den Feuererlaubnisschein wirklich erneut öffnen? Das erneute Öffnen ermöglicht die Änderung des Feuererlaubnisscheins und das Hinzufügen neuer Teilnehmer, <b>alle Unterschriften des Dokuments gehen dabei jedoch verloren</b>.
+ConfirmLockFirePermit                             = Möchten Sie den Feuererlaubnisschein wirklich sperren?<br>Diese Sperre friert die Daten und die Dokumenterzeugung ein.
+FirePermitMustBeInProgress                        = Der Feuererlaubnisschein muss laufend sein, um auf diese Funktion zuzugreifen
+NewLabelForCloneFirePermit                        = Bezeichnung des neuen Feuererlaubnisscheins
+CloneFirePermitRisk                               = Risiken des Feuererlaubnisscheins klonen
+CloneAttendantsFirePermit                         = Teilnehmer des Feuererlaubnisscheins klonen
+CloneScheduleFirePermit                           = Zeiten des Feuererlaubnisscheins klonen
+ConfirmCloneFirePermit                            = Möchten Sie den Feuererlaubnisschein <b> %s </b> wirklich klonen?
+FirePermitDescription                             = Projekt der Feuererlaubnisscheine
+FirePermitData                                    = Daten des Feuererlaubnisscheins
+FirePermitManagement                              = Verwaltung der Feuererlaubnisscheine
+FPRProject                                        = Mit den Feuererlaubnisscheinen verknüpftes Projekt
+firepermitdocument.odt                            = Feuererlaubnisschein
+firepermitdocument_custom.odt                     = Individueller Feuererlaubnisschein
+UsedEquipment                                     = Verwendete Ausrüstung
+ErrorThirdPartyHasAtLeastOneChildOfTypeFirePermit = Der Partner ist mit mindestens einem untergeordneten Element vom Typ Feuererlaubnisschein verknüpft:
+ErrorContactHasAtLeastOneChildOfTypeFirePermit    = Der Kontakt ist mit mindestens einem untergeordneten Element vom Typ Feuererlaubnisschein verknüpft:
+ConfirmDeleteFirePermit                           = Möchten Sie diesen Feuererlaubnisschein wirklich löschen?
+FirePermitRole                                    = Die Rollen des Feuererlaubnisscheins
+FirepermitSchedules                               = Zeiten des Feuererlaubnisscheins
+
+# E-Mail
+FirePermitLabel   = Zusammenfassung des Feuererlaubnisscheins
+FirePermitSubject = E-Mail zum Feuererlaubnisschein
+FirePermitContent = Anbei finden Sie das ODT-Dokument des Feuererlaubnisscheins.
+
+
+#
+# Accident - Unfall
+#
+
+# Berechtigung
+AccidentsMin = Unfälle
+
+# Trigger
+AccidentCreateTrigger         = Unfall %s angelegt
+ActionsOnAccident             = Mit dem Unfall verknüpfte Ereignisse
+AccidentGeneratedWithDolibarr = Unfall mit Dolibarr erzeugt
+AccidentWorkStopCreateTrigger = Arbeitsunfähigkeit %s zum Unfall hinzugefügt
+AccidentWorkStopModifyTrigger = Arbeitsunfähigkeit %s am Unfall geändert
+AccidentWorkStopDeleteTrigger = Arbeitsunfähigkeit %s vom Unfall gelöscht
+AccidentModifyTrigger         = Unfall %s geändert
+AccidentDeleteTrigger         = Unfall %s gelöscht
+AccidentMetaDataCreateTrigger = Speicherung der ergänzenden Unfalldaten
+AccidentLesionCreateTrigger   = Verletzung %s zum Unfall hinzugefügt
+AccidentLesionModifyTrigger   = Verletzung %s am Unfall geändert
+AccidentLesionDeleteTrigger   = Verletzung %s vom Unfall gelöscht
+ACC_USER_EMPLOYERSigned       = Unterschrift des Unternehmensverantwortlichen
+VictimAndCaregivers           = Verunfallter und betreuende Person
+Victim                        = Verunfallter
+Caregiver                     = Betreuende Person
+
+# Nummerierungsmodell
+DigiriskAccidentNumberingModule         = Nummerierungsmodell der Unfälle von Digirisk
+DigiriskAccidentStandardModel           = Gibt die Nummer in der Form ACCn zurück, wobei n ein fortlaufender Zähler ohne Lücken und ohne Rücksetzung ist.
+DigiriskAccidentWorkStopNumberingModule = Nummerierungsmodell der mit dem Unfall verknüpften Arbeitsunfähigkeiten
+DigiriskAccidentWorkStopStandardModel   = Gibt die Nummer in der Form ACCWn zurück, wobei n ein fortlaufender Zähler ohne Lücken und ohne Rücksetzung ist.
+DigiriskAccidentLesionNumberingModule   = Nummerierungsmodell der mit dem Unfall verknüpften Verletzungen
+DigiriskAccidentLesionStandardModel     = Gibt die Nummer in der Form ACCLn zurück, wobei n ein fortlaufender Zähler ohne Lücken und ohne Rücksetzung ist.
+DigiriskAccidentDocumentNumberingModule = Nummerierungsmodell der Unfallblätter von Digirisk
+DigiriskAccidentDocumentStandardModel   = Gibt die Nummer in der Form ACCDn zurück, wobei n ein fortlaufender Zähler ohne Lücken und ohne Rücksetzung ist.
+
+# ODT-Vorlage
+DigiriskTemplateDocumentAccident       = Dokumentvorlagen der Unfälle von Digirisk
+AccidentDocumentCustomDigiriskTemplate = Individuelle ODT-Vorlage der Unfälle
+AccidentDocumentDigiriskTemplate       = Standard-ODT-Vorlage der Unfälle
+AccidentDocument                       = Unfallblatt
+AccidentDocumentGeneratedWithDolibarr  = Unfall mit Dolibarr erzeugt
+
+# Daten
+NewAccident                              = Neuer Unfall
+ModifyAccident                           = Unfall bearbeiten
+AccidentList                             = Liste der Unfälle
+Accident                                 = Unfall
+AccidentCreated                          = Anlegen eines Unfalls
+DeleteAccident                           = Unfall löschen?
+AccidentModified                         = Änderung eines Unfalls
+AccidentDeleted                          = Löschen eines Unfalls
+AccidentLine                             = Risiko/Risiken
+AccidentDate                             = Datum des Unfalls
+AccidentSchedule                         = Zeiten des Unfalls
+AccidentRiskList                         = Liste der ergänzenden Informationen zum Unfall
+Accidentworkstop                         = Arbeitsunfähigkeit
+AccidentWorkStopCreated                  = Anlegen einer Arbeitsunfähigkeit
+AccidentWorkStopModified                 = Änderung einer Arbeitsunfähigkeit
+AccidentWorkStopDeleted                  = Löschen einer Arbeitsunfähigkeit
+AddAccidentWorkStop                      = Hinzufügen einer Arbeitsunfähigkeit zum Unfall
+UpdateAccidentWorkStop                   = Aktualisierung einer Arbeitsunfähigkeit am Unfall
+DeleteAccidentWorkStop                   = Löschen einer Arbeitsunfähigkeit vom Unfall
+Accidentlesion                           = Verletzung
+AccidentLesionCreated                    = Anlegen einer Verletzung
+AccidentLesionModified                   = Änderung einer Verletzung
+AccidentLesionDeleted                    = Löschen einer Verletzung
+AddAccidentLesion                        = Hinzufügen einer Verletzung zum Unfall
+UpdateAccidentLesion                     = Aktualisierung einer Verletzung am Unfall
+DeleteAccidentLesion                     = Löschen einer Verletzung vom Unfall
+AccidentDescription                      = Projekt der Unfälle
+AccidentManagement                       = Verwaltung der Unfälle
+AccidentWorkstopManagement               = Verwaltung der Arbeitsunfähigkeiten
+AccidentLesionManagement                 = Verwaltung der Verletzungen
+AccidentInvestigationManagement          = Verwaltung der Unfalluntersuchungen
+ACCProject                               = Mit den Unfällen verknüpftes Projekt
+UserVictim                               = Verunfallte Person
+AccidentType                             = Art des Unfalls
+WorkAccidentStatement                    = Arbeitsunfall
+CommutingAccident                        = Wegeunfall
+AccidentMetaData                         = Ergänzende Daten
+RelativeLocation                         = Ergänzende Angaben zum Unfallort
+VictimActivity                           = Tätigkeit des Verunfallten zum Zeitpunkt des Unfalls
+AccidentNature                           = Art des Unfalls
+AccidentObject                           = Gegenstand, durch dessen Kontakt der Verunfallte verletzt wurde
+AccidentNatureDoubt                      = Etwaige begründete Vorbehalte (fügen Sie bei Bedarf ein Begleitschreiben bei)
+AccidentNatureDoubtLink                  = Link zum Begleitschreiben
+VictimTransportedTo                      = Der Verunfallte wurde gebracht nach
+VictimWorkHours                          = Arbeitszeit des Verunfallten am Unfalltag
+WorkHoursMorningDateStart                = Beginn der Arbeitszeit des Verunfallten (Vormittag)
+WorkHoursMorningDateEnd                  = Ende der Arbeitszeit des Verunfallten (Vormittag)
+WorkHoursAfternoonDateStart              = Beginn der Arbeitszeit des Verunfallten (Nachmittag)
+WorkHoursAfternoonDateEnd                = Ende der Arbeitszeit des Verunfallten (Nachmittag)
+AccidentNoticed                          = Information über den Unfall
+Found                                    = Festgestellt
+Known                                    = Bekannt
+AccidentNoticeDate                       = Datum der Kenntnisnahme des Unfalls
+AccidentNoticeBy                         = Person, die über den Unfall informiert hat
+ByEmployer                               = Durch den Arbeitgeber
+ByEmployees                              = Durch dessen Beschäftigte
+AccidentDescribedByVictim                = Der Unfall wurde vom Verunfallten geschildert
+RegisteredInAccidentRegister             = Der Unfall ist im Register für leichte Arbeitsunfälle eingetragen
+RegisterDate                             = Datum der Eintragung im Register für leichte Arbeitsunfälle
+RegisterNumber                           = Nummer der Eintragung im Register für leichte Arbeitsunfälle
+Consequence                              = Folgen
+WithoutWorkStop                          = Ohne Arbeitsunfähigkeit
+LessThanFourDays                         = Weniger als 4 Tage
+LessThanTwentyOneDays                    = Weniger als 21 Tage
+LessThanThreeMonth                       = Weniger als 3 Monate
+LessThanSixMonths                        = Weniger als 6 Monate
+LongTimeWorkStop                         = Mehr als 6 Monate
+WithWorkStop                             = Mit Arbeitsunfähigkeit
+Fatal                                    = Todesfall
+PoliceReport                             = Polizeibericht
+PoliceReportBy                           = Person, die den Polizeibericht erstellt hat
+FirstPersonNoticedIsWitness              = Benachrichtigte Person
+Witness                                  = Zeuge
+FirstPersonNoticed                       = Erste benachrichtigte Person
+ThirdPartyResponsability                 = Wurde der Unfall durch einen Dritten verursacht?
+FkSocResponsible                         = Unternehmen des haftenden Dritten
+FkSocResponsibleInsuranceSociety         = Versicherungsgesellschaft des Dritten
+LesionLocalization                       = Lokalisation der Verletzungen
+LesionNature                             = Art der Verletzungen
+AccidentInvestigation                    = Unfalluntersuchung
+Accidentinvestigation                    = Unfalluntersuchung
+AccidentInvestigationLink                = Link zur Unfalluntersuchung
+AccidentLocation                         = Unfallort
+DigiriskDolibarrActionTrigger            = Trigger der Digirisk-Ereignisse
+CollateralVictim                         = Mitbetroffene Person
+FromDigirisk                             = Von
+At                                       = Bis
+AndFrom                                  = Und von
+ExternalAccident                         = Ereignete sich der Unfall in einem anderen Betrieb als dem Stammbetrieb des Verunfallten?
+AccidentAttendants                       = Unfall - Teilnehmer
+UserEmployer                             = Verantwortlicher des Unternehmens
+SignatureUserEmployer                    = Unterschrift des Unternehmensverantwortlichen
+CerfaLink                                = Link zum Cerfa-Formular
+WorkStopDays                             = Anzahl der Tage der Arbeitsunfähigkeit
+AccidentLesionList                       = Liste der mit dem Unfall verknüpften Verletzungen
+DocumentsMetaData                        = Ergänzende Dateianhänge
+WorkStopDocument                         = Meldung der Arbeitsunfähigkeit
+AccidentMetaDataSave                     = Die ergänzenden Unfalldaten wurden gespeichert
+ErrorFieldNotEmpty                       = Fehler: Das Feld <b>'%s'</b> darf nicht leer sein
+ErrorFieldMustBeGreaterOrEqualZero       = Fehler: Das Feld <b>'%s'</b> muss größer oder gleich 0 sein
+ConfirmDeleteAccidentWorkStop            = Möchten Sie die Arbeitsunfähigkeit <b>%s</b> am Unfall wirklich löschen?
+AccidentMetaDataLesion                   = Ergänzende Daten der Verletzungen
+TotalWorkStopDays                        = Gesamtzahl der Tage der Arbeitsunfähigkeit
+RegisterAccident                         = Leichter Unfall
+AccidentsLinked                          = Verknüpfte(r) Unfall/Unfälle
+GaugeCounter                             = Dieses Feld wird im Zähler der Anzeige verwendet
+DateStartWorkStop                        = Beginn der Arbeitsunfähigkeit
+DateEndWorkStop                          = Ende der Arbeitsunfähigkeit
+ReturnWorkDate                           = Datum der Wiederaufnahme der Tätigkeit
+DayWithoutAccident                       = Tage ohne Unfall/Unfälle
+AccidentRepartition                      = Verteilung der Unfälle nach Art
+AccidentByYear                           = Verteilung der Unfälle nach Jahr
+NbAccidentsByEmployees                   = Anzahl der Unfälle je Beschäftigten
+AccidentRegister                         = Unfall nach Register
+AccidentWithoutRegister                  = Unfälle ohne Register
+AccidentWithRegister                     = Unfälle mit Register
+WorkStopDurationDistribution             = Verteilung der Zeit nach Arbeitsunfähigkeit
+WorkStopDurationDistributionDigiriskElem = Verteilung der Arbeitsunfähigkeitszeit nach GP/UT
+WorkStopDuration                         = Dauer der Arbeitsunfähigkeit
+NoAbsence                                = Keine Arbeitsunfähigkeit
+UpTo4Days                                = Bis zu 4 Tage
+UpTo21Days                               = Bis zu 21 Tage
+UpTo3Months                              = Bis zu 3 Monate
+UpTo6Months                              = Bis zu 6 Monate
+MoreThan6Months                          = Mehr als 6 Monate
+FrequencyIndex                           = Häufigkeitsindex
+FrequencyRate                            = Häufigkeitsrate
+GravityIndex                             = Schwereindex
+GravityRate                              = Schwererate
+AccidentRateIndicator                    = Raten und Indizes der Leistungskennzahlen zu Unfällen
+NbPresquAccidents                        = Anzahl der Beinaheunfälle
+NbAccidentInvestigations                 = Anzahl der Unfalluntersuchungen
+AccidentInvestigationsMin                = Unfalluntersuchungen
+NbWorkedHours                            = Anzahl der geleisteten Arbeitsstunden
+ConfirmDeleteAccident                    = Möchten Sie den Unfall wirklich löschen?
+TheAccident                              = der Unfall
+AccidentInvestigation                    = Unfalluntersuchung
+Accident_investigation                   = Unfalluntersuchung
+AccidentInvestigationDocument            = Dokument der Unfalluntersuchung
+Accidentinvestigationdocument            = Dokument der Unfalluntersuchung
+accidentinvestigationdocument.odt        = Unfalluntersuchung
+NewAccidentInvestigation                 = Neue Unfalluntersuchung
+UpdateAccidentInvestigation              = Eine Unfalluntersuchung bearbeiten
+AccidentInvestigationList                = Liste der Unfalluntersuchungen
+TheAccidentinvestigation                 = die Unfalluntersuchung
+SeniorityInPosition                      = Betriebszugehörigkeit auf der Stelle
+VictimSkills                             = Kompetenzen des Verunfallten
+CollectiveEquipment                      = Kollektive Schutzausrüstung (KSA)
+IndividualEquipment                      = Persönliche Schutzausrüstung (PSA)
+Circumstances                            = Umstände
+CurativeAction                           = Sofortmaßnahmen
+CorrectiveAction                         = Korrekturmaßnahmen
+PreventiveAction                         = Präventivmaßnahmen
+DigiriskActionType                       = Digirisk-Aktionstyp
+Actions                                  = Aktionen
+ActionsTab                               = Aktionen
+CurativeActions                          = Sofortmaßnahmen
+PreventiveActions                        = Präventivmaßnahmen
+TotalPlannedBudget                       = Geplantes Budget
+AccidentInvestigationDocumentPDF         = EA-A4-HOCHFORMAT
+PreventionPlanDocumentPDF                = PP-A4-HOCHFORMAT
+PreventionPlanDocumentPDFDescription     = Den Präventionsplan als PDF erzeugen
+AccidentInvestigationDocumentPDFDescription = Die Unfalluntersuchung als PDF erzeugen
+AccidentInvestigationDocumentGeneratedAt = Erzeugt am
+CorrectiveActions                        = Korrekturmaßnahmen
+AddCurativeAction                        = Eine Sofortmaßnahme hinzufügen
+AddCorrectiveAction                      = Eine Korrekturmaßnahme hinzufügen
+InvestigationNotValidatedYet             = Geben Sie zuerst die Unfalluntersuchung frei, um Maßnahmen anlegen zu können
+ActionLabel                              = Bezeichnung der Maßnahme
+ActionDeadline                           = Fälligkeit
+ActionAssignedTo                         = Zugewiesen an
+ActionProgress                           = Fortschritt
+MarkAsDone                               = Als erledigt markieren
+XActionsOfY                              = %s / %s erledigt
+NoActionsYet                             = Derzeit keine Maßnahme
+ActionAdded                              = Die Maßnahme wurde angelegt
+ActionClosed                             = Die Maßnahme wurde abgeschlossen
+ActionsAreProjectTasks                   = Die Maßnahmen sind Unteraufgaben des Dolibarr-Projekts
+SeeProjectTasksView                      = Übergeordnete Aufgabe anzeigen
+OpenTask                                 = Aufgabe öffnen
+AccidentInvestigationValidated           = Die Unfalluntersuchung wurde freigegeben
+AccidentInvestigationReOpened            = Die Unfalluntersuchung wurde erneut geöffnet
+AccidentInvestigationTaskCreated         = Die Aufgaben der Unfalluntersuchung wurden angelegt
+AccidentInvestigationTaskDeleted         = Die Aufgaben der Unfalluntersuchung wurden gelöscht
+CausalityTree                            = Ursachenbaum
+TaskWillBeCreatedAfterValidation         = Die Aufgaben werden nach der Freigabe der Unfalluntersuchung angelegt
+AccidentInvestigationCreated             = Anlegen einer Unfalluntersuchung
+AccidentInvestigationModified            = Änderung einer Unfalluntersuchung
+AccidentInvestigationDeleted             = Löschen einer Unfalluntersuchung
+AccidentInvestigationValidate            = Freigabe einer Unfalluntersuchung
+AccidentInvestigationUnValidate          = Erneutes Öffnen einer Unfalluntersuchung
+AccidentInvestigationLock                = Sperren der Unfalluntersuchung
+AccidentInvestigationSigned              = Unterzeichnung einer Unfalluntersuchung
+CloneWorkStop                            = Arbeitsunfähigkeiten klonen?
+CloneMetadata                            = Ergänzende Daten klonen?
+CloneLesion                              = Ergänzende Daten der Verletzungen klonen?
+CloneFrom                                = Klon von
+AccidentInvestigationRole                = Die Rollen der Unfalluntersuchung
+LesionsOrWorkStop                        = Verletzungen oder Arbeitsunfähigkeiten
+AccidentsCategoriesArea                  = Bereich der Tags/Kategorien der Unfälle
+AddAccidentIntoCategory                  = Diese Kategorie dem Unfall zuweisen
+PreventionplansCategoriesArea            = Bereich der Tags/Kategorien der Präventionspläne
+AddPreventionplanIntoCategory            = Diese Kategorie dem Präventionsplan zuweisen
+FirepermitsCategoriesArea                = Bereich der Tags/Kategorien der Feuererlaubnisscheine
+AddFirepermitIntoCategory                = Diese Kategorie dem Feuererlaubnisschein zuweisen
+RisksCategoriesArea                      = Bereich der Tags/Kategorien der Risiken
+AddRiskIntoCategory                      = Diese Kategorie dem Risiko zuweisen
+AddTicketIntoCategory                    = Diese Kategorie dem Ticket zuweisen
+StartDateInvestigate                     = Beginn der Untersuchung
+EndDateInvestigate                       = Ende der Untersuchung
+YearType                                 = Art des Jahres
+AllYears                                 = Alle Jahre
+FiscalYear                               = Geschäftsjahr
+CalendarYear                             = Kalenderjahr
+
+# AccidentTooltip - Tooltips der Unfälle
+VictimActivityTooltip              = Geben Sie die Tätigkeit oder die Aufgabe des Verunfallten zum Zeitpunkt des Unfalls an, das heißt, was der Verunfallte gerade tat
+AccidentNatureTooltip              = Beschreiben Sie das Ereignis, das zum Unfall geführt hat, wie sich der Unfall ereignet hat (elektrisches Problem, Gasleck, Materialbruch, Ausrutschen, Sturz, körperliche Anstrengung, Übergriff ...) oder wie sich der Verunfallte verletzt hat (Anstoßen, Zusammenstoß, Quetschung, Stich, Ertrinken, Kontakt mit einem Stoff ...)
+AccidentObjectTooltip              = Das heißt, womit sich der Verunfallte verletzt hat: Material, Abfall, Werkzeug (Schraubendreher, Cutter, Bohrmaschine ...), Maschine, Fahrzeug, Flurförderzeug, chemischer Stoff, Bauteil (Tür, Wand ...), Boden ...
+AccidentNatureDoubtTooltip         = Geben Sie gegebenenfalls die begründeten Vorbehalte an, die nur berücksichtigt werden können, wenn sie die zeitlichen und örtlichen Umstände des Unfalls oder das Vorliegen einer vollständig arbeitsfremden Ursache betreffen (Art. R. 441-11 des französischen Sozialgesetzbuchs)
+VictimWorkHoursTooltip             = Geben Sie die von Ihrem Mitarbeiter geleisteten oder die vorgesehenen Arbeitsstunden am Unfalltag an
+ConsequenceTooltip                 = Hat der Verunfallte die Arbeit auf ärztliche Verordnung hin eingestellt, müssen Sie ZWINGEND das Formular «attestation de salaire accident du travail ou maladie professionnelle» - Referenz S6202 - ausfüllen und an die zuständige Krankenkasse am gewöhnlichen Wohnort des Verunfallten senden. <br> Bei einer erneuten Arbeitsunfähigkeit nach einer Behandlungsphase oder einer Wiederaufnahme der Arbeit in einem anderen Monat müssen Sie diese Formalität ebenfalls erneut erfüllen
+FirstPersonNoticedIsWitnessTooltip = Geben Sie Name, Vorname und Anschrift des Zeugen an. <br> Gibt es keinen Zeugen, geben Sie die erste Person des Unternehmens an, die über den Unfall informiert wurde
+ThirdPartyResponsabilityTooltip    = Wenn Ihnen die Beteiligung eines Dritten an einem Arbeits- oder Wegeunfall bekannt ist, muss dies unabhängig von dessen Haftungsanteil zwingend in diesem Abschnitt vermerkt werden
+FrequencyIndexTooltip              = Anzahl der Unfälle je Beschäftigten x 1 000
+FrequencyRateTooltip               = Anzahl der Unfälle je geleistete Arbeitsstunden x 1 000 000
+GravityRateTooltip                 = Anzahl der Tage der Arbeitsunfähigkeit je geleistete Arbeitsstunden x 1 000
+NbWorkedHoursTooltip               = Die Anzahl der geleisteten Arbeitsstunden wurde manuell eingegeben
+DocumentGeneratedWithVersioning    = Beim Versionieren erzeugtes Dokument
+
+# Wörterbuch
+UsualWorkplace                  = Gewöhnlicher Arbeitsplatz
+OccasionalWorkplace             = Gelegentlicher Arbeitsplatz
+LocationOfTheMeal               = Ort der Mahlzeit
+OnTheWayBetweenHomeAndWorkplace = Auf dem Weg zwischen Wohnung und Arbeitsstätte
+OnTheWayBetweenMealAndWorkplace = Auf dem Weg zwischen Arbeit und Ort der Mahlzeit
+DuringATripForTheEmployer       = Während einer Dienstreise für den Arbeitgeber
+
+Trunk             = Rumpf
+Hand              = Hand
+LowerLimbs        = Untere Gliedmaßen
+UpperLimbs        = Obere Gliedmaßen
+MultipleLocations = Mehrfache Lokalisationen
+Foot              = Fuß
+Head              = Kopf
+Eyes              = Augen
+InternalSeating   = Innere Lokalisationen
+Neck              = Hals
+Back              = Rücken
+WholeBody         = Ganzer Körper
+NotSpecified      = Nicht angegeben
+
+PainEffortLumbago           = Schmerzen, Überlastung, Hexenschuss
+Contusion                   = Prellung
+Wounds                      = Wunden
+Sprain                      = Verstauchung
+FracturePitting             = Bruch oder Riss
+MultipleInjuries            = Verletzungen unterschiedlicher Art
+MuscleOrTendonTear          = Muskel- oder Sehnenriss
+PresenceOfForeignBody       = Vorhandensein eines Fremdkörpers
+Burns                       = Verbrennung
+UnspecifiedAndMiscellaneous = Nicht angegeben und Sonstiges
+Other                       = Sonstige
+CutOff                      = Schnittverletzung
+
+Investigator = Untersuchender
+Rescuer      = Ersthelfer
+
+#
+# ListingRisksDocument - Risikoauflistung mit Dokumenten
+#
+
+# Berechtigung
+ListingRisksDocumentMin = Risikoauflistungen mit Dokumenten
+
+# Daten
+ListingRisksDocument            = Risikoauflistung
+Listingrisksdocument            = Risikoauflistung
+ListingRisksHeader              = Risiken - %s
+ListingRisksDocumentGenerated   = Erzeugung der Risikoauflistung mit Dokumenten
+listingrisksdocument.odt        = Risikoauflistung mit Dokumenten
+listingrisksdocument_custom.odt = Individuelle Risikoauflistung mit Dokumenten
+
+#
+# ListingRisksPhoto - Risikoauflistung mit Fotos
+#
+
+# Berechtigung
+ListingRisksPhotosMin = Risikoauflistungen mit Fotos
+
+# Daten
+ListingRisksPhoto            = Risikoauflistung mit Fotos
+Listingrisksphoto            = Risikoauflistung mit Fotos
+ListingRisksPhotoGenerated   = Erzeugung der Risikoauflistung mit Fotos
+listingrisksphoto.odt        = Risikoauflistung mit Fotos
+listingrisksphoto_custom.odt = Individuelle Risikoauflistung mit Fotos
+
+
+#
+# ListingRisksAction - Risikoauflistung mit Korrekturmaßnahmen
+#
+
+# Berechtigung
+ListingRisksActionsMin = Risikoauflistungen mit Korrekturmaßnahmen
+
+# Daten
+ListingRisksAction                        = Risikoauflistung mit Korrekturmaßnahmen
+Listingrisksaction                        = Risikoauflistung mit Korrekturmaßnahmen
+ListingRisksActionGenerated               = Erzeugung der Risikoauflistung mit Korrekturmaßnahmen
+listingrisksaction.odt                    = Risikoauflistung mit Korrekturmaßnahmen
+listingrisksaction_custom.odt             = Individuelle Risikoauflistung mit Korrekturmaßnahmen
+DigiriskListingRisksActionData            = Konfigurierbare Daten der Risikoauflistungen mit Korrekturmaßnahmen
+ShowTaskDoneListingRisksActionDescription = Ermöglicht das Ein- und Ausblenden der abgeschlossenen Aufgaben in der Risikoauflistung mit Korrekturmaßnahmen
+
+
+#
+# RiskAssessmentDocument - Gefährdungsbeurteilung
+#
+
+# Berechtigung
+
+RiskAssessmentDocumentsMin = Gefährdungsbeurteilungen
+
+# Daten
+RiskAssessmentDocument                                    = Gefährdungsbeurteilung
+Riskassessmentdocument                                    = Gefährdungsbeurteilung
+RiskAssessmentDocumentGenerated                           = Erzeugung der Gefährdungsbeurteilung
+AuditStartDate                                            = Beginn des Audits
+AuditEndDate                                              = Ende des Audits
+Recipient                                                 = Empfänger
+ImportantNote                                             = Wichtiger Hinweis
+SitePlans                                                 = Lage der Pläne
+SetStartEndDateBeforeSendEmail                            = Legen Sie auf dieser Seite das Anfangs- und Enddatum des Audits fest, um eine E-Mail zu versenden
+NoSitePlans                                               = Kein Plan des Unternehmens hinterlegt
+riskassessmentdocument.odt                                = Gefährdungsbeurteilung
+riskassessmentdocument_custom.odt                         = Individuelle Gefährdungsbeurteilung
+DigiriskRiskAssessmentDocumentData                        = Konfigurierbare Daten der Gefährdungsbeurteilung
+ActionPreventionCompletedTaskDone                         = Die abgeschlossenen Maßnahmen werden nicht angezeigt
+AppliedOn                                                 = Aktiv auf:
+RiskAssessmentDocumentMethod                              = * Schritt 1: Erhebung der Informationen<br />- Begehung der Räumlichkeiten<br />- Erhebung der Personaldaten<br /><br />* Schritt 2: Festlegung der Methodik und des Dokuments<br />- Freigabe der Standard-Datenblätter der Arbeitseinheiten<br />- Freigabe der Struktur der Einheiten<br /><br />* Schritt 3: Durchführung der Risikostudie<br />- Sensibilisierung des Personals für Risiken und Gefahren<br />- Anlegen der Arbeitseinheiten mit dem Personal und den Verantwortlichen<br />- Bewertung der Risiken je Arbeitseinheit mit dem Personal<br /><br />* Schritt 4<br />- Aufbereitung und Erstellung der Gefährdungsbeurteilung
+RiskAssessmentDocumentSources                             = Die Sensibilisierung für Risiken ist in der vom INRS herausgegebenen ED840 beschrieben.<br />In diesem Dokument finden Sie:<br />- Die Definition eines Risikos und einer Gefahr sowie eine erläuternde Grafik<br />- Die Erläuterungen zu den verschiedenen Bewertungsmethoden
+RiskAssessmentDocumentImportantNote                       = Wichtige Hinweise:<br />Die Dokumentation von DigiRisk finden Sie hier<br /><a href="https://wiki.dolibarr.org/index.php?title=Module_Digirisk" target="_blank">https://wiki.dolibarr.org/index.php?title=Module_Digirisk</a><br />Das Projekt können Sie hier verfolgen:<br /><a href="https://github.com/Evarisk/Digirisk/projects?type=classic" target="_blank">https://github.com/Evarisk/Digirisk/projects?type=classic</a><br />Einen Fehler melden Sie hier<br /><a href="https://github.com/Evarisk/Digirisk/issues" target="_blank">https://github.com/Evarisk/Digirisk/issues</a>
+GenerateZipArchiveWithDigiriskElementDocuments            = Erzeugung eines ZIP-Archivs mit der Gefährdungsbeurteilung
+GenerateZipArchiveWithDigiriskElementDocumentsDescription = Automatische Erzeugung eines ZIP-Archivs mit der Gefährdungsbeurteilung und allen Arbeitsplatzdatenblättern beim Erzeugen der Gefährdungsbeurteilung
+RiskAssessmentDocumentDescription                         = Aktionsplan der Gefährdungsbeurteilung
+ErrorFailToFetchDigiriskElements                          = Fehler: Die Gruppierungen und Arbeitseinheiten für das ZIP-Archiv konnten nicht abgerufen werden
+ErrorNoDocumentModelFound                                 = Fehler: Für <b>%s</b> ist keine Dokumentvorlage verfügbar
+ErrorFailToGenerateDigiriskElementDocument                = Fehler: Die Dokumenterzeugung für <b>%s</b> ist fehlgeschlagen, es fehlt im ZIP-Archiv
+
+# Boxes - Widget
+NextGenerateDate  = Nächste Erzeugung
+LastGenerateDate  = Letzte Erzeugung
+DelayGenerateDate = Verbleibende Tage
+NoDelay           = Kein Verzug
+
+# E-Mail
+RiskAssessmentDocumentLabel   = Zusammenfassung der Gefährdungsbeurteilung
+RiskAssessmentDocumentSubject = E-Mail zur Gefährdungsbeurteilung
+RiskAssessmentDocumentContent = Anbei finden Sie das ZIP-Archiv und das ODT-Dokument der Gefährdungsbeurteilung.
+
+
+
+#
+# AuditReportDocument - Auditbericht
+#
+
+# Daten
+AuditReportDocument     = Auditbericht
+Auditreportdocument     = Auditbericht
+AuditReportDocumentsMin = Auditberichte
+auditreportdocument.odt = Auditbericht
+
+
+
+#
+# GroupmentDocument - Datenblatt der Gruppierung
+#
+
+# Berechtigung
+
+# Daten
+GroupmentDocument                        = Datenblatt der Gruppierung
+Groupmentdocument                        = Datenblatt der Gruppierung
+DocumentModelStandardPDF                 = Standard-PDF-Vorlage
+GroupmentDocumentGenerated               = Erzeugung des Datenblatts der Gruppierung
+groupmentdocument.odt                    = Datenblatt der Gruppierung
+groupmentdocument_custom.odt             = Individuelles Datenblatt der Gruppierung
+groupmentdocumentinherited.odt           = Datenblatt der Gruppierung - Vererbte Risiken
+groupmentdocumentinherited_custom.odt    = Individuelles Datenblatt der Gruppierung - Vererbte Risiken
+groupmentdocumentshared.odt              = Datenblatt der Gruppierung - Geteilte Risiken
+groupmentdocumentshared_custom.odt       = Individuelles Datenblatt der Gruppierung - Geteilte Risiken
+DigiriskGroupmentDocumentData            = Konfigurierbare Daten der Datenblätter der Gruppierungen
+ShowTaskDoneGroupmentDocumentDescription = Ermöglicht das Ein- und Ausblenden der abgeschlossenen Aufgaben im Datenblatt der Gruppierung
+
+#
+# WorkUnitDocumment - Datenblatt der Arbeitseinheit
+#
+
+# Berechtigung
+
+# Daten
+WorkUnitDocument                        = Datenblatt der Arbeitseinheit
+Workunitdocument                        = Datenblatt der Arbeitseinheit
+WorkUnitDocumentGenerated               = Erzeugung des Datenblatts der Arbeitseinheit
+workunitdocument.odt                    = Datenblatt der Arbeitseinheit
+workunitdocument_custom.odt             = Individuelles Datenblatt der Arbeitseinheit
+workunitdocumentinherited.odt           = Datenblatt der Arbeitseinheit - Vererbte Risiken
+workunitdocumentinherited_custom.odt    = Individuelles Datenblatt der Arbeitseinheit - Vererbte Risiken
+workunitdocumentshared.odt              = Datenblatt der Arbeitseinheit - Geteilte Risiken
+workunitdocumentshared_custom.odt       = Individuelles Datenblatt der Arbeitseinheit - Geteilte Risiken
+workunitdocumentcomplete.odt            = Datenblatt der Arbeitseinheit - Alle Risiken (eigene, vererbte, geteilte)
+workunitdocumentcomplete_custom.odt     = Individuelles Datenblatt der Arbeitseinheit - Alle Risiken
+DigiriskWorkUnitDocumentData            = Konfigurierbare Daten der Datenblätter der Arbeitseinheiten
+ShowTaskDoneWorkUnitDocumentDescription = Ermöglicht das Ein- und Ausblenden der abgeschlossenen Aufgaben im Datenblatt der Arbeitseinheit
+
+
+#
+# DigiriskElement - Digirisk-Element
+#
+
+# Berechtigungen
+DigiriskElementsMin = Digirisk-Elemente (Gruppierung und Arbeitseinheit)
+
+# Daten
+NewDigiriskElement                  = Neues Digirisk-Element
+Digiriskelement                     = Gruppierung / Arbeitseinheit
+GPUTOrganization                    = Organisation der GP/UT
+DigiriskElement                     = Digirisk-Element
+HiddenElements                      = Papierkorb
+DigiriskElementCreated              = Anlegen eines Digirisk-Elements
+DigiriskElementModified             = Änderung eines Digirisk-Elements
+DigiriskElementDeleted              = Löschen eines Digirisk-Elements
+ElementType                         = Elementtyp
+ParentElement                       = Übergeordnetes Element
+OrganizationSaved                   = Die Organisation der Gruppierungen und Arbeitseinheiten wurde gespeichert
+OrganizationNotSaved                = Die Organisation der Gruppierungen und Arbeitseinheiten konnte nicht gespeichert werden
+UnsavedChanges                      = Nicht gespeicherte Änderungen
+SavingInProgress                    = Speichern läuft ...
+Saved                               = Gespeichert
+ErrorSaving                         = Fehler beim Speichern
+DigiriskElementOrganization         = Organisation der Struktur
+ShareDigiriskelement                = Teilen der Gruppierungen und Arbeitseinheiten aktivieren
+DIGIRISKELEMENTSharing              = Teilen der Gruppierungen und Arbeitseinheiten
+DIGIRISKELEMENTSharingDescription   = Auswahl der Mandanten, die ihre Gruppierungen und Arbeitseinheiten mit diesem Mandanten teilen.
+DigiriskElementSharedTooltip        = Diese Option ermöglicht das Teilen der Gruppierungen und Arbeitseinheiten. <br> INFO: Wenn Sie die Aufgaben anzeigen möchten, müssen Sie die Option zum Teilen der Projekte aktivieren.
+PleaseSelectADigiriskElement        = Eine Gruppierung oder eine Arbeitseinheit auswählen ...
+Registers                           = Register
+ShowInSelectOnPublicTicketInterface = Muss in der Elementliste der öffentlichen Ticket-Schnittstelle erscheinen
+Organization                        = Organisation GP/UT
+YouDontHaveOrganization             = Sie haben keine Gruppierungen oder Arbeitseinheiten angelegt, wechseln Sie zu "Gefährdungsbeurteilung" oder klicken Sie <b> hier </b>, um welche anzulegen.
+
+
+#
+# Groupment - Gruppierung
+#
+
+# Daten
+Groupment                  = Gruppierung
+GroupmentManagement        = Verwaltung der Daten der Gruppierungen
+NewGroupment               = Neue Gruppierung
+ModifyGroupment            = Gruppierung bearbeiten
+TrashGroupment             = Papierkorb-Gruppierung
+DeletedElements            = Papierkorb
+DeletedDigiriskElement     = In den Papierkorb verschobene Gruppierungen / Arbeitseinheiten
+ShowDeletedDigiriskElement = Die Gruppierungen / Arbeitseinheiten anzeigen, die sich im Papierkorb befinden
+
+#
+# WorkUnit - Arbeitseinheit
+#
+
+# Daten
+WorkUnit           = Arbeitseinheit
+Workunit           = Arbeitseinheit
+WorkUnitManagement = Verwaltung der Daten der Arbeitseinheiten
+NewWorkUnit        = Neue Arbeitseinheit
+ModifyWorkUnit     = Arbeitseinheit bearbeiten
+
+
+#
+# Evaluator - Bewerter
+#
+
+# Berechtigungen
+EvaluatorsMin = Bewerter
+
+# Daten
+Evaluator                    = Bewerter
+Evaluators                   = Bewerter
+EvaluatorCreated             = Anlegen eines Bewerters
+EvaluatorModified            = Änderung eines Bewerters
+EvaluatorDeleted             = Löschen eines Bewerters
+TheEvaluator                 = Der Bewerter
+EvaluatorWellCreated         = Bewerter angelegt
+EvaluatorNotCreated          = Fehler beim Anlegen des Bewerters
+EvaluatorList                = Liste der Bewerter
+AssignmentDate               = Zuweisungsdatum
+EvaluationDuration           = Dauer
+UserAssigned                 = Zugewiesener Benutzer
+AddEvaluatorTitle            = Hinzufügen eines Bewerters
+AddEvaluatorButton           = Bewerter hinzufügen
+EvaluatorConfig              = Konfiguration der Daten der Bewerter
+DeleteEvaluatorMessage       = Löschen des Bewerters
+DigiriskEvaluatorData        = Konfigurierbare Daten der Bewerter
+EvaluatorDuration            = Dauer der Bewertung durch den Bewerter
+EvaluatorDurationDescription = Die Zeit, die der Bewerter für seine Risikobewertung benötigt
+NbEmployeesInvolved          = Beteiligte Beschäftigte
+NbEmployees                  = Beschäftigte
+NbEmployeesInvolvedTooltip   = Eindeutige Beschäftigte (Bewerter)
+NbEmployeesTooltip           = Wenn die zentrale Verwaltung der Benutzer und Gruppen auf dem Hauptmandanten aktiviert ist.<br>Die Anzahl der Beschäftigten entspricht der Anzahl der geteilten bzw. einer Gruppe zugewiesenen Benutzer sowie der Anzahl der Administratoren des Hauptmandanten
+NbEmployeesConfTooltip       = Die Anzahl der Beschäftigten wurde manuell eingegeben
+
+
+#
+# DigiriskStandard - Digirisk-Standard
+#
+
+# Daten
+DigiriskStandardInformation = Information
+Digiriskstandard            = Digirisk-Standard
+DigiriskStandardMin         = Digirisk-Standards
+TheDigiriskstandard         = der Digirisk-Standard
+
+
+#
+# RisksAnalysis - Risikoanalyse
+#
+
+# Daten
+RiskAnalysis = Risikoanalyse
+UpdateData   = Aktualisieren
+
+#
+# Risks - Risiken
+#
+
+# Berechtigungen
+RisksMin = Risiken
+
+# Daten
+Risks                                    = Risiken
+Risk                                     = Risiko
+Riskprofessionals                        = Berufsbedingte Risiken
+RiskCreated                              = Anlegen eines Risikos
+RiskModified                             = Änderung eines Risikos
+RiskDeleted                              = Löschen eines Risikos
+RiskConfig                               = Konfiguration der Daten der Risiken
+TheRisk                                  = Das Risiko
+RiskWellCreated                          = Risiko angelegt
+RiskNotCreated                           = Fehler beim Anlegen des Risikos
+RiskWellEdited                           = Risiko bearbeitet
+RiskNotEdited                            = Fehler beim Bearbeiten des Risikos
+RiskList                                 = Risikoauflistung
+AddRiskTitle                             = Hinzufügen des Risikos
+AddRiskButton                            = Risiko hinzufügen
+EditRisk                                 = Bearbeitung des Risikos
+LinkedRisk                               = Verknüpftes Risiko
+RiskCategory                             = Kat.
+RiskCategoryEdit                         = Risikokategorie
+RiskCategoryEditDescription              = Die Änderung der Kategorie eines bestehenden Risikos aktivieren
+HowToEditRiskCategory                    = Um die Kategorie des Risikos zu ändern, klicken Sie auf das Piktogramm der Kategorie
+DigiriskElementRisksList                 = Liste der Risiken
+DigiriskElementRisk                      = Risiken
+RiskDescriptionNotEnabled                = Das Feld Beschreibung des Risikos ist nicht aktiviert
+HowToEnableRiskDescription               = Um das Feld Beschreibung des Risikos zu aktivieren, gehen Sie zu "Konfiguration des Moduls -> Gefährdungsbeurteilung"
+HowToEnableRiskCategoryEdit              = Um die Änderung der Risikokategorie zu aktivieren, gehen Sie zu "Konfiguration des Moduls -> Gefährdungsbeurteilung"
+SortRisksListingsByEvaluation            = Die Risiken nach Bewertung sortieren
+SortRisksListingsByEvaluationDescription = Die automatische Sortierung der Risiken nach Bewertung in den Auflistungen aktivieren
+ListingHeaderEvaluation                  = Liste der Bewertungen
+RiskDescription                          = Beschreibung des Risikos
+RiskDescriptionDescription               = Das Feld Beschreibung des Risikos aktivieren
+RiskDescriptionNotActivated              = Bitte aktivieren Sie das Feld Beschreibung des Risikos unter Konfiguration des Moduls / Risikoanalyse / Risiken
+AddRisk                                  = Ein Risiko hinzufügen
+MoveRisk                                 = Das Risiko verschieben
+MoveRisks                                = Die Risiken verschieben
+MoveRisksDescription                     = Ermöglicht das Verschieben der Risiken von einer Gruppierung oder Arbeitseinheit zu einer anderen
+SetConfToMoveRisk                        = Sie müssen zunächst das Verschieben der Risiken unter "Konfiguration des Moduls -> Gefährdungsbeurteilung" erlauben
+RiskDescriptionPrefill                   = Die Beschreibung vorausfüllen
+RiskDescriptionPrefillDescription        = Die Beschreibung des Risikos mit dem Namen der Kategorie vorausfüllen
+DigiriskElementSharedRisksList           = Liste der geteilten Risiken
+ImportSharedRisks                        = Geteilte Risiken importieren
+SelectAllSharedRisksOfElement            = Alle Risiken dieses Elements auswählen
+AlreadyImported                          = Bereits importiert
+ShowSharedRisks                          = Geteilte Risiken
+ShareRisk                                = Teilen der Risiken aktivieren
+RISKSharing                              = Teilen der Risiken
+RISKSharingDescription                   = Auswahl der Mandanten, die ihre Risiken mit diesem Mandanten teilen.
+ShowSharedRisksDescription               = Die geteilten Risiken in den Dokumenten und den Auflistungen anzeigen
+UnlinkSharedRisk                         = Verknüpfung des geteilten Risikos aufheben
+RiskWellUnlinkShared                     = Risikoverknüpfung aufgehoben
+RiskNotUnlinkShared                      = Fehler beim Aufheben der Risikoverknüpfung
+HasBeenUnlinkSharedM                     = wurde entkoppelt
+HasNotBeenUnlinkSharedM                  = wurde nicht entkoppelt
+RiskSharedTooltip                        = Diese Option ermöglicht das Teilen der Risiken. <br> INFO: Wenn Sie die Aufgaben anzeigen möchten, müssen Sie die Option zum Teilen der Projekte aktivieren.
+ShowInheritedRisksInListings             = Vererbte Risiken - Auflistungen <br> (aus den übergeordneten Ebenen)
+ShowInheritedRisksInListingsDescription  = Vererbte Risiken sind die auf einer übergeordneten Ebene (z. B. Standort oder GP) definierten und automatisch auf die GP/UT angewendeten Risiken. <br> Aktivieren Sie diese Option, um sie in den Auflistungen anzuzeigen
+ShowInheritedRisksInDocuments            = Vererbte Risiken - Dokumente <br> (aus den übergeordneten Ebenen)
+ShowInheritedRisksInDocumentsDescription = Vererbte Risiken sind die auf einer übergeordneten Ebene (z. B. Standort oder GP) definierten und automatisch auf die GP/UT angewendeten Risiken. <br> Aktivieren Sie diese Option, um sie in den Dokumenten anzuzeigen
+DigiriskElementInheritedRisksList        = Liste der vererbten Risiken
+ConfirmImportSharedRisks                 = Bitte wählen Sie die zu importierenden geteilten Risiken aus
+RisksRepartition                         = Verteilung der Risiken nach Bewertung
+ShowRiskOrigin                           = Die Herkunft des Risikos anzeigen
+ShowRiskOriginDescription                = Die Herkunft der Risiken in den Dokumenten anzeigen (Gefährdungsbeurteilung, Gruppierung, Arbeitseinheiten, Risikoauflistung mit Maßnahmen und mit Fotos usw.).
+SharedRiskImportWithSuccess              = Risiko erfolgreich importiert
+RiskImport                               = Import von Risiken
+RiskUnlink                               = Löschen des geteilten Risikos
+RiskDeleted                              = Das Risiko %s wurde gelöscht
+RiskSharedWithEntityRefLabel             = Teilen des Risikos %s mit
+RiskUnlinkedFromEntityRefLabel           = Entkopplung des Risikos %s von
+TheDigiriskelement                       = das Digirisk-Element
+DefaultProjectContactType                = Standardrolle für das Projekt der Gefährdungsbeurteilung
+DefaultTaskContactType                   = Standardrolle für die Aufgaben des Projekts der Gefährdungsbeurteilung
+RiskListParentView                       = Alle übergeordneten Elemente anzeigen
+RiskListParentViewDescription            = Alle übergeordneten Elemente eines Risikos in der Risikoliste und in den Dokumenten anzeigen
+CategoryOnRisk                           = Die Tags/Kategorien auf den Risiken anzeigen
+CategoryOnRiskDescription                = Ermöglicht das Zuweisen und Anzeigen von Tags/Kategorien auf den Risiken - mit Vorsicht zu verwenden
+AddPsychosocialRisk                      = Ein psychosoziales Risiko hinzufügen
+AddPsychosocialRiskTitle                 = Hinzufügen eines psychosozialen Risikos
+AddPsychosocialRiskButton                = Das psychosoziale Risiko hinzufügen
+AddSelectedPsychosocialRisks             = Die ausgewählten psychosozialen Risiken hinzufügen
+SocialRelationsAtWork                    = Soziale Beziehungen am Arbeitsplatz
+WorkIntensityAndTime                     = Arbeitsintensität und Arbeitszeit
+EmotionalRequirements                    = Emotionale Anforderungen
+Autonomy                                 = Autonomie
+MeaningOfWork                            = Sinn der Arbeit
+WorkSituationInsecurity                  = Unsicherheit der Arbeitssituation
+PreventionContextInCompany               = Präventionskontext im Unternehmen
+RPSImpactOnCompanyAndEmployees           = Auswirkung der psychosozialen Risiken auf das Unternehmen und die Beschäftigten
+PsychosocialRisksFactors                 = Psychosoziale Risikofaktoren
+CompanyPreventionInformations            = Informationen zur Prävention im Unternehmen
+Weak                                     = Gering
+Moderate                                 = Mäßig
+High                                     = Hoch
+Extreme                                  = Extrem
+HereIsTheWorkStationDescription          = Dies ist die Beschreibung des Arbeitsplatzes
+ImageAnalysis                            = Bildanalyse
+TextAnalysis                             = Textanalyse
+AnalyzeText                              = Den Text analysieren
+EnterTextForAnalysis                     = Geben Sie den zu analysierenden Text ein
+AIRiskAnalysis                           = Risikoanalyse durch KI
+AnalysisInProgress                       = Analyse läuft ...
+
+# Statistiken
+GreyRisk                                         = Geringes Risiko
+OrangeRisk                                       = Zu planendes Risiko
+RedRisk                                          = Zu behandelndes Risiko
+BlackRisk                                        = Nicht hinnehmbares Risiko
+RisksNotAssessed                                 = Nicht bewertete Risiken
+RisksRepartitionByDangerCategories               = Verteilung der Risiken nach Gefahrenkategorie
+RiskListsByDangerCategories                      = Liste der Risiken nach Gefahrenkategorie
+DigiriskElementsRepartitionByDepth               = Verteilung der Struktur der Gruppierungen der Ebene %s
+RisksRepartitionByDangerCategoriesAndCriticality = Verteilung der Risiken nach Gefahrenkategorie und Kritikalität
+NumberOfRisks                                    = Anzahl der Risiken
+DangerCategories                                 = Gefahrenkategorien
+RisksRepartitionByDigiriskElement                = Verteilung der Risiken nach Gruppierung / Arbeitseinheit %s
+
+
+
+#
+# RiskEnvironmentals - Umweltrisiken
+#
+
+# Daten
+Environment                                    = Umwelt
+Riskenvironmental                              = Umweltrisiko
+RiskEnvironmentals                             = Umweltrisiken
+Riskenvironmentals                             = Umweltrisiken
+RiskEnvironmentalsMin                          = Umweltrisiken
+AddRiskenvironmentalTitle                      = Hinzufügen des Umweltrisikos
+DigiriskElementRiskenvironmentalsList          = Liste der Umweltrisiken
+DigiriskElementInheritedRiskenvironmentalsList = Liste der vererbten Umweltrisiken
+DigiriskElementSharedRiskenvironmentalsList    = Liste der geteilten Umweltrisiken
+ImportSharedRiskenvironmentals                 = Geteilte Umweltrisiken importieren
+SelectAllSharedRiskenvironmentalsOfElement     = Alle Umweltrisiken dieses Elements auswählen
+ConfirmImportSharedRiskenvironmentals          = Bitte wählen Sie die zu importierenden geteilten Umweltrisiken aus
+EnvironmentDescription                         = Planung - Maßnahmen zur Bewältigung von Risiken und Chancen
+
+#
+# ListingRisksEnvironmentalAction - Auflistung der Umweltrisiken mit Korrekturmaßnahmen
+#
+
+# Berechtigung
+ListingRisksEnvironmentalActionMin = Auflistung der Umweltrisiken mit Korrekturmaßnahmen
+
+# Daten
+ListingRisksEnvironmentalAction            = Auflistung der Umweltrisiken mit Korrekturmaßnahmen
+Listingrisksenvironmentalaction            = Auflistung der Umweltrisiken mit Korrekturmaßnahmen
+ListingRisksEnvironmentalActionGenerated   = Erzeugung der Auflistung der Umweltrisiken mit Korrekturmaßnahmen
+listingrisksenvironmentalaction.odt        = Auflistung der Umweltrisiken mit Korrekturmaßnahmen
+listingrisksenvironmentalaction_custom.odt = Individuelle Auflistung der Umweltrisiken mit Korrekturmaßnahmen
+
+#
+# ListingRisksEnvironmentalDocument - Auflistung der Umweltrisiken mit Dokumenten
+#
+
+# Daten
+ListingRisksEnvironmentalDocument = Auflistung der Umweltrisiken
+
+
+
+#
+# RiskAssessment - Bewertung
+#
+
+# Daten
+RiskAssessment                              = Bewertung
+Riskassessment                              = Bewertung
+RiskAssessments                             = Bewertungen
+RiskAssessmentCreated                       = Anlegen einer Bewertung
+RiskAssessmentModified                      = Änderung einer Bewertung
+RiskAssessmentDeleted                       = Löschen einer Bewertung
+RiskAssessmentConfig                        = Konfiguration der Daten der Bewertungen
+TheRiskAssessment                           = Die Bewertung
+LastRiskAssessment                          = Letzte Bewertung des Risikos
+RiskAssessmentWellCreated                   = Bewertung angelegt
+RiskAssessmentNotCreated                    = Fehler beim Anlegen der Bewertung
+RiskAssessmentWellEdited                    = Bewertung bearbeitet
+RiskAssessmentNotEdited                     = Fehler beim Bearbeiten der Bewertung
+RiskAssessmentWellDeleted                   = Bewertung gelöscht
+RiskAssessmentNotDeleted                    = Fehler beim Löschen der Bewertung
+EvaluationCreate                            = Hinzufügen der Bewertung
+EvaluationEdit                              = Bearbeitung der Bewertung
+EvaluationMethod                            = Bewertungsmethode
+lastEvaluationOn                            = Letzte Bewertung am
+DeleteEvaluation                            = Möchten Sie die Bewertung wirklich löschen?
+DigiriskRiskAssessmentData                  = Konfigurierbare Daten der Bewertungen
+MultipleRiskAssessmentMethodName            = Bewertungsmethoden
+MultipleRiskAssessmentMethodDescription     = Den Wechsel der Bewertungsmethode aktivieren
+AdvancedRiskAssessmentMethod                = Erweiterte Bewertungsmethode
+AdvancedRiskAssessmentMethodDescription     = Die erweiterte Bewertungsmethode aktivieren
+RiskAssessmentList                          = Liste der Bewertungen des Risikos
+EditRiskAssessment                          = Bewertung bearbeiten
+ShowAllRiskAssessments                      = Alle Bewertungen anzeigen
+ShowAllRiskAssessmentsDescription           = Die vollständige Liste der Risikobewertungen in der Risikoliste anzeigen
+ParentRisk                                  = Übergeordnetes Risiko
+RiskAssessmentDate                          = Datum der Bewertung
+SimpleEvaluation                            = Einfache Bewertung
+AdvancedEvaluation                          = Erweiterte Bewertung
+CalculatedEvaluation                        = Berechnete Bewertung
+SelectEvaluation                            = Aktivieren Sie die Kästchen, um Ihre Bewertung zu berechnen
+EvaluationList                              = Liste der Bewertungen des Risikos
+HowToSetMultipleRiskAssessmentMethod        = Um die mehrfache Verwendung der Bewertungsmethoden zu konfigurieren, gehen Sie zu Konfiguration des Moduls - Risikoanalyse - Bewertung
+NoFileLinked                                = Kein verknüpftes Foto
+AddRiskAssessment                           = Eine Bewertung des Risikos hinzufügen
+AddRiskAssessmentTask                       = Eine Aufgabe zum Risiko hinzufügen
+ListRiskAssessmentTask                      = Liste der Aufgaben des Risikos
+ShowRiskAssessmentDate                      = Datum der Bewertungen
+ShowRiskAssessmentDateDescription           = Ersetzt das Erstellungsdatum durch das Anfangsdatum der Bewertungen im Datenblatt und in den Dokumenten
+RiskAssessmentHideDateInDocument            = Das Datum der Bewertung in den Dokumenten ausblenden
+RiskAssessmentHideDateInDocumentDescription = Das Datum der Bewertung in der Spalte "Informationen zur Bewertung" in den Dokumenten ausblenden
+RiskTaskComplete                            = Aufgabe %s abgeschlossen
+
+# Statistiken
+TasksRepartition = Verteilung der Aufgaben nach gemeldetem tatsächlichem Fortschritt
+TaskAt0Percent   = Aufgabe bei 0
+TaskInProgress   = Laufende Aufgabe
+TaskAt100Percent = Aufgabe bei 100
+
+
+#
+# RiskSign - Kennzeichnung
+#
+
+# Berechtigungen
+RiskSignsMin = Kennzeichnungen
+
+# Daten
+RiskSign                           = Kennzeichnung
+RiskSignCreated                    = Anlegen einer Kennzeichnung
+RiskSignModified                   = Änderung einer Kennzeichnung
+RiskSignDeleted                    = Löschen einer Kennzeichnung
+TheRiskSign                        = Die Kennzeichnung
+RiskSignConfig                     = Konfiguration der Daten der Kennzeichnungen
+RiskSignWellCreated                = Kennzeichnung angelegt
+RiskSignNotCreated                 = Fehler beim Anlegen der Kennzeichnung
+RiskSignWellEdited                 = Kennzeichnung bearbeitet
+RiskSignNotEdited                  = Fehler beim Bearbeiten der Kennzeichnung
+RiskSignWellDeleted                = Kennzeichnung gelöscht
+RiskSignNotDeleted                 = Fehler beim Löschen der Kennzeichnung
+RiskSignCategory                   = Kategorie
+RiskSignImport                     = Import von Kennzeichnungen
+RiskSignUnlink                     = Löschen der geteilten Kennzeichnung
+AddRiskSignTitle                   = Hinzufügen einer Kennzeichnung
+AddRiskSignButton                  = Kennzeichnung hinzufügen
+EditRiskSign                       = Bearbeitung einer Kennzeichnung
+DeleteRiskSignMessage              = Löschen der Kennzeichnung
+DigiriskElementRiskSignList        = Liste der Kennzeichnungen
+RiskSigns                          = Kennzeichnungen
+DigiriskElementSharedRiskSignsList = Liste der geteilten Kennzeichnungen
+ImportSharedRiskSigns              = Geteilte Kennzeichnungen importieren
+SelectAllSharedRiskSignsOfElement  = Alle Kennzeichnungen dieses Elements auswählen
+AlreadyImportedF                   = Bereits importiert
+ShowSharedRiskSigns                = Geteilte Kennzeichnungen
+ShowSharedRiskSignsDescription     = Die geteilten Kennzeichnungen in den Dokumenten und den Auflistungen anzeigen
+DigiriskElementSharedRiskSign      = Geteilte Kennzeichnungen
+SharedRiskSigns                    = Geteilte Kennzeichnungen
+ShareRisksign                      = Teilen der Kennzeichnungen aktivieren
+RISKSIGNSharing                    = Teilen der Kennzeichnungen
+RISKSIGNSharingDescription         = Auswahl der Mandanten, die ihre Kennzeichnungen mit diesem Mandanten teilen.
+UnlinkSharedRiskSign               = Verknüpfung der geteilten Kennzeichnung aufheben
+RiskSignWellUnlinkShared           = Kennzeichnungsverknüpfung aufgehoben
+RiskSignNotUnlinkShared            = Fehler beim Aufheben der Kennzeichnungsverknüpfung
+HasBeenUnlinkSharedF               = wurde entkoppelt
+HasNotBeenUnlinkSharedF            = wurde nicht entkoppelt
+RiskSignSharedTooltip              = Diese Option ermöglicht das Teilen der Kennzeichnungen. <br> INFO: Wenn Sie die Aufgaben anzeigen möchten, müssen Sie die Option zum Teilen der Projekte aktivieren.
+ShowInheritedRiskSigns             = Vererbte Kennzeichnungen
+ShowInheritedRiskSignsDescription  = Die vererbten Kennzeichnungen in den Dokumenten und den Auflistungen anzeigen
+DigiriskElementInheritedRiskSignsList = Liste der vererbten Kennzeichnungen
+ConfirmImportSharedRiskSigns       = Bitte wählen Sie die zu importierenden geteilten Kennzeichnungen aus
+RiskSignSharedWithEntityRefLabel   = Teilen der Kennzeichnung %s mit
+RiskSignUnlinkedFromEntityRefLabel = Entkopplung der Kennzeichnung %s von
+
+#
+# Tasks - Aufgabe
+#
+
+# Daten
+ActionPlan                               = Aktionsplan
+Task                                     = Aufgabe
+TaskCreatedEvent                         = Anlegen einer Aufgabe
+TaskModifiedEvent                        = Änderung einer Aufgabe
+TaskDeletedEvent                         = Löschen einer Aufgabe
+TheTask                                  = Die Aufgabe
+TaskConfig                               = Konfiguration der Daten der Aufgaben
+TaskWellCreated                          = Aufgabe angelegt
+TaskNotCreated                           = Fehler beim Anlegen der Aufgabe
+TaskWellEdited                           = Aufgabe bearbeitet
+TaskNotEdited                            = Fehler beim Bearbeiten der Aufgabe
+TaskWellDeleted                          = Aufgabe gelöscht
+TaskNotDeleted                           = Fehler beim Löschen der Aufgabe
+TasksManagement                          = Verwaltung der Aufgaben
+SelectProject                            = Auswahl des Projekts
+DUProject                                = Mit den Aufgaben der Risiken verknüpftes Projekt
+EnvironmentProject                       = Mit den Aufgaben der Umweltrisiken verknüpftes Projekt
+NoTaskLinked                             = Keine laufende Aufgabe
+TaskList                                 = Liste der Aufgaben des Risikos
+TaskCreate                               = Hinzufügen der Aufgabe
+TaskEdit                                 = Bearbeitung der Aufgabe
+HowToSetDUProject                        = Um die Auswahl des Projekts zu konfigurieren, gehen Sie zu Konfiguration des Moduls - Risikoanalyse - Aufgabe
+DeleteTask                               = Möchten Sie die Aufgabe wirklich löschen?
+ListingHeaderTask                        = Liste der Aufgaben
+ListingHeaderTaskTooltip                 = Aktivieren Sie das Teilen der Projekte, um die Aufgaben anzuzeigen
+TasksManagementDescription               = Die Aufgabenverwaltung aktivieren
+TaskManagementNotActivated               = Bitte aktivieren Sie die Aufgabenverwaltung unter Konfiguration des Moduls / Risikoanalyse / Aufgabe
+DigiriskProgress                         = Fortschritt
+ShowTaskStartDate                        = Anfangsdatum der Aufgaben
+ShowTaskStartDateDescription             = Ersetzt das Erstellungsdatum durch das Anfangsdatum der Aufgaben im Datenblatt und in den Dokumenten
+ShowTaskEndDate                          = Enddatum der Aufgaben
+ShowTaskEndDateDescription               = Das Enddatum der Aufgaben anzeigen
+ShowTasksDone                            = Abgeschlossene Aufgaben
+ShowTasksDoneDescription                 = Die zu 100 abgeschlossenen Aufgaben anzeigen
+ShowTasksDoneDescriptionExtend           = in den Risikolisten
+ShowTaskCalculatedProgress               = Fortschritt der Aufgabe
+ShowTaskCalculatedProgressDescription    = Den berechneten Fortschritt der Aufgabe anstelle des gemeldeten Fortschritts anzeigen
+ShowAllTasks                             = Alle Aufgaben eines Risikos in den Auflistungen
+ShowAllTasksDescription                  = Alle Aufgaben in der Aufgabenliste eines Risikos in den Auflistungen anzeigen
+DeleteTaskTimeSpent                      = Möchten Sie wirklich %s Min. aufgewendete Zeit von der Aufgabe löschen?
+TaskTimeSpentEdit                        = Bearbeitung der aufgewendeten Zeit der Aufgabe
+TheTaskTimeSpent                         = Die aufgewendete Zeit
+TaskTimeSpentCreated                     = Anlegen aufgewendeter Zeit
+TaskTimeSpentModified                    = Änderung aufgewendeter Zeit
+TaskTimeSpentDeleted                     = Löschen aufgewendeter Zeit
+TaskTimeSpentWellCreated                 = Aufgewendete Zeit angelegt
+TaskTimeSpentNotCreated                  = Fehler beim Anlegen der aufgewendeten Zeit
+TaskTimeSpentWellEdited                  = Aufgewendete Zeit bearbeitet
+TaskTimeSpentNotEdited                   = Fehler beim Bearbeiten der aufgewendeten Zeit
+TaskTimeSpentWellDeleted                 = Aufgewendete Zeit gelöscht
+TaskTimeSpentNotDeleted                  = Fehler beim Löschen der aufgewendeten Zeit
+OnTheTask                                = an der Aufgabe
+TaskTimeSpentDuration                    = Dauer der aufgewendeten Zeit
+TaskTimeSpentDurationDescription         = Die standardmäßig zu jeder Aufgabe hinzugefügte aufgewendete Zeit
+NoTaskShared                             = Keine geteilten Aufgaben
+WarningTaskLabel                         = Achtung, Sie haben die maximal zulässige Zeichenzahl (255) überschritten
+ErrorRecordHasSubTasks                   = Die Aufgabe hat untergeordnete Elemente
+TotalConsumedTime                        = Gesamte aufgewendete Zeit im Projekt
+TotalConsumedTimeAmount                  = Kosten der aufgewendeten Zeit
+NbTasks                                  = Anzahl der Aufgaben
+TotalProgress                            = Gesamter tatsächlicher Fortschritt der Aufgaben
+TotalBudget                              = Summe der Budgets der Aufgaben
+TaskTimeSpentDate                        = Datum der aufgewendeten Zeit
+StartDateCannotBeAfterEndDate            = Das Enddatum darf nicht vor dem Anfangsdatum liegen
+TasksFromProject                         = Die angezeigten Aufgaben stammen aus dem Projekt, das als "Projekt der Gefährdungsbeurteilung" festgelegt ist
+TaskHideRefInDocument                    = Die Referenz ausblenden
+TaskHideRefInDocumentDescription         = Die Referenz der Aufgabe in den Dokumenten ausblenden
+TaskHideResponsibleInDocument            = Den Verantwortlichen ausblenden
+TaskHideResponsibleInDocumentDescription = Den Verantwortlichen der Aufgabe in den Dokumenten ausblenden
+TaskHideDateInDocument                   = Das Datum ausblenden
+TaskHideDateInDocumentDescription        = Das Anfangs- und Enddatum der Aufgabe in den Dokumenten ausblenden
+TaskHideBudgetInDocument                 = Das Budget ausblenden
+TaskHideBudgetInDocumentDescription      = Das Budget der Aufgabe in den Dokumenten ausblenden
+
+#
+# DigiAI - DigiAI
+#
+
+# Daten
+WelcomeToDigiAI = Willkommen bei DigiAI
+UploadAnImage = Ein Bild hochladen
+OpenAIApiKey = OpenAI-API-Schlüssel
+OpenAIApiKeyDescription = Um DigiAI zu verwenden, benötigen Sie einen OpenAI-API-Schlüssel. Sie erhalten einen, indem Sie ein Konto auf <a href="https://platform.openai.com/signup" target="_blank">https://platform.openai.com/signup</a> anlegen. Nach der Registrierung können Sie im Bereich "API Keys" Ihres Dashboards einen API-Schlüssel erzeugen.
+
+#
+# Ticket - Öffentliche Ticket-Schnittstelle
+#
+
+# Berechtigungen
+TicketTagsConfig                         = Änderung der Arbeitsschutzregister
+
+# Daten
+Register                                 = Register
+Send                                     = Senden
+TicketSent                               = Ticket gesendet
+FilesLinked                              = Fotos / Anhänge
+AddDocument                              = Dokument hinzufügen
+LastnamePlaceholder                      = Beispiel: Müller
+FirstnamePlaceholder                     = Beispiel: Hans
+PhonePlaceholder                         = 00.00.00.00.00
+LocationPlaceholder                      = Beispiel: Büro A
+ServicePlaceholder                       = Beispiel: Müllwerker
+Location                                 = Ort
+CategoriesCreated                        = Anlegen der Ticket-Kategorien
+ExtrafieldsCreated                       = Anlegen der Zusatzfelder für Tickets
+AnticipatedLeave                         = Vorzeitiges Verlassen
+DGI                                      = Ernste und unmittelbare Gefahr
+SST                                      = Sicherheit und Gesundheit bei der Arbeit
+PresquAccident                           = Beinaheunfall
+Accident                                 = Unfall
+EnhancementSuggestion                    = Verbesserungsvorschlag
+MaterialProblem                          = Materielles Problem
+HumanProblem                             = Menschliches Problem
+Others                                   = Sonstiges
+AccidentWithoutDIAT                      = Leichter Unfall
+AccidentWithDIAT                         = Arbeitsunfall
+Environment                              = Umwelt
+Quality                                  = Qualität
+NonCompliance                            = Nichtkonformität
+FirstName                                = Vorname
+LastName                                 = Name
+Phone                                    = Telefon
+DeclarationDate                          = Meldung
+DigiriskTicketPublicAccess               = Unter der folgenden URL steht eine öffentliche Schnittstelle zur Verfügung, die keine Anmeldung erfordert
+TicketActivatePublicInterface            = Die öffentliche Schnittstelle aktivieren
+GenerateExtrafields                      = Erzeugung der Standard-Zusatzfelder für Tickets
+GenerateTicketCategories                 = Erzeugung der Standard-Kategorien für Tickets
+AlreadyGenerated                         = Bereits erzeugt
+NotGenerated                             = Noch nicht erzeugt
+NotCreated                               = Noch nicht angelegt
+ExtrafieldsGeneration                    = Diese Option ermöglicht die Erzeugung der Standard-Zusatzfelder für Tickets. Angelegt werden: <br> Name, Vorname, Telefon, GP/UT, Ort und Datum
+CategoriesGeneration                     = Diese Option ermöglicht die Erzeugung der Standard-Kategorien für Tickets. Angelegt werden: <br> - Register <br> - - Unfall <br> - - - Beinaheunfall, Leichter Unfall, Arbeitsunfall <br> - - Sicherheit und Gesundheit bei der Arbeit <br> - - - Vorzeitiges Verlassen, Sonstiges, Menschliches Problem, Materielles Problem <br> - - Ernste und unmittelbare Gefahr <br> - - Qualität <br> - - - Nichtkonformität, Verbesserungsvorschlag <br> - - Umwelt <br> - - - Nichtkonformität, Sonstiges
+TicketSuccess                            = Ihr Registereintrag wurde an die Präventionsabteilung übermittelt unter der Nummer:
+TicketPublicAccess                       = Rücklink zur öffentlichen Ticket-Schnittstelle:
+TicketShowCompanyLogo                    = Das Logo des Unternehmens in der öffentlichen Schnittstelle anzeigen
+TicketShowCompanyLogoHelp                = Aktivieren Sie diese Option, um das Logo des Unternehmens auf den Seiten der öffentlichen Schnittstelle auszublenden
+YouMustNotifyYourHierarchy               = Sie sind <b>verpflichtet</b>, Ihre Vorgesetzten zu informieren
+GoBackToTicketCreation                   = Zur Seite der Ticketverfolgung wechseln
+SendEmailOnTicketSubmit                  = E-Mails beim Anlegen versenden
+CatTicketsList                           = Liste der Tags/Kategorien der Tickets
+SendEmailTo                              = Zu benachrichtigende E-Mail-Adresse
+SendEmailOnTicketSubmitHelp              = Den automatischen E-Mail-Versand beim Anlegen eines Tickets aktivieren
+MultipleEmailsSeparator                  = Um mehrere zu benachrichtigende E-Mail-Adressen zuzuweisen, trennen Sie sie durch ein ";". Beispiel: "aaaa@bbb.cc;dddd@eee.ff"
+TicketCategories                         = Kategorien der Tickets
+TicketDocumentsConfig                    = Dokumente der Tickets
+TicketExtrafields                        = Zusatzfelder der Tickets
+MainCategorySetting                      = Diese Option legt die Kategorie fest, deren Unterkategorien in der öffentlichen Schnittstelle erscheinen
+TicketCategoriesInDocumentsSetting       = Diese Option legt fest, welche Ticket-Kategorien in der Ticketliste der Dokumente (Gefährdungsbeurteilung, Datenblatt der Gruppierung usw.) angezeigt werden. Ist keine Kategorie ausgewählt, werden alle Kategorien angezeigt
+ParentCategorySetting                    = Diese Option legt den Titel der übergeordneten Kategorie für die öffentliche Ticket-Schnittstelle fest
+ChildCategorySetting                     = Diese Option legt den Titel der untergeordneten Kategorie für die öffentliche Ticket-Schnittstelle fest
+TicketManagement                         = Verwaltung der Tickets
+MainCategory                             = Auswahl der Hauptkategorie
+TicketCategoriesInDocuments              = In den Dokumenten angezeigte Kategorien
+ParentCategoryLabel                      = Titel der übergeordneten Kategorie
+ChildCategoryLabel                       = Titel der untergeordneten Kategorie
+TicketPublicInterfaceEnabled             = Die öffentliche Ticket-Schnittstelle wurde aktiviert
+TicketPublicInterfaceDisabled            = Die öffentliche Ticket-Schnittstelle wurde deaktiviert
+TicketPublicInterface                    = Öffentliche Schnittstelle
+EmailsToNotifySet                        = Die zu benachrichtigenden E-Mail-Adressen wurden gespeichert
+MainCategorySet                          = Die Hauptkategorie wurde festgelegt
+TicketCategoriesInDocumentsSet           = Die in den Dokumenten angezeigten Kategorien wurden festgelegt
+ParentCategoryLabelSet                   = Der Titel der übergeordneten Kategorie wurde festgelegt
+ChildCategoryLabelSet                    = Der Titel der untergeordneten Kategorie wurde festgelegt
+TicketPublicInterfaceConfigDocumentation = Um die öffentliche Ticket-Schnittstelle zu konfigurieren, lesen Sie die Dokumentation
+ParentCategory                           = Übergeordnete Kategorie
+TSProject                                = Mit den Tickets verknüpftes Projekt
+TicketDescription                        = Projekt der Tickets
+TicketProjectUpdated                     = Das Standardprojekt der Tickets wurde aktualisiert
+QRCodeAlreadyGenerated                   = QR-Code erzeugt
+GenerateQRCode                           = QR-Code erzeugen
+CompanyQRCodeGeneration                  = Erzeugung des QR-Codes des Mandanten
+QRCodeGeneration                         = Erzeugung des QR-Codes
+MultiCompanyQRCodeGeneration             = Erzeugung des mandantenübergreifenden QR-Codes
+TicketCreationMailWellSent               = Bestätigungs-E-Mail zum Anlegen des Tickets gesendet
+TicketCreationMailSent                   = Die E-Mail zum Anlegen des Tickets wurde an %s gesendet
+HowToSetupTicketCategories               = Um die Ticket-Kategorien zu konfigurieren, klicken Sie bitte auf diesen Link:
+ConfigTicketCategories                   = Konfiguration der Ticket-Kategorien
+NewTicketSubmitted                       = Über die öffentliche Schnittstelle wurde ein Ticket eingereicht
+ANewTicketHasBeenSubmitted               = Neues Sicherheitsregister angelegt für %s
+TicketCreationSubject                    = Anlegen eines Tickets über die öffentliche Schnittstelle von Digirisk
+TicketDocumentCustomDigiriskTemplate     = Individuelle ODT-Vorlage der Ticket-Datenblätter
+HowToSetupDigiriskElement                = Um die Digirisk-Elemente (Gruppierungen/Arbeitseinheiten) zu konfigurieren, klicken Sie bitte auf diesen Link:
+ConfigDigiriskElement                    = Konfiguration der Digirisk-Elemente
+ErrorFieldEmail                          = Fehler: Die E-Mail muss dem folgenden Format entsprechen: <b>'aaa@aaa.fr'</b>
+ErrorFieldPhone                          = Fehler: Die Telefonnummer muss dem folgenden Format entsprechen: <b>'0XXXXXXXXXXX'</b> oder <b>'+33XXXXXXXXX'</b>
+TicketEmailRequired                      = E-Mail zum Anlegen eines Tickets erforderlich
+TicketEmailRequiredHelp                  = Aktivieren Sie diese Option, um die Eingabe einer E-Mail-Adresse beim Anlegen eines Tickets in der öffentlichen Schnittstelle verpflichtend zu machen
+WelcomeToPublicTicketInterface           = Willkommen in der öffentlichen Ticket-Schnittstelle
+PleaseSelectAnEntity                     = Bitte wählen Sie einen Mandanten aus:
+ShowSelectorOnTicketPublicInterface      = Die Mandantenauswahl in der öffentlichen Ticket-Schnittstelle anstelle der Mandantenliste anzeigen
+ShowSelectorOnTicketPublicInterfaceHelp  = Die Mandantenauswahl in der öffentlichen Ticket-Schnittstelle anstelle der Liste der Mandanten mit ihrem Logo anzeigen
+MultiEntityPublicInterface               = Öffentliche Ticket-Schnittstelle für mehrere Mandanten
+TicketCategoriesNotCreated               = Sie haben keine Ticket-Kategorien angelegt
+TicketPublicInterfaceQRCode              = QR-Code der öffentlichen Ticket-Schnittstelle
+MultiEntityTicketPublicInterfaceQRCode   = QR-Code der öffentlichen Ticket-Schnittstelle für mehrere Mandanten
+PublicInterfaceConfiguration             = Sichtbare / erforderliche Felder der öffentlichen Schnittstelle
+TicketNumber                             = Ticket-Nr.
+FromAndDate                              = Herkunft und Datum
+AuthorRequest                            = Antragsteller
+DateCloture                              = Abschlussdatum
+
+PublicInterfaceUseSignatory              = Unterschrift zum Melden dieses Registereintrags erforderlich
+ValidateText                             = Für die Unterschrift zu akzeptierende Bedingungen
+TicketPublicInterfaceShowCategory        = Die Beschreibung der Kategorie anzeigen
+EmailTemplate                            = E-Mail-Vorlage
+EmailTemplateDescription                 = E-Mail-Vorlage
+
+OpenInNewTab                             = In einem neuen Tab öffnen
+TicketDigiriskElementRequired            = GP/UT zum Anlegen eines Tickets erforderlich
+TicketDigiriskElementRequiredHelp        = Aktivieren Sie diese Option, um die Auswahl einer GP/UT beim Anlegen eines Tickets in der öffentlichen Schnittstelle verpflichtend zu machen
+TicketDigiriskElementHideRef             = Die Referenz der GP/UT in der Bereichsauswahl der öffentlichen Schnittstelle ausblenden
+TicketDigiriskElementHideRefHelp         = Aktivieren Sie diese Option, um die Referenz einer GP/UT in der öffentlichen Schnittstelle auszublenden
+TicketDigiriskelementVisible             = Das Feld GP/UT zum Anlegen eines Tickets anzeigen
+TicketServiceVisible                     = Das Feld GP/UT zum Anlegen eines Tickets anzeigen
+TicketDigiriskelementVisibleHelp         = Aktivieren Sie diese Option, um das Feld GP/UT in der öffentlichen Schnittstelle anzuzeigen und es bei Bedarf verpflichtend zu machen
+TicketServiceVisibleHelp                 = Aktivieren Sie diese Option, um das Feld GP/UT in der öffentlichen Schnittstelle anzuzeigen und es bei Bedarf verpflichtend zu machen
+TicketPhotoVisible                       = Das Feld Foto zum Anlegen eines Tickets anzeigen
+TicketPhotoVisibleHelp                   = Aktivieren Sie diese Option, um das Feld Foto in der öffentlichen Schnittstelle anzuzeigen
+TicketEmailVisible                       = Das Feld E-Mail zum Anlegen eines Tickets anzeigen
+TicketEmailVisibleHelp                   = Aktivieren Sie diese Option, um das Feld E-Mail in der öffentlichen Schnittstelle anzuzeigen und es bei Bedarf verpflichtend zu machen
+TicketLastnameVisible                    = Das Feld Name zum Anlegen eines Tickets anzeigen
+TicketLastnameVisibleHelp                = Aktivieren Sie diese Option, um das Feld Name in der öffentlichen Schnittstelle anzuzeigen und es bei Bedarf verpflichtend zu machen
+TicketFirstnameVisible                   = Das Feld Vorname zum Anlegen eines Tickets anzeigen
+TicketFirstnameVisibleHelp               = Aktivieren Sie diese Option, um das Feld Vorname in der öffentlichen Schnittstelle anzuzeigen und es bei Bedarf verpflichtend zu machen
+TicketPhoneVisible                       = Das Feld Telefon zum Anlegen eines Tickets anzeigen
+TicketPhoneVisibleHelp                   = Aktivieren Sie diese Option, um das Feld Telefon in der öffentlichen Schnittstelle anzuzeigen und es bei Bedarf verpflichtend zu machen
+TicketLocationVisible                    = Das Feld Ort zum Anlegen eines Tickets anzeigen
+TicketLocationVisibleHelp                = Aktivieren Sie diese Option, um das Feld Ort in der öffentlichen Schnittstelle anzuzeigen und es bei Bedarf verpflichtend zu machen
+TicketDateVisible                        = Das Feld Datum zum Anlegen eines Tickets anzeigen
+TicketDateVisibleHelp                    = Aktivieren Sie diese Option, um das Feld Datum in der öffentlichen Schnittstelle anzuzeigen und es bei Bedarf verpflichtend zu machen
+QRCodeGenerated                          = QR-Code erzeugt
+FkTicket                                 = Verknüpftes Ticket
+PublicTicket                             = Öffentliche Ticket-Schnittstelle
+TicketPublicInterfaceForbidden           = Zugriff auf die öffentliche Ticket-Schnittstelle verboten
+DefaultUserGroup                         = Standardgruppe
+DefaultUserGroupDescription              = Standardgruppe in den Gruppenauswahlen
+ConfigureDefaultUserGroup                = Die Standardgruppe konfigurieren
+RegisterSigned                           = Register unterschrieben
+
+#Öffentliche Schnittstelle
+TicketPublicInterfaceShowCategoryDescription     = Die Beschreibung der Ticket-Kategorien in der öffentlichen Schnittstelle anzeigen
+TicketPublicInterfaceShowCategoryDescriptionHelp = Aktivieren Sie diese Option, um die Beschreibung der Ticket-Kategorien in der öffentlichen Schnittstelle anzuzeigen
+
+
+# Statistiken
+TicketStatistics    = Statistiken der Tickets
+ExportCSV           = CSV-Export
+GenerateCSV         = Die CSV-Datei erzeugen
+SuccessGenerateCSV  = CSV-Datei %s erfolgreich erzeugt
+ErrorMissingData    = Fehler: Die CSV-Datei konnte nicht erzeugt werden, die an die Datei gesendeten Daten sind fehlerhaft. <br> Bitte prüfen Sie, ob Tickets GP/UT zugewiesen sind.
+CSVFileExport       = Export der Registereinträge im CSV-Format mit Zuordnung zu GP/UT
+ThirdPartyHelp      = Ist der Filter "Partner" leer, wird kein Partner für die Suche verwendet
+GP/UTHelp           = Standardmäßig berücksichtigt der Filter alle GP/UT
+CategoryTicketHelp  = Standardmäßig berücksichtigt der Filter alle Kategorien
+CreatedByHelp       = Ist der Filter "Angelegt von" leer, wird kein Benutzer für die Suche verwendet
+AssignedToHelp      = Ist der Filter "Zugewiesen an" leer, wird kein Benutzer für die Suche verwendet
+StatusHelp          = Standardmäßig berücksichtigt der Filter alle Status<br>
+ConcernedTimePeriod = Berücksichtigter Zeitraum
+LessThan            = Weniger als
+MoreThan            = Mehr als
+Comparator          = Vergleichsoperator
+RangeNumber         = Menge
+TimeRange           = Zeiteinheit
+RangeLabel          = Name der Bedingung
+Inferior            = Kleiner als
+Superior            = Größer als
+TimeRangeAdded      = Bedingung hinzugefügt
+TimeRangeDeleted    = Bedingung gelöscht
+
+NumberOfTicketsByMainCategorieAndDigiriskElement    = Anzahl der Registereinträge nach Kategorie und nach GP
+NumberOfTicketsByMainSubCategorieAndDigiriskElement = Anzahl der Registereinträge nach Unterkategorie und nach GP
+NumberOfTicketsByYear                           = Anzahl der Tickets nach Jahr
+
+# Ticket Management Dashboard - Übersicht der Ticketverwaltung
+TicketManagementDashboard                 = Übersicht der Ticketverwaltung
+RunningTicket                             = Laufende Tickets
+NbOfOpenedTicket                          = Anzahl der offenen Tickets
+OldestTicket                              = Ältestes Ticket
+OldestTicketDescription                   = Ältestes Ticket mit der seit seiner Erstellung vergangenen Zeit
+OldestMessageTicket                       = Ältestes Ticket mit einer Nachricht
+OldestMessageTicketDescription            = Ältestes Ticket mit einer Nachricht und der seit der Erstellung der Nachricht vergangenen Zeit
+MeanAnswerTime                            = Durchschnittliche Antwortzeit
+MeanAnswerTimeDescription                 = Durchschnittliche Zeit zwischen Öffnung und Abschluss, nur auf Basis der abgeschlossenen Tickets berechnet
+MeanFirstResponseTime                     = Durchschnittliche Zeit bis zur ersten Antwort
+MeanFirstResponseTimeDescription          = Durchschnittliche Zeit zwischen der Öffnung des Tickets und der ersten für den Melder sichtbaren Nachricht. Interne Notizen zählen nicht, und Tickets ohne öffentliche Nachricht sind von der Berechnung ausgenommen
+NbTicketPerUser                           = Durchschnittliche Anzahl der je Person zugewiesenen Tickets
+NbExchangePerTicket                       = Anzahl der Kontakte je Ticket
+TicketRepartitionPerUserAndMeanAnswerTime = Verteilung der Tickets nach Benutzer und durchschnittliche Antwortzeit
+TopSocietyWithMostTickets                 = Top %s der Unternehmen mit den meisten Tickets
+TicketsCreatedVersusClosedByMonth         = In den letzten %s Monaten angelegte und abgeschlossene Tickets
+TicketsCreated                            = Angelegt
+TicketsClosed                             = Abgeschlossen
+OpenTicketsByStatus                       = Verteilung der offenen Tickets nach Status
+OpenTicketBacklogAge                      = Alter der offenen Tickets (seit der Erstellung)
+BacklogAgeUnderDays                       = Weniger als %s Tage
+BacklogAgeBetweenDays                     = Von %s bis %s Tage
+BacklogAgeOverDays                        = Mehr als %s Tage
+ShowSelectedDateTypes                     = Wählen Sie die anzuzeigende Datumsart aus
+
+# E-Mail
+The                            = Am
+TicketMessage                  = Nachricht des Registereintrags
+SeeTicketUrl                   = Ticket anzeigen
+AutoNotificationTicket         = E-Mail-Benachrichtigung automatisch versendet von
+TicketPublicInterfaceOtherName = Verwaltungsschnittstelle der Arbeitsschutzregister und der Register für ernste und unmittelbare Gefahr
+
+
+
+# Ticket-Dokument
+
+# Daten
+TicketDocument                 = Datenblatt des Tickets
+Ticketdocument                 = Datenblatt des Tickets
+ticketdocument.odt             = Datenblatt des Tickets
+ticketdocument_custom.odt      = Individuelles Datenblatt des Tickets
+ticketdocument_events.odt      = Datenblatt des Tickets mit Ereignissen
+ticketdocument_sign.odt        = Datenblatt des Tickets mit Unterschrift
+ticketdocument_event_sign.odt  = Datenblatt des Tickets mit Ereignis und Unterschrift
+TicketSuccessMessage           = Erfolgsmeldung des Tickets
+TicketSuccessMessageSet        = Die Meldung wurde geändert
+TicketDocumentPDF              = FT-A4-QUERFORMAT
+TicketDocumentPDFDescription   = Das Datenblatt des Tickets anzeigen
+GeneratedTicketDocumentDate    = Datum des Exports dieses Tickets
+
+
+# Projektdokument
+
+# ODT-Vorlage
+DigiriskTemplateDocumentProject = Dokumentvorlagen der Projektdatenblätter von Digirisk
+DocumentModelPapripactA3Paysage = Dokumentvorlagen des Prognoseberichts zu den Projektaufgaben
+PapripactFullName               = Jährliches Programm zur Verhütung berufsbedingter Risiken und zur Verbesserung der Arbeitsbedingungen
+
+# Registerdokument
+
+RegisterDocument     = Register für leichte Arbeitsunfälle
+Registerdocument     = Register für leichte Arbeitsunfälle
+RegisterDocumentsMin = Register für leichte Arbeitsunfälle
+registerdocument.odt = Register für leichte Arbeitsunfälle
+
+#
+# Tools - Werkzeuge
+#
+
+# Daten
+Tools                                        = Werkzeuge
+DigiriskDataMigration                        = Verwaltung der Migrationsdaten
+DataMigrationImport                          = Import der Strukturdaten von Digirisk
+DataMigrationImportDescription               = Import der Strukturdaten von Digirisk WordPress im ZIP-Format
+DataMigrationImportRisks                     = Import der Risikodaten von Digirisk
+DataMigrationImportRisksDescription          = Import der Risikodaten von Digirisk WordPress im ZIP-Format
+ErrorFileNotWellFormatted                    = Die Datei hat nicht das richtige Format oder ist leer. Sie müssen eine Importdatei aus Digirisk WordPress mit dem Namen DATE_OBJET_export.json anhängen
+ErrorFileNotWellFormattedZIP                 = Die Datei hat nicht das richtige Format oder ist leer. Sie müssen eine Importdatei aus Digirisk WordPress mit dem Namen DATE_OBJET_export.zip anhängen
+ErrorJsonBadFormatted                        = Die JSON-Datei ist nicht korrekt formatiert
+SuccessImport                                = Import der Daten erfolgreich
+DataMigrationImportRiskSigns                 = Import der Kennzeichnungsdaten von Digirisk
+DataMigrationImportRiskSignsDescription      = Import der Kennzeichnungsdaten von Digirisk WordPress im ZIP-Format
+DataMigrationImportGlobal                    = Import der Gesamtdaten von Digirisk <br> (Struktur, Risiken und Kennzeichnungen)
+DataMigrationImportGlobalDescription         = Import der Gesamtdaten von Digirisk WordPress im ZIP-Format <br> (Struktur, Risiken und Kennzeichnungen)
+DataMigrationExportGlobal                    = Export der Gesamtdaten von Digirisk <br> (Struktur, Risiken und Kennzeichnungen)
+DataMigrationExportGlobalDescription         = Export der Gesamtdaten von Digirisk Dolibarr im ZIP-Format <br> (Struktur, Risiken und Kennzeichnungen)
+DataMigrationExportTree                      = Export der Struktur von Digirisk <br> (Nur die Struktur)
+DataMigrationExportTreeDescription           = Export der Struktur von Digirisk Dolibarr im ZIP-Format <br> (Für den aktuellen Mandanten sichtbare GP/UT, ohne Risiken und ohne Kennzeichnungen)
+DataMigrationImportGlobalDolibarrDescription = Import der Gesamtdaten von Digirisk Dolibarr im ZIP-Format <br> (Struktur, Risiken und Kennzeichnungen)
+DataMigrationTreeAlreadyImported             = Import der Strukturdaten bereits durchgeführt
+DataMigrationRisksAlreadyImported            = Import der Risikodaten bereits durchgeführt
+DataMigrationRiskSignsAlreadyImported        = Import der Kennzeichnungsdaten bereits durchgeführt
+DataMigrationGlobalAlreadyImported           = Import der Gesamtdaten (Struktur, Risiken und Kennzeichnungen) bereits durchgeführt
+AdvancedImport                               = Erweiterter Import
+AdvancedImportDescription                    = Ermöglicht den unabhängigen Import jedes Elements (Struktur, Risiken und Kennzeichnungen)
+DataMigrationWordPressToDolibarr             = Migration der Daten von WordPress nach Dolibarr
+DataMigrationDolibarrToDolibarr              = Migration der Daten von Dolibarr nach Dolibarr
+RepairRisks                                  = Die Risiken reparieren
+NumberOfRisksCorrupted                       = Sie haben %s Risiko/Risiken mit beschädigter Kategorie, gehen Sie zur Seite "Werkzeuge", um sie zu reparieren
+NoRiskToRepair                               = Kein Risiko zu reparieren
+DigiriskElementSuccessfullyRepaired          = Digirisk-Elemente (GP/UT) erfolgreich repariert
+RiskSuccessfullyRepaired                     = Risiken erfolgreich repariert
+RiskAssessmentSuccessfullyRepaired           = Bewertungen erfolgreich repariert
+CorruptedCategoryOnRiskList                  = Liste der Risiken mit beschädigter Kategorie
+
+# Clean - Bereinigen
+Clean                                          = Bereinigen
+CleanObject                                    = Die Daten bereinigen
+CleanDigiriskElementExistParentDigiriskElement = %d Digirisk-Elemente (GP/UT) haben ein ungültiges übergeordnetes Element
+CleanDigiriskElement                           = Die Digirisk-Elemente (GP/UT) bereinigen
+CleanRiskFkElement                             = %d Risiken haben eine ungültige GP/UT
+CleanRiskStatus                                = %d Risiken haben einen ungültigen Status
+CleanRiskExistFkElement                        = %d Risiken sind verwaist
+CleanRiskExistRiskAssessment                   = %d Risiken haben keine Bewertung
+CleanRisk                                      = Die Risiken bereinigen
+CleanRiskAssessmentStatus                      = %d Bewertungen haben einen ungültigen Status
+CleanRiskAssessmentCotation                    = %d Bewertungen haben eine leere Einstufung
+CleanRiskAssessmentExistFkRisk                 = %d Bewertungen sind verwaist
+CleanRiskAssessment                            = Die Bewertungen bereinigen
+NoDigiriskElementToClean                       = Kein Digirisk-Element (GP/UT) zu bereinigen
+NoRiskToClean                                  = Kein Risiko zu bereinigen
+NoRiskAssessmentToClean                        = Keine Bewertung zu bereinigen
+
+
+#
+# Sonstiges
+#
+
+# Daten
+AT = bis
+
+LabourInspectorName                 = DREETS
+UrlLabourInspector                  = https://travail-emploi.gouv.fr/ministere/organisation/article/dreets-directions-regionales-de-l-economie-de-l-emploi-du-travail-et-des
+IDCCTooltip                         = Dieses Feld stammt aus dem Modul Digirisk für Dolibarr <br> Die Systematik der Tarifverträge stammt von travail-emploi.gouv.fr
+NoEmailContact                      = Keine E-Mail-Adresse bei diesem Kontakt
+AddMedia                            = Ein Medium hinzufügen
+NoMediaLinked                       = Kein verknüpftes Medium
+UserGroup                           = Benutzergruppe
+ReaderGroup                         = Lesergruppe
+UserCreated                         = Der Benutzer wurde angelegt
+GetAPI                              = Verwendung der Digirisk-API-Routen mit der Methode GET
+PostAPI                             = Verwendung der Digirisk-API-Routen mit der Methode POST
+MinimizeMenu                        = Menü verkleinern
+ActionsLine                         = Aktionen
+PhotoWellSent                       = Das Foto wurde der Medienbibliothek hinzugefügt
+PhotoNotSent                        = Das Foto wurde nicht korrekt gesendet
+PhotoWellSaved                      = Das Medium bzw. die Medien wurde(n) hinzugefügt
+PhotoNotSaved                       = Das Medium bzw. die Medien wurde(n) nicht hinzugefügt
+UseCaptcha                          = Grafischer Code (CAPTCHA)
+UseCaptchaDescription               = Verwendung des grafischen Codes (CAPTCHA) auf den Seiten der öffentlichen Schnittstelle
+GP/UTParticipation                  = Beteiligung GP/UT
+LabourDoctorName                    = AMETRA
+LabourDoctorFirstName               = Betriebs-
+LabourDoctorLastName                = arzt
+DashBoard                           = Übersicht
+Close                               = Schließen
+DateRange                           = Zeitraum
+UseDateRange                        = Den Zeitraum verwenden
+SiretNumber                         = Siret-Nr.
+Society                             = Unternehmen
+MulticompanyTransverseModeEnabled   = Die zentrale Verwaltung der Benutzer und Gruppen auf dem Hauptmandanten ist aktiviert.<br>Sie können daher auf diesem Mandanten keinen Benutzer und keine Gruppe anlegen.<br>Bitte wechseln Sie zum Hauptmandanten, um dies vorzunehmen.
+ManuelInputNBEmployees              = Die Anzahl der Beschäftigten manuell eingeben
+ManuelInputNBEmployeesDescription   = Ist die Option aktiviert, können Sie die Anzahl der Beschäftigten in der Konfiguration des Unternehmens manuell eingeben.<br>Andernfalls wird die Anzahl der Beschäftigten berechnet.<br>Weitere Informationen finden Sie in der Dokumentation.
+ManuelInputNBWorkedHours            = Die Anzahl der geleisteten Arbeitsstunden manuell eingeben
+ManuelInputNBWorkedHoursDescription = Ist die Option aktiviert, können Sie die Anzahl der geleisteten Arbeitsstunden in der Konfiguration des Unternehmens manuell eingeben.<br>Andernfalls wird die Anzahl der geleisteten Arbeitsstunden berechnet.<br>Weitere Informationen finden Sie in der Dokumentation.
+ShowPatchNoteAgain                  = Den Versionshinweis anzeigen
+ShowPatchNoteAgainDescription       = Ist die Option aktiviert, erscheint der Versionshinweis der aktuellen Version erneut auf der Startseite von Digirisk.<br>(Erfordert, dass die Option «Versionshinweise von GitHub anzeigen» aktiviert ist, um sichtbar zu sein.)
+HowToConfigureSetupConf             = Um die mit Digirisk verknüpften Unternehmensdaten zu konfigurieren,<br>wechseln Sie bitte zu Digirisk - Konfiguration - Einstellungen
+LabourDoctorNameFull                = Ärztevereinigung
+PermissionInheritedFromConfig       = Die Berechtigungen werden von der allgemeinen Konfiguration oder von der übergeordneten Konfiguration geerbt
+CategorieManagement                 = Verwaltung der Kategorien
+ShowSelectedRiskTypes               = Wählen Sie die anzuzeigenden Risikoarten aus
+CharRemaining                       = Verbleibende Zeichen
+NumberOfLinkedFiles                 = Anzahl der Dateianhänge
+ChooseAnImage                       = Ein Bild auswählen
+
+# Action Plan - Gantt / Kanban
+ActionPlanGantt                     = Gantt-Diagramm
+ActionPlanKanban                    = Kanban
+ActionPlanView                      = Aktionsplan
+ColumnDraft                         = Entwurf
+ColumnInProgress                    = Laufend
+ColumnInControl                     = Zu prüfen
+ColumnDone                          = Erledigt
+NoTasks                             = Keine Korrekturmaßnahme
+ActionPlanGlobalProgress            = Gesamtfortschritt des PAPRIPACT
+ActionPlanGlobalProgressInfo        = Durchschnitt des Fortschritts von %s Korrekturmaßnahme(n)
+KanbanLoadMore                      = Mehr anzeigen (%s)
+KanbanDisplay                       = Darstellung des Kanban
+KanbanPageSize                      = Anzahl der Karten je Spalte
+KanbanPageSizeDesc                  = Anzahl der zunächst in jeder Spalte angezeigten Korrekturmaßnahmen; die weiteren werden über die Schaltfläche «Mehr anzeigen» geladen (verbessert die Leistung bei großen Datenmengen)
+KanbanDraftMax                      = Schwelle der Spalte «Entwurf»
+KanbanDraftMaxDesc                  = Maximaler Fortschritt (%), damit eine Maßnahme in der Spalte «Entwurf» bleibt
+KanbanProgressMax                   = Schwelle der Spalte «Laufend»
+KanbanProgressMaxDesc               = Maximaler Fortschritt (%) für die Spalte «Laufend»
+KanbanControlMax                    = Schwelle der Spalte «Zu prüfen»
+KanbanControlMaxDesc                = Maximaler Fortschritt (%) für die Spalte «Zu prüfen»; darüber wechselt die Maßnahme zu «Erledigt»
+PlannedWorkload                     = Geplanter Aufwand
+TimeSpent                           = Aufgewendete Zeit
+LinkedRisk                          = Zugeordnetes Risiko
+TaskMovedTo                         = Aufgabe verschoben nach %s
+
+AddCategory                        = Eine Kategorie hinzufügen
+SelectCategory                     = Eine Kategorie auswählen
+DateEndBeforeStart                 = Enddatum liegt vor dem Anfangsdatum
+InternalUsers                      = Interne Benutzer
+ExternalContacts                   = Externe Kontakte
+AddContributor                     = Einen Mitwirkenden hinzufügen
+RemoveContact                      = Den Kontakt entfernen
+ColumnWidth                        = Breite
+ColumnGap                          = Abstand
+ActionPlanExportCsv                = Den PAPRIPACT im CSV-Format herunterladen
+ActionPlanExportA3                 = Den PAPRIPACT als PDF im A3-Querformat herunterladen
+ActionPlanExportGantt              = Das Gantt-Diagramm als PNG-Bild herunterladen
+ActionPlanDisplayedProject         = Angezeigtes Projekt
+ActionPlanChangeProject            = Projekt wechseln
+ActionPlanDefaultProject           = Gefährdungsbeurteilung (Standard)
+ActionPlanNoProjectConfigured      = Kein Projekt konfiguriert
+
+# ActionPlan — Ereignisprotokollierung
+ActionPlanLogging                  = Aktionsplan — Verlauf der Änderungen
+ActionPlanLoggingDescription       = Das Anlegen von Ereignissen bei Änderungen im Kanban aktivieren
+ActionPlanLogLabel                 = Änderung der Bezeichnung
+ActionPlanLogLabelDesc             = Ein Ereignis anlegen, wenn die Bezeichnung einer Aufgabe geändert wird
+ActionPlanLogWorkload              = Änderung des Aufwands
+ActionPlanLogWorkloadDesc          = Ein Ereignis anlegen, wenn der geplante Aufwand geändert wird
+ActionPlanLogBudget                = Änderung des Budgets
+ActionPlanLogBudgetDesc            = Ein Ereignis anlegen, wenn das Budget geändert wird
+ActionPlanLogContributorAdd        = Hinzufügen eines Mitwirkenden
+ActionPlanLogContributorAddDesc    = Ein Ereignis anlegen, wenn ein Mitwirkender hinzugefügt wird
+ActionPlanLogContributorRemove     = Entfernen eines Mitwirkenden
+ActionPlanLogContributorRemoveDesc = Ein Ereignis anlegen, wenn ein Mitwirkender entfernt wird
+ActionPlanLogProgress              = Änderung des Fortschritts
+ActionPlanLogProgressDesc          = Ein Ereignis anlegen, wenn der Fortschritt geändert wird
+ActionPlanLogTag                   = Änderung der Tags
+ActionPlanLogTagDesc               = Ein Ereignis anlegen, wenn ein Tag hinzugefügt oder entfernt wird
+ActionPlanLogDateStart             = Änderung des Anfangsdatums
+ActionPlanLogDateStartDesc         = Ein Ereignis anlegen, wenn das Anfangsdatum geändert wird
+ActionPlanLogDateEnd               = Änderung des Enddatums
+ActionPlanLogDateEndDesc           = Ein Ereignis anlegen, wenn das Enddatum geändert wird
+ActionPlanTaskLabelChanged         = Bezeichnung geändert: "%s" → "%s"
+ActionPlanTaskWorkloadChanged      = Aufwand geändert: %s → %s
+ActionPlanTaskBudgetChanged        = Budget geändert: %s → %s
+ActionPlanTaskContributorAdded     = Mitwirkender hinzugefügt: %s
+ActionPlanTaskContributorRemoved   = Mitwirkender entfernt: ID %s
+ActionPlanTaskProgressChanged      = Fortschritt geändert: %s%% → %s%%
+ActionPlanTaskTagAdded             = Tag hinzugefügt: %s
+ActionPlanTaskTagRemoved           = Tag entfernt: ID %s
+ActionPlanTaskDateStartChanged     = Anfangsdatum geändert: %s → %s
+ActionPlanTaskDateEndChanged       = Enddatum geändert: %s → %s
+
+# ===========================================================================
+# Filter des Aktionsplans — issue #4907 (GP/UT, Risikostufe, Tags)
+# ===========================================================================
+ActionPlanElement                    = GP/UT
+ActionPlanFilterElementChildren      = Mit den untergeordneten Elementen
+ActionPlanFilterElementChildrenHelp  = Die Korrekturmaßnahmen der untergeordneten GP/UT der ausgewählten GP/UT einbeziehen
+ActionPlanFilterScale                = Risikostufe
+ActionPlanFilterAllScales            = Alle Stufen
+ActionPlanFilterTags                 = Tags
+ActionPlanFilterCount                = %s Korrekturmaßnahme(n) von %s angezeigt
+ActionPlanDictionaries               = Listen des Kanban
+ActionPlanDictionariesDesc           = Die in den Listen des Aktionsplans und der Kanban angebotenen Werte verwalten
+ActionPlanTagDictionary              = Tags der Korrekturmaßnahmen
+ActionPlanTagDictionaryDesc          = Tags (Aufgabenkategorien), die auf den Karten und im Filter des Kanban des Aktionsplans angeboten werden
+ActionPlanTicketDictionaries         = Wörterbücher der Ticket-Kanban
+ActionPlanTicketDictionariesDesc     = Typen, Gruppen und Schweregrade, aus denen sich die Spalten der Ticket-Kanban zusammensetzen
+ActionPlanManageDictionary           = Verwalten
+
+# ===========================================================================
+# Ticket-Aktionskarte — issue #4443 (1-Klick-Oberfläche)
+# ===========================================================================
+TicketActionCard                     = Ticket-Aktion
+TicketActionCardPickerIntro          = Wählen Sie ein Ticket aus, um eine schnelle Aktion mit 1 Klick auszuführen.
+TicketActionCardStatusSection        = Status
+TicketActionCardAssignSection        = Zuweisung
+TicketActionCardContentSection       = Inhalt
+TicketActionCardDangerSection        = Sensibler Bereich
+TicketActionMarkRead                 = Als gelesen markieren
+TicketActionInProgress               = Auf laufend setzen
+TicketActionWaiting                  = Auf wartend setzen
+TicketActionClose                    = Abschließen
+TicketActionCancel                   = Ticket stornieren
+TicketActionAssignSelf               = Mir zuweisen
+TicketActionAssignOther              = Zuweisen an ...
+TicketActionAddMessage               = Eine Nachricht hinzufügen
+TicketActionLinkAccident             = Einen Unfall verknüpfen
+TicketActionOpenFull                 = Vollständige Details
+TicketActionMarkedRead               = Ticket als gelesen markiert
+TicketActionInProgressDone           = Ticket auf laufend gesetzt
+TicketActionWaitingDone              = Ticket auf wartend gesetzt
+TicketActionClosedDone               = Ticket abgeschlossen
+TicketActionCancelledDone            = Ticket storniert
+TicketActionAssignedSelfDone         = Ticket Ihnen zugewiesen
+TicketActionAssignedOtherDone        = Ticket zugewiesen
+TicketActionCloseConfirm             = Abschluss bestätigen
+TicketActionCancelConfirm            = Stornierung bestätigen
+TicketActionCardRegistresSection      = Informationen zu den Registern
+TicketMessageTitle                    = Titel der Nachricht
+TicketResponsibleAndProgress          = Verantwortlicher und Fortschritt
+TicketActionCardClassificationSection = Klassifizierung
+TicketActionCardDatesSection          = Wichtige Daten
+TicketActionCardIdentificationSection = Identifikation
+TicketActionCardOtherFieldsSection    = Weitere Informationen
+TicketActionCardEventsSection         = Aktuelle Ereignisse
+TicketActionCardRelatedSection        = Verknüpfte Objekte
+UnknownFieldToUpdate                  = Unbekanntes Feld: %s
+Saved                                 = Gespeichert
+SeeAll                                = Alles anzeigen
+LayoutCustomize                       = Anpassen
+LayoutDone                            = Fertig
+LayoutControls                        = Layout-Steuerung
+LayoutWidthHalf                       = Halbe Spalte
+LayoutWidthFull                       = Ganze Spalte
+LayoutWidthSpan                       = Volle Breite
+LayoutSaved                           = Layout gespeichert
+LayoutReset                           = Zurücksetzen
+LayoutResetTitle                      = Das Layout zurücksetzen (zu den Standardwerten zurückkehren)
+LayoutDensity                         = Anzeigedichte
+LayoutDensityCompact                  = Kompakt
+LayoutDensityCozy                     = Komfortabel
+LayoutDensitySpacious                 = Großzügig
+AddTag                                = Einen Tag hinzufügen
+TagAdded                              = Tag hinzugefügt
+TagRemoved                            = Tag entfernt
+Preview                               = Vorschau
+OpenInNewTab                          = In einem neuen Tab öffnen
+FileDeleted                           = Datei gelöscht
+OtherTicket                           = weiteres Ticket
+OtherTickets                          = weitere Tickets
+SeeOtherTicketsForThisCompany         = Den Ticketverlauf dieses Kunden anzeigen
+StatusTimeline                        = Zeitleiste des Status
+WatchTicket                           = Diesem Ticket folgen
+UnwatchTicket                         = Diesem Ticket nicht mehr folgen
+TicketWatched                         = Ticket wird verfolgt
+TicketUnwatched                       = Ticket aus der Verfolgung entfernt
+WatchedTicket                         = Verfolgtes Ticket
+WatchedOnly                           = Nur verfolgte
+AllTickets                            = Alle
+NoWatchedTicket                       = Kein verfolgtes Ticket
+FileUploaded                          = Datei gesendet
+UploadFile                            = Eine Datei auswählen
+OrDropAnywhere                        = oder per Drag-and-drop auf die Karte ziehen
+Messages                              = Nachrichten
+TypeYourReply                         = Geben Sie Ihre Antwort ein …
+PrivateMessage                        = Private Nachricht
+Send                                  = Senden
+NoMessageYet                          = Derzeit keine Nachricht
+BeFirstToReply                        = Antworten Sie als Erster
+MessagePosted                         = Nachricht gesendet
+MessageEdited                         = Nachricht geändert
+MessageDeleted                        = Nachricht gelöscht
+ConfirmDeleteMessage                  = Diese Nachricht löschen?
+ReplyByEmail                          = Per E-Mail senden
+SentByMail                            = Per E-Mail gesendet
+MailSentToNRecipients                 = E-Mail an %d Empfänger gesendet
+MailNotSent                           = E-Mail-Versand fehlgeschlagen
+NoRecipientFound                      = kein Empfänger gefunden
+OriginalMessage                       = Ursprüngliche Nachricht
+JustNow                               = gerade eben
+NMinAgo                               = vor %d Min.
+NHAgo                                 = vor %d Std.
+NDAgo                                 = vor %d T.
+NAttachedFiles                        = %d Dateianhang/Dateianhänge
+Quote                                 = Zitieren
+NotAllowed                            = Aktion nicht zulässig
+Private                               = Privat
+Unknown                               = Unbekannt
+LayoutTagsMode                        = Darstellung der Tags
+LayoutTagsModeChips                   = Vollständige Liste (Chips)
+LayoutTagsModeSelector                = Auswahlliste
+LayoutActionsMode                     = Darstellung der Aktionen
+LayoutActionsModeBar                  = Aktionsleiste
+LayoutActionsModeMenu                 = Menü (⋮)
+Move                                  = Verschieben
+Hide                                  = Ausblenden
+Show                                  = Anzeigen
+
+# ===========================================================================
+# Ticket-Kanban — Konfiguration der Protokollierung — issue #4753
+# ===========================================================================
+TicketKanban                           = Ticket-Kanban
+TicketKanbanLogging                    = Ticket-Kanban — Verlauf der Änderungen
+TicketKanbanLoggingDescription         = Das Anlegen von Ereignissen bei Änderungen im Kanban aktivieren
+TicketKanbanLogStatus                  = Änderung des Status
+TicketKanbanLogStatusDesc              = Ein Ereignis anlegen, wenn der Status eines Tickets über das Kanban geändert wird
+TicketKanbanLogAssignee                = Änderung des Zuständigen
+TicketKanbanLogAssigneeDesc            = Ein Ereignis anlegen, wenn der Zuständige eines Tickets über das Kanban geändert wird
+TicketKanbanLogCategoryAdd             = Hinzufügen eines Tags
+TicketKanbanLogCategoryAddDesc         = Ein Ereignis anlegen, wenn einem Ticket über das Kanban ein Tag hinzugefügt wird
+TicketKanbanLogCategoryRemove          = Entfernen eines Tags
+TicketKanbanLogCategoryRemoveDesc      = Ein Ereignis anlegen, wenn von einem Ticket über das Kanban ein Tag entfernt wird
+TicketKanbanLogType                    = Änderung des Typs
+TicketKanbanLogTypeDesc                = Ein Ereignis anlegen, wenn der Typ eines Tickets über das Kanban geändert wird
+TicketKanbanLogGroup                   = Änderung der Gruppe
+TicketKanbanLogGroupDesc               = Ein Ereignis anlegen, wenn die Gruppe eines Tickets über das Kanban geändert wird
+TicketKanbanLogSeverity                = Änderung des Schweregrads
+TicketKanbanLogSeverityDesc            = Ein Ereignis anlegen, wenn der Schweregrad eines Tickets über das Kanban geändert wird
+TicketKanbanLogSubject                 = Änderung des Betreffs
+TicketKanbanLogSubjectDesc             = Ein Ereignis anlegen, wenn der Betreff eines Tickets über das Kanban geändert wird
+TicketKanbanLogDeadline                = Änderung der Frist
+TicketKanbanLogDeadlineDesc            = Ein Ereignis anlegen, wenn die Frist eines Tickets über das Kanban geändert wird
+TicketKanbanClosedLimit                = Grenze für abgeschlossene Tickets
+TicketKanbanClosedLimitDesc            = Maximale Anzahl der im Kanban angezeigten abgeschlossenen/stornierten Tickets (0 = unbegrenzt)
+
+# ===========================================================================
+# Ticket — Nachvollziehbarkeit der Änderungen — issue #4885
+# ===========================================================================
+TicketLogModifications                 = Nachvollziehbarkeit der Änderungen
+TicketLogModificationsDesc             = Für jede Bearbeitung im Ticket-Datenblatt ein Ereignis anlegen (Betreff, Nachricht, Register, Zuständiger, Partner, Projekt, Fortschritt, Status, Aufgaben, Dokumente)
+TicketMessageEdited                    = Nachricht geändert
+TicketMessageDeleted                   = Nachricht gelöscht
+TicketTaskCreated                      = Aufgabe angelegt: %s
+TicketDocumentGenerated                = Dokument erzeugt
+TicketFileDeleted                      = Datei gelöscht
+
+# Bereich für das schnelle Anlegen eines Tickets
+SelectNothing                          = — Auswählen —
+QuickCreateTicket                      = Schnell ein Ticket anlegen
+TicketSubjectPlaceholder               = Titel des Tickets ...
+TicketInitialMessage                   = Erste Nachricht
+OptionalDescription                    = Beschreibung (optional) ...
+Unassigned                             = Nicht zugewiesen
+QuickCreateAttachments                 = Anhänge
+QuickCreateDropzone                    = Ziehen Sie Dateien hierher oder klicken Sie zur Auswahl
+QuickCreateDropzoneActive              = Hier ablegen …
+QuickCreateAttachmentHint              = Zulässige Formate: Bilder, PDF, Dokumente. Max. 10 MB je Datei.
+QuickCreateTicketSuccess               = Ticket %s erfolgreich angelegt.
+
+# MeteoVigilance - Wetterwarnung Météo-France
+MeteoVigilance = Wetterwarnung Météo-France
+MeteoVigilancePanelTitle = Warnung %s
+MeteoVigilanceAdvice2 = Seien Sie aufmerksam
+MeteoVigilanceAdvice3 = Seien Sie sehr wachsam
+MeteoVigilanceAdvice4 = Höchste Wachsamkeit
+MeteoVigilanceUpdatedAt = Aktualisiert %s
+MeteoVigilanceEnabled = Die Wetterwarnung aktivieren
+MeteoVigilanceEnabledDescription = Zeigt das Widget der Wetterwarnung von Météo-France in der Übersicht an (sowie das Warnband bei einer orangen/roten Warnung).
+MeteoVigilanceLevel = Warnstufe
+MeteoVigilanceActivePhenomena = Aktive Phänomene
+MeteoVigilanceNoAlert = Keine besondere Warnung
+MeteoVigilanceSource = Quelle
+MeteoVigilanceSeeOnMeteoFrance = Auf vigilance.meteofrance.fr ansehen
+MeteoVigilanceNotConfigured = API-Schlüssel von Météo-France nicht konfiguriert — zum Konfigurieren klicken
+MeteoVigilanceUnknownDepartment = Département des Unternehmens nicht ermittelt
+MeteoVigilanceUnavailable = Warndaten vorübergehend nicht verfügbar
+MeteoVigilanceBannerTitle = Warnung %s aktiv im Département %s
+MeteoVigilanceLevel1 = Grün
+MeteoVigilanceLevel2 = Gelb
+MeteoVigilanceLevel3 = Orange
+MeteoVigilanceLevel4 = Rot
+MeteoVigilancePhenomenon1 = Sturm
+MeteoVigilancePhenomenon2 = Regen und Überschwemmung
+MeteoVigilancePhenomenon3 = Gewitter
+MeteoVigilancePhenomenon4 = Hochwasser
+MeteoVigilancePhenomenon5 = Schnee und Glatteis
+MeteoVigilancePhenomenon6 = Hitzewelle
+MeteoVigilancePhenomenon7 = Extreme Kälte
+MeteoVigilancePhenomenon8 = Lawinen
+MeteoVigilancePhenomenon9 = Sturmflut
+MeteoVigilanceSetup = Konfiguration der Wetterwarnung
+MeteoVigilanceApiKey = API-Schlüssel von Météo-France
+MeteoVigilanceApiKeyDescription = API-Schlüssel des Portals von Météo-France (legen Sie ein Konto und eine Anwendung «Bulletin Vigilance» auf <a href="https://portail-api.meteofrance.fr" target="_blank">portail-api.meteofrance.fr</a> an, um den Schlüssel zu erzeugen).
+MeteoVigilanceDepartment = Code des Départements (Überschreibung)
+MeteoVigilanceDepartmentDescription = Lassen Sie das Feld leer, um das Département automatisch aus der Anschrift des Unternehmens abzuleiten. Andernfalls geben Sie einen Code ein (z. B. 35, 2A).
+MeteoVigilanceCacheTTL = Dauer des Caches (Sekunden)
+MeteoVigilanceCacheTTLDescription = Dauer, für die die Daten der API zwischengespeichert werden, bevor ein neuer Aufruf erfolgt (Standard 3600).
+MeteoVigilanceSettings = Konfiguration der Wetterwarnung
+MeteoVigilanceRefreshNow = Jetzt aktualisieren
+MeteoVigilanceRefreshed = Daten aktualisiert: Warnung %s im Département %s
+
+# Konversationssystem der Tickets
+Conversation = Konversation
+PublicMessage = Öffentliche Nachricht
+ConvTo = An
+ConvCc = Cc
+
+SaveNote = Notiz speichern
+
+AddRecipient = Einen Empfänger hinzufügen
+NoRecipientFound = Kein Empfänger
+
+AddFile = Eine Datei hinzufügen
+
+MentionAgents = Mitarbeiter erwähnen
+YouWereMentionedOnTicket = Sie wurden im Ticket %s erwähnt
+YouWereMentionedOnTicketBody = %s hat Sie im Ticket %s erwähnt:
+
+Mentioned = Erwähnt
+
+# Schnelles mobiles Anlegen eines Präventionsplans
+MobileQuickCreation = Schnelles mobiles Anlegen
+MobilePPInteriorCompany = Einsatzbetrieb (intern)
+MobilePPResponsibleAutoSign = Verantwortlicher (unterschreibt automatisch)
+MobilePPSignatureSaved = Unterschrift gespeichert
+MobilePPEditSignature = Die Unterschrift ändern
+MobilePPDrawSignatureHint = Zeichnen Sie unten Ihre Unterschrift und speichern Sie sie. Sie wird für Ihre nächsten Pläne wiederverwendet.
+MobilePPClearSignature = Löschen
+MobilePPSaveSignature = Meine Unterschrift speichern
+MobilePPExteriorCompany = Fremdfirma
+MobileSirenOrSiret = SIREN / SIRET
+MobileSirenOrSiretPlaceholder = 9 oder 14 Ziffern
+MobilePPResponsibleToSign = Verantwortlicher, der unterschreiben soll
+MobilePPChooseExistingContact = Einen bestehenden Kontakt auswählen
+MobilePPNewContact = Neuer Kontakt
+MobilePPEmailForSignatureHelp = An diese E-Mail-Adresse wird die Unterschriftsanfrage gesendet.
+MobilePPPeriod = Einsatzzeitraum
+MobilePPMaxOneYearHint = Maximal 1 Jahr zwischen Anfangs- und Enddatum.
+MobilePPSubmit = Den Präventionsplan anlegen
+MobilePPErrorNoSignature = Sie müssen Ihre Unterschrift speichern, bevor Sie den Plan anlegen.
+MobilePPErrorEmptySignature = Die Unterschrift ist leer.
+MobilePPErrorInvalidSiren = Ungültige SIREN oder SIRET (9 oder 14 Ziffern erwartet).
+MobilePPErrorEndBeforeStart = Das Enddatum muss nach dem Anfangsdatum liegen.
+MobilePPErrorMaxOneYear = Die Dauer darf 1 Jahr nicht überschreiten.
+MobilePPErrorDatesRequired = Geben Sie das Anfangs- und das Enddatum an.
+MobilePPErrorStartRequired = Das Anfangsdatum fehlt.
+MobilePPErrorEndRequired = Das Enddatum fehlt.
+MobilePPErrorNoProject = Es ist kein Standardprojekt für Präventionspläne konfiguriert.
+MobilePPCompanyFound = Unternehmen gefunden:
+MobilePPCompanyNotFound = Kein Unternehmen in der Datenbank gefunden: Es wird ein neues angelegt.
+MobilePPWarningEmailNotSent = Der Plan wurde angelegt, die E-Mail zur Unterschrift konnte jedoch nicht gesendet werden.
+MobilePPWarningEmailNotConfigured = Der Plan wurde angelegt, die E-Mail ist jedoch nicht konfiguriert: Unterschriftsanfrage nicht gesendet.
+MobilePPCreated = Präventionsplan %s angelegt.
+MobilePPUpdated = Präventionsplan %s aktualisiert.
+MobilePPSignatureEmailSubject = Anfrage zur Unterzeichnung des Präventionsplans %s
+MobilePPSignatureEmailContent = Guten Tag,<br><br>Sie sind eingeladen, den Präventionsplan zu %s zu unterzeichnen.<br><br><a href="%s">Hier klicken, um zu unterschreiben</a><br><br>Mit freundlichen Grüßen.
+MobilePPSuccessTitle = Präventionsplan angelegt
+MobilePPSuccessText = Der interne Verantwortliche hat automatisch unterschrieben. Eine Unterschriftsanfrage wurde an die Fremdfirma gesendet.
+MobilePPViewPlan = Den Plan anzeigen
+MobilePPCreateAnother = Einen weiteren Plan anlegen
+MobileSuccessInteriorSigned = Interner Verantwortlicher: unterschrieben
+MobileSuccessExteriorNotified = Fremdfirma: Unterschriftsanfrage gesendet
+MobileSuccessExteriorNotSigned = Fremdfirma: Unterschrift noch einzuholen
+MobileSuccessExteriorNotNotified = Fremdfirma: Unterschriftsanfrage nicht gesendet
+MobileSuccessExteriorSigned = Fremdfirma: unterschrieben
+MobileSuccessDocumentGenerated = Dokument des Plans erzeugt
+MobilePPWarningEmailNotSentDetail = Die E-Mail zur Unterschrift konnte nicht gesendet werden: %s
+MobilePPWarningNoRecipientEmail = keine gültige E-Mail-Adresse für den externen Verantwortlichen
+MobilePPSignatureEmailSentTo = Unterschriftsanfrage gesendet an %s
+MobilePPExtSignatureTitle = Unterschrift der Fremdfirma
+MobilePPExtEmailSentOn = Anfrage gesendet an %s am %s
+MobilePPExtEmailNotSent = Unterschriftsanfrage nicht gesendet: Leiten Sie den Link weiter oder lassen Sie jetzt unterschreiben
+MobilePPSpreadDefaultsTitle = Öffentliche Darstellung der Verteilung
+MobilePPSpreadShowCount = Die Anzahl der Unterzeichner anzeigen
+MobilePPSpreadShowName = Vor- und Nachname anzeigen
+MobilePPSpreadShowContact = Telefon und E-Mail-Adresse anzeigen
+MobilePPSpreadHidePublicNote = Die öffentliche Notiz nicht anzeigen
+MobilePPExtAlreadySigned = Unterschrieben am %s
+MobilePPExtSignNow = Jetzt unterschreiben lassen
+MobilePPExtResendEmail = Die E-Mail erneut senden
+MobilePPNoTagAvailable = Es ist kein Tag für Präventionspläne verfügbar.
+MobilePPCreateTag = Einen Tag anlegen
+MobileSpreadShareTitle = Die Verteilung teilen
+MobileSpreadShareText = Lassen Sie die betroffenen Personen diesen Code scannen. Ohne Konto und ohne Anmeldung geben sie ihre Kontaktdaten ein, laden ihre Dokumente hoch und unterschreiben.
+MobileSpreadOpen = Die Verteilung öffnen
+MobilePPRisks = Risiken
+MobilePPAddRisk = Ein Risiko hinzufügen
+MobilePPRiskModalTitle = Ein Risiko auswählen
+MobilePPRiskComment = Kommentar
+MobilePPRiskDescriptionPlaceholder = Das Risiko vor Ort beschreiben
+MobilePPNoRiskYet = Derzeit kein Risiko hinzugefügt.
+MobilePPDeleteRiskTitle = Das Risiko löschen
+MobilePPDeleteRiskConfirm = «%s» wird mit seiner Beschreibung, seinen Fotos und seinen Schutzmaßnahmen aus dem Plan entfernt.
+MobilePPUserCompany = Einsatzbetrieb
+MobilePPUserCompanyShort = EU
+MobilePPConcernedCompanies = Betrifft
+MobilePPExteriorCompanyShort = EE
+MobilePPPriorFormalities = Vorherige Formalitäten
+MobilePPPriorVisitDone = Gemeinsame Vorbegehung durchgeführt
+MobilePPPriorVisitTextPlaceholder = Was bei der Begehung festgestellt wurde
+MobileRiskCompanies = Von den Risiken betroffene Unternehmen (mobil)
+CertificationDictionary = Zertifizierungen und Befähigungen
+MobilePPChooseExistingCompany = Einen bestehenden Partner auswählen
+MobilePPOrFillManually = oder die Informationen eingeben
+MobilePPProtections = Schutzmaßnahmen
+MobilePPAddProtection = Eine Schutzmaßnahme hinzufügen
+MobilePPProtectionModalTitle = Eine Schutzmaßnahme auswählen
+MobilePPMandatory = Pflicht
+MobileProtections = Schutzmaßnahmen (mobil)
+MobilePPCertifications = Erforderliche Zertifizierungen
+MobilePPAddCertification = Eine Zertifizierung hinzufügen
+MobileCertifications = Zertifizierungen (mobil)
+MobilePPUploadCertPhoto = Ein Foto senden
+MobilePPErrorCreatingThirdparty = Fehler beim Anlegen des Partners.
+MobilePPErrorCreatingContact = Fehler beim Anlegen des Kontakts.
+MobilePPErrorUpdatingPlan = Fehler beim Aktualisieren des Präventionsplans.
+MobilePPErrorCreatingPlan = Fehler beim Anlegen des Präventionsplans.
+MobileSuccessViewDocument = Das Dokument anzeigen
+MobileSuccessPlanSentByEmailOn = Präventionsplan per E-Mail gesendet am %s
+MobileSuccessExteriorSignedOn = Verantwortlicher der Fremdfirma (EE): Unterschrieben am %s
+MobileSuccessExteriorPendingSignature = Verantwortlicher der Fremdfirma (EE): Wartet auf Unterschrift
+MobilePPDefaultsTitle = Standardwerte (mobiles Anlegen)
+MobilePPDefaultDateStartToday = Anfangsdatum = heutiges Datum
+MobilePPDefaultDuration = Standarddauer des Zeitraums (Tage)
+MobilePPEmailAutoSend = Die E-Mail zur Unterschrift beim Anlegen automatisch senden
+
+# Schnelles mobiles Anlegen eines Feuererlaubnisscheins
+MobileFPPreventionPlanHelp = Die Fremdfirma und der Zeitraum des ausgewählten Plans werden automatisch übernommen.
+MobileFPPeriod = Ort und Zeitraum der Arbeiten
+MobileFPMaxOneMonthHint = Maximal ein Monat zwischen Beginn und Ende der Arbeiten.
+MobileFPErrorMaxOneMonth = Die Dauer darf einen Monat nicht überschreiten.
+MobileFPErrorNoProject = Es ist kein Standardprojekt für Feuererlaubnisscheine konfiguriert.
+MobileFPWorkTypes = Arten der Arbeiten
+MobileFPAddWorkType = Eine Art der Arbeiten hinzufügen
+MobileFPWorkTypeModalTitle = Eine Art der Arbeiten auswählen
+MobileFPSubmit = Den Feuererlaubnisschein anlegen
+MobileFPCreated = Feuererlaubnisschein %s angelegt.
+MobileFPUpdated = Feuererlaubnisschein %s aktualisiert.
+MobileFPSignatureEmailSubject = Anfrage zur Unterzeichnung des Feuererlaubnisscheins %s
+MobileFPSignatureEmailContent = Guten Tag,<br><br>Sie sind eingeladen, den Feuererlaubnisschein für %s zu unterzeichnen.<br><br><a href="%s">Hier klicken, um zu unterschreiben</a><br><br>Mit freundlichen Grüßen.
+MobileFPSuccessTitle = Feuererlaubnisschein angelegt
+MobileFPViewPermit = Den Erlaubnisschein anzeigen
+MobileFPCreateAnother = Einen weiteren Erlaubnisschein anlegen
+
+# Digirisk PWA
+PwaApplication = Mobile App
+PwaNavHome = Start
+PwaNavPreventionPlans = Pläne
+PwaNavFirePermits = Erlaubnisscheine
+PwaNavMenu = Menü
+PwaNavFavoritesHint = Unten angezeigte Favoriten (max. %s)
+PwaNavAddFavorite = Zu den Favoriten hinzufügen
+PwaNavRemoveFavorite = Aus den Favoriten entfernen
+PwaHello = Guten Tag %s
+PwaResultCount = %s Ergebnis(se)
+AllStatus = Alle Status
+PwaTilePreventionPlanInProgress = Laufende Pläne
+PwaTilePreventionPlanToSign = Zu unterschreibende Pläne
+PwaTileFirePermitInProgress = Laufende Erlaubnisscheine
+PwaTileFirePermitToSign = Zu unterschreibende Erlaubnisscheine
+
+# Massenaktionen auf den Aufgaben
+MassValidateTasks = Die Aufgaben freigeben
+MassChangeTasksProject = Projekt wechseln
+ConfirmMassValidateTasksQuestion = Möchten Sie die %s ausgewählte(n) Aufgabe(n) wirklich freigeben? Nur Aufgaben mit dem Status Entwurf werden freigegeben.
+ConfirmMassChangeTasksProjectQuestion = Möchten Sie die %s ausgewählte(n) Aufgabe(n) wirklich dem gewählten Projekt zuordnen?
+MassValidateTasksSuccess = %s Aufgabe(n) von %s ausgewählten freigegeben
+MassChangeTasksProjectSuccess = %s Aufgabe(n) dem Projekt %s zugeordnet
+
+# PDF des Präventionsplans
+PreventionPlanLegalNotice = Der Präventionsplan ist ein verpflichtendes Dokument zur Verhütung der Risiken, die sich aus dem Zusammenwirken der Tätigkeiten mehrerer Unternehmen an einem Standort ergeben, gemäß Artikel R4512-7 des französischen Arbeitsgesetzbuchs.
+PreventionPlanUserCompany = Einsatzbetrieb - EU
+PreventionPlanExteriorCompany = Fremdfirma - EE
+PreventionPlanUserCompanyResponsible = Verantwortlicher des Einsatzbetriebs (EU)
+PreventionPlanExteriorCompanyResponsible = Verantwortlicher der Fremdfirma (EE)
+EmergencyNumbers = Notrufnummern
+Firefighters = Feuerwehr
+AnyEmergency = Jeder Notfall
+PriorVisitIntro = Der Einsatzbetrieb hat vor der Durchführung des Vorhabens am %s eine gemeinsame Vorbegehung durchgeführt. Bei dieser Begehung wurden vom Einsatzbetrieb die folgenden Punkte vorgestellt (Art. R. 4512-2 und R. 4512-3 des französischen Arbeitsgesetzbuchs):
+PriorVisitCheckList = Arbeitsstätten|Dort befindliche Anlagen|Gegebenenfalls den Fremdfirmen zur Verfügung gestellte Ausrüstung|Den Einsatzbereich der Fremdfirmen abgrenzen|Die Zonen dieses Bereichs kennzeichnen, die Gefahren für die Beschäftigten darstellen können|Die Verkehrswege angeben, die die Beschäftigten sowie die Fahrzeuge und Maschinen aller Art der Fremdfirmen benutzen dürfen|Die Zugangswege der Beschäftigten zu den Räumen und Anlagen für die Fremdfirmen festlegen (insbesondere Sanitäranlagen, Gemeinschaftsumkleiden und Aufenthaltsräume)
+PriorVisitComments = Die folgenden Anmerkungen wurden festgehalten:
+InterventionPeriodSentence = Dieser Plan beginnt am %s und endet am %s. Die Einsätze finden zu folgenden Zeiten statt:
+RiskAnalysisIntro = Sie haben %s Einsatz/Einsätze für diesen Präventionsplan vorgesehen: nachstehend die Einzelheiten der vorgesehenen Tätigkeiten, die entstehenden Risiken und die umgesetzten Präventionsmittel.
+PreventionPlanAttendants = Beteiligte: Fremdfirma (EE) und Nachunternehmer
+Morning = Vormittag
+Afternoon = Nachmittag
+Signatures = Unterschriften
+SignaturePending = Ausstehend
+PreventionPlanRiskPhotos = Fotos des Risikos
+InterventionPeriodOnly = Dieser Plan beginnt am %s und endet am %s.
+
+DigiRisk=DigiRisk
+DigiriskIdentification=BESCHREIBUNG UND MERKMALE
+DigiriskSecurity=SICHERHEIT
+DigiriskUserManual=VEREINFACHTE BEDIENUNGSANLEITUNG
+DigiriskQualification=QUALIFIKATION UND BEFÄHIGUNG
+DigiriskHygiene=HYGIENE UND REINIGUNG
+DigiriskMaintenance=WARTUNG UND PRÜFUNGEN
+DangerCategory=Risikofamilie
+SelectDangerCategory=Eine Risikofamilie auswählen
+DescribeRiskOnProduct=Das Risiko bei diesem Produkt beschreiben ...
+ConfirmDeleteProductRisk=Dieses Risiko löschen?
+AddProductRisk=Ein Produktrisiko hinzufügen
+ClickToAddContent=Zum Hinzufügen von Inhalt klicken ...
+AddProtection=Eine Schutzmaßnahme hinzufügen
+
+SelectProtection=Eine PSA-Schutzmaßnahme auswählen
+TechnicalSheet=Technisches Datenblatt
+DigiriskRisks=RISIKEN UND SCHUTZMASSNAHMEN
+MobileSuccessInteriorSignedOn=Verantwortlicher des Einsatzbetriebs (EU): Unterschrieben am %s
+
+MobileSuccessPlanSentByEmailOn = Präventionsplan per E-Mail gesendet am %s
+MobileSuccessExteriorSignedOn = Verantwortlicher der Fremdfirma (EE): Unterschrieben am %s
+MobileSuccessExteriorPendingSignature = Verantwortlicher der Fremdfirma (EE): Wartet auf Unterschrift
+
+MobilePPErrorInvalidEmail = Bitte beachten Sie das Format der E-Mail-Adresse.
+MobilePPErrorInvalidPhone = Bitte beachten Sie das Format der Telefonnummer.
+MobilePPExtSendEmail = Die E-Mail senden
+MobilePPErrorMailServerNotConfigured = Ihr Mailserver ist nicht konfiguriert, wenden Sie sich bitte an den Administrator.
+MobilePPDoliletterNotInstalled = Das Modul Doliletter ist nicht installiert. Die Verteilung der Präventionspläne und Feuererlaubnisscheine steht nicht zur Verfügung (wenden Sie sich an Ihren Administrator)
+
+# Status und Typen für die Tooltips
+preventionplan = Präventionsplan
+Locked = Gesperrt
+InProgress = Laufend
+ValidatePendingSignature = Wartet auf Unterschrift
+Archived = Archiviert
+
+ProductFIChaptersManagement=Anpassung der Kapitel des Unterweisungsblatts
+ProductFIChaptersManagementSub=Anpassung des Reiters "Unterweisungsblatt" und des Reiters "Risiken" im Produktdatenblatt
+DefaultContent=Standardinhalt
+CustomSvgUploaded=Individuelles SVG
+DeleteCustomSvg=Löschen
+DefaultSvgUsed=Standard-SVG
+
+PwaTilePreventionPlanLocked = Freigegebene Pläne
+PwaTileFirePermitLocked = Freigegebene Erlaubnisscheine
+
+# ===========================================================================
+# Wörterbuch der Kanban-Spalten des Aktionsplans — issue #5017
+# ===========================================================================
+ActionPlanColumnDictionary           = Spalten des Kanban des Aktionsplans
+ActionPlanColumnDictionaryDesc       = Im Kanban des PAPRIPACT angezeigte Spalten, wenn der Wörterbuchmodus aktiviert ist: Bezeichnung, Fortschrittsbereich, Farbe und Symbol
+KanbanColumnSource                   = Quelle der Spalten
+KanbanColumnSourceDesc               = Das Kanban mit den nachstehenden Prozentschwellen (bisheriges Verhalten) oder mit dem Wörterbuch der Spalten aufteilen
+KanbanColumnSourceThresholds         = Prozentschwellen (Standard)
+KanbanColumnSourceDictionary         = Wörterbuch der Spalten
+ActionPlanColumnProgressHelp         = Von der Spalte abgedeckte Fortschrittsgrenzen, von 0 bis 100
+ActionPlanColumnColorHelp            = Hexadezimale Farbe der Spalte, zum Beispiel #3085d6
+ActionPlanColumnPictoHelp            = Name des Font-Awesome-Symbols, zum Beispiel fa-check
+Progress_min                         = Fortschritt min.
+Progress_max                         = Fortschritt max.
+Picto                                = Symbol
+
+# Erfassung der aufgewendeten Zeit
+GenerateTimeSpentReport = Die Zeiterfassung erzeugen (PDF)
+TimeSpentReport = Erfassung der aufgewendeten Zeit
+TimeSpentReportUsersHelp = Lassen Sie das Feld leer, um alle Personen einzubeziehen, die Zeit auf dieses Projekt gebucht haben.
+TimeSpentReportSummary = Zusammenfassung nach Benutzer
+TimeSpentReportGrandTotal = Gesamtsumme
+TimeSpentReportGeneratedAt = Erzeugt am
+TimeSpentReportWholePeriod = Seit Beginn des Projekts
+TimeSpentReportNoData = Keine aufgewendete Zeit entspricht den ausgewählten Benutzern und dem ausgewählten Zeitraum.
+TimeSpentDocumentPDFDescription = Auf ein Projekt aufgewendete Zeit, nach Benutzer gruppiert
+
+# Angleichung des mobilen Feuererlaubnisscheins an den Präventionsplan - issue #5042
+MobileProgress = Fortschritt
+MobileStepDone = ERLEDIGT
+MobileStepInProgress = LAUFEND
+MobileStepTodo = ZU ERLEDIGEN
+MobileStepSignedOn = UNTERSCHRIEBEN AM
+MobilePPStepCreated = PP angelegt
+MobileFPStepCreated = FE angelegt
+MobileStepUserCompanyResponsible = Verantw. EU
+MobileStepExteriorCompanyResponsible = Verantw. EE
+MobileStepLock = Sperren
+MobileStepArchive = Archivieren
+MobileLock = Sperren
+MobileResponsibleShort = Verantw.
+MobileMailSentTo = E-Mail gesendet an
+MobilePPMotif = Grund des Einsatzes
+MobilePPSchedules = Einsatzzeiten
+MobilePPConfigHours = Konfigurieren Sie hier Ihre Zeiten
+MobilePPCopyCompanyHours = Die Zeiten des Unternehmens übernehmen
+FirePermitUserCompany = Einsatzbetrieb - EU
+FirePermitExteriorCompany = Fremdfirma - EE
+MobileFPMotif = Grund der Arbeiten
+MobileFPMotifPlaceholder = Z. B.: Schweißen am Dachstuhl
+MobileFPNoMotif = Kein Grund angegeben
+MobileFPSchedules = Zeiten der Arbeiten
+MobileFPWorkTypeDescriptionPlaceholder = Die Arbeiten vor Ort beschreiben
+MobileFPNoWorkTypeYet = Derzeit keine Art der Arbeiten hinzugefügt.
+MobileFPDeleteWorkTypeTitle = Die Art der Arbeiten löschen
+MobileFPDeleteWorkTypeConfirm = «%s» wird mit ihrer Beschreibung, ihrer Ausrüstung, ihren Fotos und ihren Schutzmaßnahmen aus dem Erlaubnisschein entfernt.
+MobileFPNoTagAvailable = Es ist kein Tag für Feuererlaubnisscheine verfügbar.
+MobileFPErrorUpdatingPermit = Fehler beim Aktualisieren des Feuererlaubnisscheins.
+MobileFPErrorCreatingPermit = Fehler beim Anlegen des Feuererlaubnisscheins.
+MobileFPLockNeedsSignature = Der Erlaubnisschein muss unterschrieben sein, bevor er gesperrt werden kann.
+MobileFPSpreadAvailableOnceSignedAndLocked = Die Verteilung steht zur Verfügung, sobald der Erlaubnisschein von den Verantwortlichen unterschrieben und gesperrt ist.
+MobileFPDefaultDateStartToday = Anfangsdatum = heutiges Datum
+MobileFPDefaultDuration = Standarddauer des Zeitraums (Tage)
+firepermit = Feuererlaubnisschein
+ErrorRecordIsLocked = Dieser Datensatz ist gesperrt und kann nicht mehr geändert werden.
+MobilePPEmailTemplateExt = E-Mail-Vorlage für den Verantwortlichen der Fremdfirma
+MobilePPEmailTemplateInt = E-Mail-Vorlage für die Beschäftigten der Fremdfirma
+
+#
+# ListingRisksDocument PDF - Risikoauflistung im PDF-Format
+#
+
+ListingRisksDocumentPDF            = Risikoauflistung PDF
+ListingRisksDocumentPDFDescription = Risikoauflistung als natives PDF, beginnend mit der Kurz-Gefährdungsbeurteilung des Elements
+ListingRisksDocumentPDFTitle       = GEFÄHRDUNGSBEURTEILUNG
+ListingRisksEstablishment          = Betrieb
+ListingRisksCoverContent           = Inhalt
+ListingRisksCoverHierarchy         = Hierarchie
+ListingRisksCoverDuerpFollowUp     = Nachverfolgung der Gefährdungsbeurteilung
+ListingRisksCoverEmergencyNumbers  = Notrufnummern
+ListingRisksCoverReportIncident    = Einen Unfall oder ein Problem melden
+ListingRisksCoverRegisters         = Arbeitsschutzregister und Register für ernste und unmittelbare Gefahr
+ListingRisksCoverIllustration      = Illustrationsbild
+NoPreventionOfficerAssigned        = Kein Präventionsverantwortlicher benannt
+NoEmergencyNumberConfigured        = Keine Notrufnummer konfiguriert
+NoResponsibleAssigned              = Kein Verantwortlicher benannt
+ListingRisksLegalTitle             = Rechtlicher Rahmen
+RiskDefinitionTitle                = Definition eines Risikos
+RiskDefinitionText                 = Risiko: Subst. Gefahr oder Nachteil, dem man sich aussetzt. Etwas auf eigenes Risiko tun, also die volle Verantwortung für die Folgen übernehmen. Ein kalkuliertes Risiko. Risiken eingehen: sich einer Gefahr aussetzen.
+DangerDefinitionTitle              = Definition einer Gefahr
+DangerDefinitionText               = Gefahr: Subst. (aus dem Vulgärlatein dominiarium „Macht", von dominus „Herr"; ursprünglich der Umstand, jemandem ausgeliefert zu sein). Was die Sicherheit oder das Leben einer Person bedroht; was eine Situation, ein Vorhaben usw. gefährden kann.
+SingleDocumentTitle                = Die Gefährdungsbeurteilung
+SingleDocumentText                 = Die Gefährdungsbeurteilung ist in den Artikeln R4121-1 bis 4 des französischen Arbeitsgesetzbuchs geregelt. Die allgemeinen Grundsätze der Prävention geben die Reihenfolge der Risikobehandlung vor.
+PreventionPrinciplesTitle          = Die allgemeinen Grundsätze der Prävention - Artikel L4121-2
+PreventionPrinciplesIntro          = Der Arbeitgeber setzt die in Artikel L. 4121-1 vorgesehenen Maßnahmen auf der Grundlage der folgenden allgemeinen Präventionsgrundsätze um:
+PreventionPrinciple1               = Risiken vermeiden.
+PreventionPrinciple2               = Nicht vermeidbare Risiken beurteilen.
+PreventionPrinciple3               = Risiken an der Quelle bekämpfen.
+PreventionPrinciple4               = Die Arbeit an den Menschen anpassen, insbesondere hinsichtlich der Gestaltung der Arbeitsplätze sowie der Auswahl der Arbeitsmittel und der Arbeits- und Fertigungsverfahren, vor allem um eintönige Arbeit und taktgebundene Arbeit zu begrenzen und ihre Auswirkungen auf die Gesundheit zu verringern.
+PreventionPrinciple5               = Den Stand der Technik berücksichtigen.
+PreventionPrinciple6               = Gefährliches durch Ungefährliches oder weniger Gefährliches ersetzen.
+PreventionPrinciple7               = Die Prävention planen und dabei Technik, Arbeitsorganisation, Arbeitsbedingungen, soziale Beziehungen und den Einfluss von Umgebungsfaktoren zu einem stimmigen Ganzen verbinden, insbesondere die Risiken durch Mobbing und sexuelle Belästigung sowie durch sexistisches Verhalten.
+PreventionPrinciple8               = Kollektive Schutzmaßnahmen ergreifen und ihnen Vorrang vor individuellen Schutzmaßnahmen einräumen.
+PreventionPrinciple9               = Den Beschäftigten geeignete Anweisungen erteilen.
+ListingRisksCotationMethodTitle    = Berechnungsmethode der Bewertungspunkte
+ListingRisksCotationMethodText     = Die Bewertung eines Risikos ist eine Punktzahl von 0 bis 100, die bei seiner Beurteilung vergeben wird. Die in der Auflistung angegebene Risikostufe ergibt sich unmittelbar daraus, gemäß der nachstehenden Tabelle.
+ListingRisksCotationLevel          = Stufe
+ListingRisksCotationRange          = Bewertung
+ListingRisksCotationMeaning        = Bedeutung
+ListingRisksCotationAction         = Vorgehensweise
+ListingRisksCotationAction1        = Die vorhandenen Präventionsmittel beibehalten.
+ListingRisksCotationAction2        = Eine Maßnahme in das jährliche Präventionsprogramm aufnehmen.
+ListingRisksCotationAction3        = Eine kurzfristige Präventionsmaßnahme einleiten.
+ListingRisksCotationAction4        = Sofort handeln, die Exposition muss aufhören.
+ListingRisksListTitle              = Liste der Risiken
+ListingRisksActionPlan             = Maßnahmen des jährlichen Präventionsprogramms
+ListingRisksCotationColumn         = Bew.
+ListingRisksRiskColumn             = Risiko
+ListingRisksAssessmentColumn       = Informationen zur Beurteilung
+NoRiskAssessed                     = Kein Risiko in diesem Bereich beurteilt

--- a/langs/de_DE/index.php
+++ b/langs/de_DE/index.php
@@ -1,0 +1,2 @@
+<?php
+//Silence is golden

--- a/langs/en_US/digiriskdolibarr.lang
+++ b/langs/en_US/digiriskdolibarr.lang
@@ -1,3 +1,622 @@
+# Copyright (C) 2021-2023 EVARISK <technique@evarisk.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#
+# Generic
+#
+
+# Module label 'ModuleDigiriskdolibarrName'
+ModuleDigiriskdolibarrName = Digirisk
+
+# Module description 'ModuleDigiriskdolibarrDesc'
+ModuleDigiriskdolibarrDesc = Digirisk for Dolibarr
+
+# Missing Saturne module
+SaturneModuleMissing = The Saturne module is required by Digirisk. Download it for free on the Dolistore (https://dolistore.com/en/modules/1906-Saturne.html) and install it before enabling Digirisk.
+
+# Tutorial image column on the setup pages
+TutoImage = Image
+
+#
+# Administration page
+#
+
+# Data
+DigiriskdolibarrSetup       = Digirisk module setup
+DigiriskdolibarrSetupPage        = Digirisk module setup page
+AgendaModuleRequired        = To ensure the traceability of actions in Digirisk, make sure the Agenda module is enabled
+DigiriskDolibarrDescription = Digirisk for Dolibarr
+HowToSetupOtherModules      = For more features in Digirisk, you can enable many modules (supplier management, invoices, etc.) from this link:
+ConfigMyModules             = Modules setup
+AvoidLogoProblems              = To avoid any problem with logos in generated documents, please refer to these setup tips:
+LogoHelpLink                = https://wiki.dolibarr.org/index.php?title=Premiers_paramétrages
+SecurityConfiguration       = Security data setup
+SocialConfiguration          = Social data setup
+Uncompleted                     = Not completed
+DigiriskData                 = Digirisk configurable data
+DigiriskManagement          = Redirection after login
+DigiriskDescription          = Redirect to the Digirisk welcome page by default instead of the Dolibarr one.
+HowToSetupIHM                   = For more features on the Dolibarr display (background image setup, etc.), you can go to this link:
+ConfigIHM                    = Display setup
+ConfigDico                     = Go to the dictionaries setup page
+LinkedProject               = Linked project
+DigiriskUpdate                  = Digirisk update:
+Security                       = Security
+HowToSharedElement          = For more information about the shared elements setup, please go to this link:
+
+HowToSharedElementLink        = https://wiki.dolibarr.org/index.php?title=Module_Digirisk#Configuration
+ConfigSharedElement         = Shared elements setup (risks/risk signs)
+DisabledSharedElement       = Option disabled because Multi-company is not enabled or the shared elements setup (risks/risk signs) has not been done
+DigiriskEventAutoDesc       = Define here the events for which Digirisk will automatically create an entry in the agenda. Each event contains the information about the action performed.
+DigiriskActionsEvents       = Events for which Digirisk must automatically insert an event into the agenda.
+DigiriskDolibarr            = Digirisk
+Create                      = Create
+
+# Ticket
+MultiCompanyTicketPublicInterfaceConfig = Multi-company ticket public interface setup
+Subtitle                                = Subtitle
+
+# DigiriskElement
+DigiriskElementDepthGraph            = Depth level in the Digirisk element graphs
+DigiriskElementDepthGraphDescription = This option sets the depth level used in the Digirisk element graphs <br> Default: level 1
+
+# WHSRegister = Occupational health and safety register
+TicketsPublicInterfaceConfig         = Ticket public interface setup
+WHSRegister                          = Occupational health and safety register
+CurrentTicketPublicInterfaceURL      = Ticket public interface URL
+MulticompanyTicketPublicInterfaceURL = Multi-company ticket public interface URL
+OriginURL                            = Origin URL
+ShortURL                             = Short URL
+ExternalURL                          = External URL
+AddExtraField                        = Create an extrafield
+IfEmptyVisibleAllCategories          = If empty, visible on all categories
+
+# DigiQuali Sheet - Sheets
+LinkDigiriskdolibarr_digiriskstandard                 = Enable the link with the Digirisk standard main entities
+LinkDigiriskdolibarr_digiriskstandardDescription      = Allows linking Digirisk standard entities and sheets
+LinkDigiriskdolibarr_digiriskelement                  = Enable the link with groupings and work units
+LinkDigiriskdolibarr_digiriskelementDescription       = Allows linking groupings and work units with sheets
+LinkDigiriskdolibarr_risk                             = Enable the link with risks
+LinkDigiriskdolibarr_riskDescription                  = Allows linking risks and sheets
+LinkDigiriskdolibarr_riskassessment                   = Enable the link with risk assessments
+LinkDigiriskdolibarr_riskassessmentDescription        = Allows linking risk assessments and sheets
+LinkDigiriskdolibarr_evaluator                        = Enable the link with evaluators
+LinkDigiriskdolibarr_evaluatorDescription             = Allows linking evaluators and sheets
+LinkDigiriskdolibarr_risksign                         = Enable the link with risk signs
+LinkDigiriskdolibarr_risksignDescription              = Allows linking risk signs and sheets
+LinkDigiriskdolibarr_preventionplan                   = Enable the link with prevention plans
+LinkDigiriskdolibarr_preventionplanDescription        = Allows linking prevention plans and sheets
+LinkDigiriskdolibarr_firepermit                       = Enable the link with fire permits
+LinkDigiriskdolibarr_firepermitDescription            = Allows linking fire permits and sheets
+LinkDigiriskdolibarr_accident                         = Enable the link with accidents
+LinkDigiriskdolibarr_accidentDescription              = Allows linking accidents and sheets
+LinkDigiriskdolibarr_accidentinvestigation            = Enable the link with accident investigations
+LinkDigiriskdolibarr_accidentinvestigationDescription = Allows linking investigations and sheets
+
+#
+# DigiriskDolibarr
+#
+
+# Right
+LireDigirisk                 = View the Digirisk dashboard
+ReadDigirisk                 = View the Digirisk dashboard (read)
+YouDontHaveTheRightToSeeThis = You are not allowed to see groupings and work units
+CanNotDoThis                 = You are not allowed to do this
+EnableDigiriskdolibarr       = Please enable the DigiriskDolibarr module to access this page
+
+# Data
+DigiriskMenu          = Add information about your company/organization. Click the "Save" button at the bottom of the page to save
+DigiriskConfigSociety = Company setup
+PermissionDenied      = Permission denied
+AddUser               = Create a user
+StartDate             = Start date
+EndDate               = End date
+NoPhoneNumber         = No phone number
+HasBeenCreatedF       = has been created
+HasBeenCreatedM       = has been created
+HasNotBeenCreatedF    = has not been created
+HasNotBeenCreatedM    = has not been created
+YourDocuments         = Documents
+NoData                = N/A
+HasBeenEditedF        = has been edited
+HasBeenEditedM        = has been edited
+HasNotBeenEditedF     = has not been edited
+HasNotBeenEditedM     = has not been edited
+
+HasBeenDeletedF    = has been deleted
+HasBeenDeletedM    = has been deleted
+HasNotBeenDeletedF = has not been deleted
+HasNotBeenDeletedM = has not been deleted
+
+DigiriskUserGroup                 = Digirisk - Users
+DigiriskUserGroupDescription      = The Digirisk user group is allowed to view and edit Digirisk-related objects
+DigiriskAdminUserGroup            = Digirisk - Administrators
+DigiriskAdminUserGroupDescription = The administrator group has all permissions on Digirisk and the required modules
+DigiriskReaderGroup               = Digirisk - Readers
+DigiriskReaderGroupDescription    = The reader group has all read-only permissions on Digirisk and the required modules
+
+ContractType              = Contract type
+Apprentice/Student        = Apprentice/Student
+Interim                   = Temporary worker
+ProfessionalQualification = Professional qualification
+DigiriskDocumentation     = Digirisk documentation
+
+SelectUser               = Select a user
+LabourInspectorFirstName = Labor
+LabourInspectorLastName  = inspector
+LabourInspector          = Labor inspector
+LabourInspectorSociety   = Labor inspector third party
+LabourInspectorAssigned  = Labor inspector
+
+SocieteSchedules = Company opening hours
+weekDayDefault   = See website
+weekEndDefault   = Closed Closed
+
+#
+# DigriskDocuments - Digirisk documents
+#
+
+# Data
+DigiriskDocuments              = Digirisk document
+Responsible                    = Responsible
+ContactsAction                 = Action contacts
+PERCOTooltip                   = If your company has a PERCO savings plan, tick this box
+PEETooltip                     = If your company has a PEE savings plan, tick this box
+ShowPictoName                  = Show the hazard pictogram name
+ShowPictoNameDescription       = Show the risk hazard pictogram name in the documents <br> Useful if you want to export the table to a spreadsheet
+RiskAssessmentColor            = Risk assessment color
+RiskAssessmentColorDescription = Displays the risk assessment color in the Papripact-A3-Landscape document
+
+#
+# LegalDisplay - Legal display
+#
+
+# Right
+LegalDisplaysMin = Legal displays
+
+# Data
+LegalDisplay             = Legal display
+Legaldisplay             = Legal display
+HowToSetDataLegalDisplay = To configure the legal display data, go to Home - Setup - Company/Organization - Security
+
+LegalDisplayDocumentGenerated       = Legal display generation
+LabourDoctor                        = Occupational physician
+LabourInspector                     = Labor inspector
+FireBrigade                         = Fire department
+AllEmergencies                      = All emergencies
+RightsDefender                      = Rights defender
+PoisonControlCenter                 = Poison control center
+Police                              = Police emergency
+SafetyInstructions                  = Safety instructions
+ResponsibleToNotify                 = Responsible person to notify
+PreventionOfficers                  = Prevention officers
+PreventionOfficer                   = Prevention officer
+LocationOfDetailedInstructions      = Location of the detailed instructions
+LocationOfDetailedInstructionsValue = No detailed instructions on this site
+FirstAid                            = First aid
+FirstAidValue                       = <h2>List of the workplace first aiders present on site (Name, Company, Phone)</h2><br><br>Each team must be made up so that first aid can be given to any team member in any circumstance.<br />Workplace first aiders must be clearly identified and known to everyone.<h2>What to do in the event of an accident</h2><br><br><h3>Minor accident</h3><br><ul><li> - Care given by the workplace first aiders</li><br><li> - A first aid kit is available</li></ul><br><br>Each machine is fitted with at least one first aid kit so that minor injuries can be treated.<br><br><h3>Serious accident</h3><br><ul><li> - Warn the workplace first aider present on site</li><br><li> - Start the emergency procedure</li><br><li> - Inform the manager of the user company, 24/7 on-call operations</li><br><li> - Contact in the event of an accident</li></ul><br><br>The user company lists the emergency numbers in the appendix. <br />
+AddPhoneNumber                      = Add a phone number to the user
+ConfigureLabourInspector            = Configure a labor inspector
+SocietyAdditionalDetails            = Additional company information
+GeneralMeansAtDisposal              = General resources provided
+GeneralMeansAtDisposalValue         = <h2>Emergency resources provided</h2><br><ul><li> - Infirmary</li><br><li> - Our workplace first aiders are identified on their helmets and their work equipment with the first aider badge</li><br><li> - First aid kits for minor accidents available on every site</li></ul><br><br><h2>Instructions in the event of a minor accident</h2><br><ul><li> - Contact the nearest workplace first aider</li><br><li> - Care with the first aid kit provided</li><br><li> - Report on the site:</li></ul><br><br><h2>Instructions in the event of an accident</h2><br><ul><li> - Fire department: 18</li><br><li> - Emergency medical service: 15</li><br><li> - Police: 17</li><br><li> - European emergency number: 112</li></ul><br><br><h2>Instructions in the event of a fire</h2><br>In the event of a fire, proceed in this order:<br><ol><li> - Set off the alarm signal.</li><br><li> - Fight the fire (if it is not too large) with an extinguisher.</li><br><li> - If the fire is not out after a single extinguisher has been used, or if the fire is already too large, call the fire department.</li><br><li> - Close the doors and windows before leaving the premises.</li><br><li> - Ask the trained teams for help.</li><br></ol>
+GeneralInstructions                 = General instructions
+GeneralInstructionsValue            = <h2>All facilities</h2><br><br><p>Smoking, lighting a fire or using a naked flame is strictly forbidden in and on the facilities.<br />If the work requires the use of an open flame (welding work, etc.), a fire permit must be issued (see the example in appendix 9.5).<br />As a general rule, access to the facilities is forbidden to unauthorized persons.<br />Every worker must carry their authorization certificates and training certificates. They must be able to show them on site at the request of the user company.</p><br><br><h2>Authorizations</h2><br>Every worker must hold a copy of the following authorizations:<br><ul><li> - Electrical authorization matching the work to be carried out</li><br><li> - Training certificate or authorization for work at height and rescue at height</li></ul><br>And be able to present it on simple request from the user company, the person in charge of the work, or any sworn inspector<br><br><h2>Personal protective equipment</h2><br>Every worker must be able to have the following personal protective equipment, depending on the type of work carried out and the protective measures defined in the risk assessment.<br><br><h3>Miscellaneous work</h3><br><ul><li> - Helmet designed for work at height (EN397) with a chin strap and/or meeting electrical insulation requirements (electrical environment)</li><br><li> - Safety shoes</li><br><li> - Hearing protection, if needed</li><br><li> - Others (to be specified): depending on the work carried out and the associated risks.</li></ul><br><br><h3>Electrical work</h3><br><ul><li> - Insulating mat or insulating stool</li><br><li> - Gloves suited to the voltage range</li><br><li> - Helmets for electrical work with a face shield (EN166)</li><br><li> - Regulatory PPE for medium-voltage work (UTE C 18-510)</li></ul><br><br><h3>Others</h3><br>Note: exterior companies must provide their workers with the PPE listed above. A stool and a rescue pole are available in the delivery substations.<br><br><h3>Work at height</h3><br><ul><li> - Regulatory PPE (harness, helmet, 2 shock-absorbing lanyards or Y double lanyard, karabiners, fall arrester, etc.) with up-to-date inspections</li><br><li> - Automatic evacuation system:</li><br><li> - Quantity: 1 evacuation kit (designed for 2 people)</li><li>Location: in the nacelle</li><br><li> - Remember to take an extra evacuation kit if there are more than two people in the nacelle</li><br><li> - Other (to be specified): fall arrester used: HACA reference 0529 7103 (sternal attachment on the harness)</li></ul><br><br>Fall arresters must be compatible with the rigid belay system fitted to the machines. Fall arresters must comply with the latest standard and must have successfully passed the additional tests (additional tests CNB/P/11.073 of 13/10/2010) made mandatory by the French Ministry of Labor notice of 28 September 2010 in order to guarantee compliance with the requirements of directive 89/686/EEC.
+RulesOfProcedure                    = Internal rules
+RulesOfProcedureValue               = Available on the mandatory display board in the break room
+CollectiveAgreement                 = Collective agreements
+CollectiveAgreementValue            = Available on the government website:<br /><a href="https://www.service-public.fr/particuliers/vosdroits/F78" target="_blank">https://www.service-public.fr/particuliers/vosdroits/F78</a>
+legaldisplay.odt                    = Legal display
+legaldisplay_custom.odt             = Custom legal display
+
+#
+# InformationsSharing - Information sharing
+#
+
+# Right
+InformationsSharingsMin = Information sharing
+
+# Data
+InformationsSharing                  = Information sharing
+Informationssharing                  = Information sharing
+InformationsSharingDocumentGenerated = Information sharing generation
+HowToSetDataInformationsSharing      = To configure the information sharing data, go to Home - Setup - Company/Organization - Social
+ConfigureSecurityAndSocialData       = Configure the company data
+LastMainDoc                          = Last generated document
+
+ParticipationAgreement      = Profit-sharing agreements
+ParticipationAgreementValue = Yes, every employee with an open-ended or fixed-term employment contract in progress with the company, whatever its nature, can benefit from profit sharing.<br />A length-of-service condition is nevertheless required: 6 months in the company.<br />To determine the required length of service, all employment contracts performed during the calculation period and the 12 months preceding it are taken into account.<br />The length of service is assessed at the closing date of the financial year concerned or at the leaving date if the contract is terminated during the year.
+TermsAndConditions          = Terms
+
+ESC                  = Social and Economic Committee
+StaffRepresentatives = Staff representatives
+ElectionDate         = Election date
+ElectionDateCSE      = Social and Economic Committee election date
+ElectionDateDP       = Staff representatives election date
+
+Titulars                       = Full members
+Alternates                     = Deputy members
+informationssharing.odt        = Information sharing
+informationssharing_custom.odt = Custom information sharing
+ActionOnUser                   = User concerned
+HarassmentOfficer              = Harassment officer
+HarassmentOfficerCSE           = Social and Economic Committee harassment officer
+ExceptionsToWorkingHours       = Exemptions from working hours
+PermanentDerogation            = Permanent exemption
+PermanentDerogationValue       = No
+OccasionalDerogation           = Occasional exemption
+OccasionalDerogationValue      = Yes
+
+
+#
+# PreventionPlan - Prevention plan
+#
+
+# Right
+PreventionPlansMin = prevention plans
+
+# Data
+
+PreventionPlan                                        = Prevention plan
+Preventionplan                                        = Prevention plan
+ThePreventionplan                                     = the prevention plan
+PreventionPlanDocument                                = Prevention plan
+Preventionplandocument                                = Prevention plan
+PreventionPlanDocumentGenerated                       = Prevention plan generation
+PreventionPlanList                                    = List of prevention plans
+PreventionPlanLine                                    = risk(s)
+PreventionPlanLineCreated                             = Risk creation in prevention plan
+PreventionPlanLineModified                            = Risk modification in prevention plan
+PreventionPlanLineDeleted                             = Risk deletion in prevention plan
+NewPreventionPlan                                     = New prevention plan
+PriorVisit                                            = Joint prior inspection
+PriorVisitYesNo                                       = Preliminary visit carried out
+PriorVisitText                                        = Inspection note
+CSSCTIntervention                                     = CSSCT intervention
+CSSCTInterventionText                                 = CSSCT intervention?
+MasterWorker                                          = User company manager
+MasterWorker                                          = User company manager
+ExtSociety                                            = Exterior company
+ExtSocietyResponsible                                 = Exterior company manager
+ExtSocietyResponsible                                 = Exterior company manager
+ExtSocietyAttendant                                   = Exterior company worker
+ActionsDescription                                    = Description of the actions
+INRSRisk                                              = Risk (INRS)
+PreventionMethod                                      = Prevention resources
+PreventionplanSchedules                               = Prevention plan schedule
+Attendants                                            = Attendants
+ModifyPreventionPlan                                  = Edit the prevention plan
+ActionsDescriptionTooltip                             = Description of the actions carried out by the worker
+INRSRiskTooltip                                       = List of the risk categories offered in the INRS reference framework
+PreventionMethodTooltip                               = Prevention resource to put in place to limit the risk
+LockPreventionPlan                                    = Lock the prevention plan
+ConfirmLockPreventionPlan                             = Are you sure you want to lock the prevention plan?<br>Locking freezes the data and the document generation.
+AllSignatoriesMustHaveSigned                          = All the attendants must have signed to lock the object
+ValidatePreventionPlan                                = Validate the prevention plan
+ConfirmValidatePreventionPlan                         = Are you sure you want to validate the prevention plan? <br> Validation lets the attendants sign the document but <b> prevents adding new attendants or editing the prevention plan </b>.
+ReOpenPreventionPlan                                  = Reopen the prevention plan
+ConfirmReOpenPreventionPlan                           = Are you sure you want to reopen the prevention plan? Reopening allows the prevention plan to be edited and new attendants to be added but <b>all the signatures on the document will be lost</b>.
+PreventionPlanRiskList                                = List of the prevention plan risks
+ActionsPreventionPlanRisk                             = Actions
+PreventionPlanDescription                             = Prevention plans project
+PriorVisitDate                                        = Joint prior inspection date
+AddPreventionPlanLine                                 = Risk addition
+UpdatePreventionPlanLine                              = Risk update
+DeletePreventionPlanLine                              = Risk deletion
+PreventionPlanDet                                     = Prevention plan risk
+Preventionplandet                                     = Prevention plan risk
+PreventionPlanMessage                                 = to the prevention plan
+PreventionPlanMustBeValidated                         = The prevention plan must be validated to reopen it
+PreventionPlanMustBeInProgress                        = The prevention plan must be in progress to access this feature
+PreventionPlanMustBeInProgressToValidate              = The prevention plan is already validated
+CSEMustBeAlerted3DaysBeforeVisit                      = The Social and Economic Committee must be informed 3 days before the joint prior inspection (art. R. 4514-1 1°, R. 4514-3 and R. 4514-9 of the French Labor Code)
+PreventionPlanData                                    = Prevention plan data
+MasterWorkerDescription                               = The user used by default as the user company manager
+NoPreventionPlanRisk                                  = No risk on the prevention plan
+NoPreventionPlanLinked                                = No linked prevention plan
+PreventionPlanLinked                                  = Linked prevention plan
+PreventionPlanManagement                              = Prevention plan management
+PPRProject                                            = Project linked to the prevention plans
+NewLabelForClonePreventionPlan                        = Label of the new prevention plan
+ClonePreventionPlanRisk                               = Clone the prevention plan risks
+CloneAttendantsPreventionPlan                         = Clone the prevention plan attendants
+CloneSchedulePreventionPlan                           = Clone the prevention plan schedule
+ConfirmClonePreventionPlan                            = Are you sure you want to clone the prevention plan <b> %s </b>?
+preventionplandocument.odt                            = Prevention plan
+preventionplandocument_custom.odt                     = Custom prevention plan
+ErrorThirdPartyHasAtLeastOneChildOfTypePreventionPlan = The third party is linked to at least one child of type prevention plan:
+ErrorContactHasAtLeastOneChildOfTypePreventionPlan    = The contact is linked to at least one child of type prevention plan:
+ConfirmDeletePreventionPlan                           = Are you sure you want to delete this prevention plan?
+PreventionPlanRole                                    = The prevention plan roles
+
+# Email
+PreventionPlanLabel   = Prevention plan summary
+PreventionPlanSubject = Prevention plan email
+PreventionPlanContent = Please find attached the ODT document of the prevention plan.
+
+# Triggers
+PreventionPlanCreated          = Prevention plan creation
+PreventionPlanModified         = Prevention plan modification
+PreventionPlanDeleted          = Prevention plan deletion
+PreventionPlanInProgress       = Prevention plan reopening
+PreventionPlanPendingSignature = Prevention plan set to pending signature
+PreventionPlanLocked           = Prevention plan locking
+PreventionPlanArchived         = Prevention plan archiving
+PreventionPlanSentByMail       = Prevention plan sent by email
+
+#
+# FirePermit - Fire permit
+#
+
+# Right
+FirePermitMin  = fire permit
+FirePermitsMin = fire permits
+
+# Data
+NewFirePermit                                     = New fire permit
+ModifyFirePermit                                  = Edit the fire permit
+FirePermitList                                    = List of fire permits
+FirePermit                                        = Fire permit
+Firepermit                                        = Fire permit
+TheFirepermit                                     = the fire permit
+FirePermitDocument                                = Fire permit
+Firepermitdocument                                = Fire permit
+FirePermitDocumentGenerated                       = Fire permit generation
+FirePermitCreated                                 = Fire permit creation
+FirePermitModified                                = Fire permit modification
+FirePermitDeleted                                 = Fire permit deletion
+FirePermitInProgress                              = Fire permit reopening
+FirePermitPendingSignature                        = Fire permit set to pending signature
+FirePermitLocked                                  = Fire permit locking
+FirePermitArchived                                = Fire permit archiving
+FirePermitSignatureAddAttendant                   = Attendant added to the fire permit
+FirePermitSentByMail                              = Fire permit sent by email
+FirePermitLine                                    = risk(s)
+FirePermitDet                                     = Fire permit risk
+Firepermitdet                                     = Fire permit risk
+FirePermitLineCreated                             = Risk creation in fire permit
+FirePermitLineModified                            = Risk modification in fire permit
+FirePermitLineDeleted                             = Risk deletion in fire permit
+FirePermitRiskList                                = List of the fire permit risks
+AddFirePermitLine                                 = Risk addition
+UpdateFirePermitLine                              = Risk update
+DeleteFirePermitLine                              = Risk deletion
+FirePermitMessage                                 = to the fire permit
+UsedMaterialTooltip                               = Equipment to use to limit the risk
+ActionsFirePermitRisk                             = Actions
+ConfirmValidateFirePermit                         = Are you sure you want to validate the fire permit? <br> Validation lets the attendants sign the document but <b> prevents adding new attendants or editing the fire permit </b>.
+ConfirmReOpenFirePermit                           = Are you sure you want to reopen the fire permit? Reopening allows the fire permit to be edited and new attendants to be added but <b>all the signatures on the document will be lost</b>.
+ConfirmLockFirePermit                             = Are you sure you want to lock the fire permit?<br>Locking freezes the data and the document generation.
+FirePermitMustBeInProgress                        = The fire permit must be in progress to access this feature
+NewLabelForCloneFirePermit                        = Label of the new fire permit
+CloneFirePermitRisk                               = Clone the fire permit risks
+CloneAttendantsFirePermit                         = Clone the fire permit attendants
+CloneScheduleFirePermit                           = Clone the fire permit schedule
+ConfirmCloneFirePermit                            = Are you sure you want to clone the fire permit <b> %s </b>?
+FirePermitDescription                             = Fire permits project
+FirePermitData                                    = Fire permit data
+FirePermitManagement                              = Fire permit management
+FPRProject                                        = Project linked to the fire permits
+firepermitdocument.odt                            = Fire permit
+firepermitdocument_custom.odt                     = Custom fire permit
+UsedEquipment                                     = Equipment used
+ErrorThirdPartyHasAtLeastOneChildOfTypeFirePermit = The third party is linked to at least one child of type fire permit:
+ErrorContactHasAtLeastOneChildOfTypeFirePermit    = The contact is linked to at least one child of type fire permit:
+ConfirmDeleteFirePermit                           = Are you sure you want to delete this fire permit?
+FirePermitRole                                    = The fire permit roles
+FirepermitSchedules                               = Fire permit schedule
+
+# Email
+FirePermitLabel   = Fire permit summary
+FirePermitSubject = Fire permit email
+FirePermitContent = Please find attached the ODT document of the fire permit.
+
+
+#
+# Accident
+#
+
+# Right
+AccidentsMin = accidents
+
+# Trigger
+AccidentCreateTrigger         = Accident %s created
+ActionsOnAccident             = Events linked to the accident
+AccidentGeneratedWithDolibarr = Accident generated with Dolibarr
+AccidentWorkStopCreateTrigger = Work stoppage %s added to the accident
+AccidentWorkStopModifyTrigger = Work stoppage %s modified on the accident
+AccidentWorkStopDeleteTrigger = Work stoppage %s deleted from the accident
+AccidentModifyTrigger         = Accident %s modified
+AccidentDeleteTrigger         = Accident %s deleted
+AccidentMetaDataCreateTrigger = Accident additional data saved
+AccidentLesionCreateTrigger   = Injury %s added to the accident
+AccidentLesionModifyTrigger   = Injury %s modified on the accident
+AccidentLesionDeleteTrigger   = Injury %s deleted from the accident
+ACC_USER_EMPLOYERSigned       = Company manager signature
+VictimAndCaregivers           = Victim and caregiver
+Victim                        = Victim
+Caregiver                     = Caregiver
+
+# Numbering model
+DigiriskAccidentNumberingModule         = Digirisk accident numbering model
+DigiriskAccidentStandardModel           = Returns the number in the form ACCn where n is a sequential counter with no gap and no reset.
+DigiriskAccidentWorkStopNumberingModule = Numbering model for the work stoppages linked to the accident
+DigiriskAccidentWorkStopStandardModel   = Returns the number in the form ACCWn where n is a sequential counter with no gap and no reset.
+DigiriskAccidentLesionNumberingModule   = Numbering model for the injuries linked to the accident
+DigiriskAccidentLesionStandardModel     = Returns the number in the form ACCLn where n is a sequential counter with no gap and no reset.
+DigiriskAccidentDocumentNumberingModule = Digirisk accident sheet numbering model
+DigiriskAccidentDocumentStandardModel   = Returns the number in the form ACCDn where n is a sequential counter with no gap and no reset.
+
+# ODT Template
+DigiriskTemplateDocumentAccident       = Digirisk accident document templates
+AccidentDocumentCustomDigiriskTemplate = Custom accident ODT
+AccidentDocumentDigiriskTemplate       = Default accident ODT
+AccidentDocument                       = Accident sheet
+AccidentDocumentGeneratedWithDolibarr  = Accident generated with Dolibarr
+
+# Data
+NewAccident                              = New accident
+ModifyAccident                           = Edit the accident
+AccidentList                             = List of accidents
+Accident                                 = Accident
+AccidentCreated                          = Accident creation
+DeleteAccident                           = Delete the accident?
+AccidentModified                         = Accident modification
+AccidentDeleted                          = Accident deletion
+AccidentLine                             = risk(s)
+AccidentDate                             = Accident date
+AccidentSchedule                         = Accident schedule
+AccidentRiskList                         = List of additional information about the accident
+Accidentworkstop                         = Work stoppage
+AccidentWorkStopCreated                  = Work stoppage creation
+AccidentWorkStopModified                 = Work stoppage modification
+AccidentWorkStopDeleted                  = Work stoppage deletion
+AddAccidentWorkStop                      = Work stoppage added to the accident
+UpdateAccidentWorkStop                   = Work stoppage updated on the accident
+DeleteAccidentWorkStop                   = Work stoppage deleted from the accident
+Accidentlesion                           = Injury
+AccidentLesionCreated                    = Injury creation
+AccidentLesionModified                   = Injury modification
+AccidentLesionDeleted                    = Injury deletion
+AddAccidentLesion                        = Injury added to the accident
+UpdateAccidentLesion                     = Injury updated on the accident
+DeleteAccidentLesion                     = Injury deleted from the accident
+AccidentDescription                      = Accidents project
+AccidentManagement                       = Accident management
+AccidentWorkstopManagement               = Work stoppage management
+AccidentLesionManagement                 = Injury management
+AccidentInvestigationManagement          = Accident investigation management
+ACCProject                               = Project linked to the accidents
+UserVictim                               = Accident victim
+AccidentType                             = Accident type
+WorkAccidentStatement                    = Workplace accident
+CommutingAccident                        = Commuting accident
+AccidentMetaData                         = Additional data
+RelativeLocation                         = Further details about the accident location
+VictimActivity                           = Activity of the victim at the time of the accident
+AccidentNature                           = Nature of the accident
+AccidentObject                           = Object whose contact injured the victim
+AccidentNatureDoubt                      = Any reasoned reservations (attach a covering letter if needed)
+AccidentNatureDoubtLink                  = Link to the covering letter
+VictimTransportedTo                      = The victim was taken to
+VictimWorkHours                          = Working hours of the victim on the day of the accident
+WorkHoursMorningDateStart                = Start of the victim's working hours (morning)
+WorkHoursMorningDateEnd                  = End of the victim's working hours (morning)
+WorkHoursAfternoonDateStart              = Start of the victim's working hours (afternoon)
+WorkHoursAfternoonDateEnd                = End of the victim's working hours (afternoon)
+AccidentNoticed                          = Accident notification
+Found                                    = Observed
+Known                                    = Known
+AccidentNoticeDate                       = Date the accident became known
+AccidentNoticeBy                         = Person who reported the accident
+ByEmployer                               = By the employer
+ByEmployees                              = By the employer's staff
+AccidentDescribedByVictim                = The accident was described by the victim
+RegisteredInAccidentRegister             = The accident is entered in the register of minor workplace accidents
+RegisterDate                             = Date of entry in the register of minor workplace accidents
+RegisterNumber                           = Entry number in the register of minor workplace accidents
+Consequence                              = Consequences
+WithoutWorkStop                          = Without work stoppage
+LessThanFourDays                         = Less than 4 days
+LessThanTwentyOneDays                    = Less than 21 days
+LessThanThreeMonth                       = Less than 3 months
+LessThanSixMonths                        = Less than 6 months
+LongTimeWorkStop                         = More than 6 months
+WithWorkStop                             = With work stoppage
+Fatal                                    = Death
+PoliceReport                             = Police report
+PoliceReportBy                           = Person who wrote the police report
+FirstPersonNoticedIsWitness              = Person informed
+Witness                                  = Witness
+FirstPersonNoticed                       = First person informed
+ThirdPartyResponsability                 = Was the accident caused by a third party?
+FkSocResponsible                         = Company of the liable third party
+FkSocResponsibleInsuranceSociety         = Insurance company of the third party
+LesionLocalization                       = Location of the injuries
+LesionNature                             = Nature of the injuries
+AccidentInvestigation                    = Accident investigation
+Accidentinvestigation                    = Accident investigation
+AccidentInvestigationLink                = Link to the accident investigation
+AccidentLocation                         = Accident location
+DigiriskDolibarrActionTrigger            = Digirisk event trigger
+CollateralVictim                         = Collateral victim
+FromDigirisk                             = From
+At                                       = To
+AndFrom                                  = And from
+ExternalAccident                         = Did the accident happen in an establishment other than the victim's home establishment
+AccidentAttendants                       = Accident - Attendants
+UserEmployer                             = Company manager
+SignatureUserEmployer                    = Company manager signature
+CerfaLink                                = Link to the Cerfa form
+WorkStopDays                             = Number of days of work stoppage
+AccidentLesionList                       = List of the injuries linked to the accident
+DocumentsMetaData                        = Additional attached files
+WorkStopDocument                         = Work stoppage declaration
+AccidentMetaDataSave                     = The additional accident data has been saved
+ErrorFieldNotEmpty                       = Error: the <b>'%s'</b> field cannot be empty
+ErrorFieldMustBeGreaterOrEqualZero       = Error: the <b>'%s'</b> field must be greater than or equal to 0
+ConfirmDeleteAccidentWorkStop            = Are you sure you want to delete the work stoppage <b>%s</b> on the accident?
+AccidentMetaDataLesion                   = Additional injury data
+TotalWorkStopDays                        = Total number of days of work stoppage
+RegisterAccident                         = Minor accident
+AccidentsLinked                          = Linked accident(s)
+GaugeCounter                             = This field is used in the gauge counter
+DateStartWorkStop                        = Work stoppage start date
+DateEndWorkStop                          = Work stoppage end date
+ReturnWorkDate                           = Return-to-work date
+DayWithoutAccident                       = Days without accident(s)
+AccidentRepartition                      = Breakdown of accidents by type
+AccidentByYear                           = Breakdown of accidents by year
+NbAccidentsByEmployees                   = Number of accidents per employee
+AccidentRegister                         = Accident by register
+AccidentWithoutRegister                  = Accidents without a register
+AccidentWithRegister                     = Accidents with a register
+WorkStopDurationDistribution             = Breakdown of time by work stoppage
+WorkStopDurationDistributionDigiriskElem = Breakdown of work stoppage time by GP/UT
+WorkStopDuration                         = Work stoppage duration
+NoAbsence                                = No work stoppage
+UpTo4Days                                = Up to 4 days
+UpTo21Days                               = Up to 21 days
+UpTo3Months                              = Up to 3 months
+UpTo6Months                              = Up to 6 months
+MoreThan6Months                          = More than 6 months
+FrequencyIndex                           = Frequency index
+FrequencyRate                            = Frequency rate
+GravityIndex                             = Severity index
+GravityRate                              = Severity rate
+AccidentRateIndicator                    = Rates and indexes of the accident performance indicators
+NbPresquAccidents                        = Number of near misses
+NbAccidentInvestigations                 = Number of accident investigations
+AccidentInvestigationsMin                = accident investigations
+NbWorkedHours                            = Number of hours worked
+ConfirmDeleteAccident                    = Are you sure you want to delete the accident?
+TheAccident                              = the accident
+AccidentInvestigation                    = Accident investigation
+Accident_investigation                   = Accident investigation
+AccidentInvestigationDocument            = Accident investigation document
+Accidentinvestigationdocument            = Accident investigation document
+accidentinvestigationdocument.odt        = Accident investigation
+NewAccidentInvestigation                 = New accident investigation
+UpdateAccidentInvestigation              = Edit an accident investigation
+AccidentInvestigationList                = List of accident investigations
+TheAccidentinvestigation                 = the accident investigation
+SeniorityInPosition                      = Seniority in the position
+VictimSkills                             = Skills of the injured person
+CollectiveEquipment                      = Collective protective equipment (CPE)
+IndividualEquipment                      = Personal protective equipment (PPE)
+Circumstances                            = Circumstances
 CurativeAction                           = Curative actions
 CorrectiveAction                         = Corrective actions
 PreventiveAction                         = Preventive actions
@@ -28,6 +647,1344 @@ ActionClosed                             = Action has been closed
 ActionsAreProjectTasks                   = Actions are Dolibarr project sub-tasks
 SeeProjectTasksView                      = See parent task
 OpenTask                                 = Open task
+AccidentInvestigationValidated           = The accident investigation has been validated
+AccidentInvestigationReOpened            = The accident investigation has been reopened
+AccidentInvestigationTaskCreated         = The accident investigation tasks have been created
+AccidentInvestigationTaskDeleted         = The accident investigation tasks have been deleted
+CausalityTree                            = Causal tree
+TaskWillBeCreatedAfterValidation         = The tasks will be created once the accident investigation is validated
+AccidentInvestigationCreated             = Accident investigation creation
+AccidentInvestigationModified            = Accident investigation modification
+AccidentInvestigationDeleted             = Accident investigation deletion
+AccidentInvestigationValidate            = Accident investigation validation
+AccidentInvestigationUnValidate          = Accident investigation reopening
+AccidentInvestigationLock                = Accident investigation locking
+AccidentInvestigationSigned              = Accident investigation signature
+CloneWorkStop                            = Clone the work stoppages?
+CloneMetadata                            = Clone the additional data?
+CloneLesion                              = Clone the additional injury data?
+CloneFrom                                = Clone of
+AccidentInvestigationRole                = The accident investigation roles
+LesionsOrWorkStop                        = injuries or work stoppages
+AccidentsCategoriesArea                  = Accidents tags/categories area
+AddAccidentIntoCategory                  = Assign this category to the accident
+PreventionplansCategoriesArea            = Prevention plans tags/categories area
+AddPreventionplanIntoCategory            = Assign this category to the prevention plan
+FirepermitsCategoriesArea                = Fire permits tags/categories area
+AddFirepermitIntoCategory                = Assign this category to the fire permit
+RisksCategoriesArea                      = Risks tags/categories area
+AddRiskIntoCategory                      = Assign this category to the risk
+AddTicketIntoCategory                    = Assign this category to the ticket
+StartDateInvestigate                     = Investigation start date
+EndDateInvestigate                       = Investigation end date
+YearType                                 = Year type
+AllYears                                 = All years
+FiscalYear                               = Fiscal year
+CalendarYear                             = Calendar year
+
+# AccidentTooltip - Accident tooltips
+VictimActivityTooltip              = Specify the activity or the task of the victim at the time of the accident, that is to say what the victim was doing
+AccidentNatureTooltip              = Describe the event that led to the accident, how the accident happened (electrical problem, gas leak, equipment failure, slip, fall, physical effort, assault, etc.), or how the victim was injured (impact, collision, crushing, puncture, drowning, contact with a substance, etc.)
+AccidentObjectTooltip              = That is to say what the victim was injured with: material, waste, tool (screwdriver, cutter, drill, etc.), machine, vehicle, handling truck, chemical substance, building element (door, wall, etc.), floor, etc.
+AccidentNatureDoubtTooltip         = Where applicable, state the reasoned reservations, which can only be taken into account if they relate to the time and place of the accident or to the existence of a cause entirely unrelated to work (art. R. 441-11 of the French Social Security Code)
+VictimWorkHoursTooltip             = State the working hours performed by your employee, or the hours scheduled, on the day of the accident
+ConsequenceTooltip                 = If the victim stopped work on a doctor's prescription, you MUST fill in and send the "attestation de salaire accident du travail ou maladie professionnelle" form - reference S6202 - to the primary health insurance fund of the victim's usual place of residence. <br> Afterwards, in the event of a new work stoppage after a period of care or a return to work, in a different month, you must also complete this same formality
+FirstPersonNoticedIsWitnessTooltip = State the surname, first name and address of the witness. <br> If there is no witness, state the first person in the company who was informed of the accident
+ThirdPartyResponsabilityTooltip    = When you are aware that a third party is involved, whatever their share of liability, in a workplace or commuting accident, this must be reported in this section
+FrequencyIndexTooltip              = Number of accidents per employee x 1,000
+FrequencyRateTooltip               = Number of accidents per hours worked x 1,000,000
+GravityRateTooltip                 = Number of days of work stoppage per hours worked x 1,000
+NbWorkedHoursTooltip               = The number of hours worked was entered manually
+DocumentGeneratedWithVersioning    = Document generated during versioning
+
+# Dictionary
+UsualWorkplace                  = Usual workplace
+OccasionalWorkplace             = Occasional workplace
+LocationOfTheMeal               = Place of the meal
+OnTheWayBetweenHomeAndWorkplace = On the way between home and the workplace
+OnTheWayBetweenMealAndWorkplace = On the way between work and the place of the meal
+DuringATripForTheEmployer       = During a trip for the employer
+
+Trunk             = Trunk
+Hand              = Hand
+LowerLimbs        = Lower limbs
+UpperLimbs        = Upper limbs
+MultipleLocations = Multiple locations
+Foot              = Foot
+Head              = Head
+Eyes              = Eyes
+InternalSeating   = Internal locations
+Neck              = Neck
+Back              = Back
+WholeBody         = Whole body
+NotSpecified      = Not specified
+
+PainEffortLumbago           = Pain, strain, lumbago
+Contusion                   = Contusion
+Wounds                      = Wounds
+Sprain                      = Sprain
+FracturePitting             = Fracture or crack
+MultipleInjuries            = Injuries of multiple kinds
+MuscleOrTendonTear          = Muscle or tendon tear
+PresenceOfForeignBody       = Presence of a foreign body
+Burns                       = Burns
+UnspecifiedAndMiscellaneous = Not specified and miscellaneous
+Other                       = Other
+CutOff                      = Cut
+
+Investigator = Investigator
+Rescuer      = First aider
+
+#
+# ListingRisksDocument - Risks listing with documents
+#
+
+# Right
+ListingRisksDocumentMin = risk listings with documents
+
+# Data
+ListingRisksDocument            = Risks listing
+Listingrisksdocument            = Risks listing
+ListingRisksHeader              = Risks - %s
+ListingRisksDocumentGenerated   = Generation of the risks listing with documents
+listingrisksdocument.odt        = Risks listing with documents
+listingrisksdocument_custom.odt = Custom risks listing with documents
+
+#
+# ListingRisksPhoto - Risks listing with photos
+#
+
+# Right
+ListingRisksPhotosMin = risk listings with photos
+
+# Data
+ListingRisksPhoto            = Risks listing with photos
+Listingrisksphoto            = Risks listing with photos
+ListingRisksPhotoGenerated   = Generation of the risks listing with photos
+listingrisksphoto.odt        = Risks listing with photos
+listingrisksphoto_custom.odt = Custom risks listing with photos
+
+
+#
+# ListingRisksAction - Risks listing with corrective actions
+#
+
+# Right
+ListingRisksActionsMin = risk listings with corrective actions
+
+# Data
+ListingRisksAction                        = Risks listing with corrective actions
+Listingrisksaction                        = Risks listing with corrective actions
+ListingRisksActionGenerated               = Generation of the risks listing with corrective actions
+listingrisksaction.odt                    = Risks listing with corrective actions
+listingrisksaction_custom.odt             = Custom risks listing with corrective actions
+DigiriskListingRisksActionData            = Configurable data of the risks listings with corrective actions
+ShowTaskDoneListingRisksActionDescription = Allows showing or hiding the completed tasks in the risks listing with corrective actions
+
+
+#
+# RiskAssessmentDocument - Risk assessment document
+#
+
+# Right
+
+RiskAssessmentDocumentsMin = Risk assessment documents
+
+# Data
+RiskAssessmentDocument                                    = Risk assessment document
+Riskassessmentdocument                                    = Risk assessment document
+RiskAssessmentDocumentGenerated                           = Risk assessment document generation
+AuditStartDate                                            = Audit start date
+AuditEndDate                                              = Audit end date
+Recipient                                                 = Recipient
+ImportantNote                                             = Important note
+SitePlans                                                 = Location of the site plans
+SetStartEndDateBeforeSendEmail                            = Set the audit start and end dates on this page to send an email
+NoSitePlans                                               = No company site plan filled in
+riskassessmentdocument.odt                                = Risk assessment document
+riskassessmentdocument_custom.odt                         = Custom risk assessment document
+DigiriskRiskAssessmentDocumentData                        = Configurable data of the risk assessment document
+ActionPreventionCompletedTaskDone                         = The completed actions are not displayed
+AppliedOn                                                 = Active on:
+RiskAssessmentDocumentMethod                              = * Step 1: Gathering the information<br />- Site visit<br />- Gathering the staff data<br /><br />* Step 2: Defining the methodology and the document<br />- Validating the standard work unit sheets<br />- Validating the unit tree<br /><br />* Step 3: Carrying out the risk study<br />- Making the staff aware of the risks and the hazards<br />- Creating the work units with the staff and the manager(s)<br />- Assessing the risks by work unit with the staff<br /><br />* Step 4<br />- Processing and writing the risk assessment document
+RiskAssessmentDocumentSources                             = Risk awareness is defined in the ED840 published by the INRS.<br />In this document you will find:<br />- The definition of a risk and of a hazard, with an explanatory diagram<br />- The explanations about the different assessment methods
+RiskAssessmentDocumentImportantNote                       = Important notes:<br />You can read the DigiRisk documentation here<br /><a href="https://wiki.dolibarr.org/index.php?title=Module_Digirisk" target="_blank">https://wiki.dolibarr.org/index.php?title=Module_Digirisk</a><br />You can follow the project here:<br /><a href="https://github.com/Evarisk/Digirisk/projects?type=classic" target="_blank">https://github.com/Evarisk/Digirisk/projects?type=classic</a><br />Report a bug here<br /><a href="https://github.com/Evarisk/Digirisk/issues" target="_blank">https://github.com/Evarisk/Digirisk/issues</a>
+GenerateZipArchiveWithDigiriskElementDocuments            = Generation of a ZIP archive with the risk assessment document
+GenerateZipArchiveWithDigiriskElementDocumentsDescription = Automatic generation of a ZIP archive containing the risk assessment document and all the job sheets when the risk assessment document is generated
+RiskAssessmentDocumentDescription                         = Risk assessment document action plan
+ErrorFailToFetchDigiriskElements                          = Error: unable to retrieve the groupings and work units to include in the ZIP archive
+ErrorNoDocumentModelFound                                 = Error: no document template available for <b>%s</b>
+ErrorFailToGenerateDigiriskElementDocument                = Error: the document generation for <b>%s</b> failed, it is missing from the ZIP archive
+
+# Boxes - Widget
+NextGenerateDate  = Next generation
+LastGenerateDate  = Last generation
+DelayGenerateDate = Days remaining
+NoDelay           = No delay
+
+# Email
+RiskAssessmentDocumentLabel   = Risk assessment document summary
+RiskAssessmentDocumentSubject = Risk assessment document email
+RiskAssessmentDocumentContent = Please find attached the ZIP and the ODT document of the risk assessment document.
+
+
+
+#
+# AuditReportDocument - Audit report
+#
+
+# Data
+AuditReportDocument     = Audit report
+Auditreportdocument     = Audit report
+AuditReportDocumentsMin = audit reports
+auditreportdocument.odt = Audit report
+
+
+
+#
+# GroupmentDocument - Grouping sheet
+#
+
+# Right
+
+# Data
+GroupmentDocument                        = Grouping sheet
+Groupmentdocument                        = Grouping sheet
+DocumentModelStandardPDF                 = Standard PDF template
+GroupmentDocumentGenerated               = Grouping sheet generation
+groupmentdocument.odt                    = Grouping sheet
+groupmentdocument_custom.odt             = Custom grouping sheet
+groupmentdocumentinherited.odt           = Grouping sheet - Inherited risks
+groupmentdocumentinherited_custom.odt    = Custom grouping sheet - Inherited risks
+groupmentdocumentshared.odt              = Grouping sheet - Shared risks
+groupmentdocumentshared_custom.odt       = Custom grouping sheet - Shared risks
+DigiriskGroupmentDocumentData            = Configurable data of the grouping sheets
+ShowTaskDoneGroupmentDocumentDescription = Allows showing or hiding the completed tasks in the grouping sheet
+
+#
+# WorkUnitDocumment - Work unit sheet
+#
+
+# Right
+
+# Data
+WorkUnitDocument                        = Work unit sheet
+Workunitdocument                        = Work unit sheet
+WorkUnitDocumentGenerated               = Work unit sheet generation
+workunitdocument.odt                    = Work unit sheet
+workunitdocument_custom.odt             = Custom work unit sheet
+workunitdocumentinherited.odt           = Work unit sheet - Inherited risks
+workunitdocumentinherited_custom.odt    = Custom work unit sheet - Inherited risks
+workunitdocumentshared.odt              = Work unit sheet - Shared risks
+workunitdocumentshared_custom.odt       = Custom work unit sheet - Shared risks
+workunitdocumentcomplete.odt            = Work unit sheet - All risks (own, inherited, shared)
+workunitdocumentcomplete_custom.odt     = Custom work unit sheet - All risks
+DigiriskWorkUnitDocumentData            = Configurable data of the work unit sheets
+ShowTaskDoneWorkUnitDocumentDescription = Allows showing or hiding the completed tasks in the work unit sheet
+
+
+#
+# DigiriskElement - Digirisk element
+#
+
+# Rights
+DigiriskElementsMin = Digirisk elements (grouping and work unit)
+
+# Data
+NewDigiriskElement                  = New Digirisk element
+Digiriskelement                     = Grouping / Work unit
+GPUTOrganization                    = GP/UT organization
+DigiriskElement                     = Digirisk element
+HiddenElements                      = Trash
+DigiriskElementCreated              = Digirisk element creation
+DigiriskElementModified             = Digirisk element modification
+DigiriskElementDeleted              = Digirisk element deletion
+ElementType                         = Element type
+ParentElement                       = Parent element
+OrganizationSaved                   = The organization of the groupings and the work units has been saved
+OrganizationNotSaved                = The organization of the groupings and the work units could not be saved
+UnsavedChanges                      = Unsaved changes
+SavingInProgress                    = Saving in progress...
+Saved                               = Saved
+ErrorSaving                         = Error while saving
+DigiriskElementOrganization         = Tree organization
+ShareDigiriskelement                = Enable the sharing of groupings and work units
+DIGIRISKELEMENTSharing              = Sharing of the groupings and work units
+DIGIRISKELEMENTSharingDescription   = Selection of the entities that will share their groupings and work units with this entity.
+DigiriskElementSharedTooltip        = This option allows sharing the groupings and work units. <br> INFO: if you want to be able to display the tasks, you must enable the project sharing option.
+PleaseSelectADigiriskElement        = Select a grouping or a work unit...
+Registers                           = Registers
+ShowInSelectOnPublicTicketInterface = Must appear in the element list of the ticket public interface
+Organization                        = GP/UT organization
+YouDontHaveOrganization             = You have not created any grouping or work unit, please go to "Risk assessment document" or click <b> here </b> to create one.
+
+
+#
+# Groupment - Grouping
+#
+
+# Data
+Groupment                  = Grouping
+GroupmentManagement        = Grouping data management
+NewGroupment               = New grouping
+ModifyGroupment            = Edit grouping
+TrashGroupment             = Trash grouping
+DeletedElements            = Trash
+DeletedDigiriskElement     = Groupings / Work units moved to the trash
+ShowDeletedDigiriskElement = Show the groupings / work units that are in the trash
+
+#
+# WorkUnit - Work unit
+#
+
+# Data
+WorkUnit           = Work unit
+Workunit           = Work unit
+WorkUnitManagement = Work unit data management
+NewWorkUnit        = New work unit
+ModifyWorkUnit     = Edit work unit
+
+
+#
+# Evaluator - Evaluator
+#
+
+# Rights
+EvaluatorsMin = evaluators
+
+# Data
+Evaluator                    = Evaluator
+Evaluators                   = Evaluators
+EvaluatorCreated             = Evaluator creation
+EvaluatorModified            = Evaluator modification
+EvaluatorDeleted             = Evaluator deletion
+TheEvaluator                 = The evaluator
+EvaluatorWellCreated         = Evaluator created
+EvaluatorNotCreated          = Error while creating the evaluator
+EvaluatorList                = List of evaluators
+AssignmentDate               = Assignment date
+EvaluationDuration           = Duration
+UserAssigned                 = Assigned user
+AddEvaluatorTitle            = Adding an evaluator
+AddEvaluatorButton           = Add the evaluator
+EvaluatorConfig              = Evaluator data setup
+DeleteEvaluatorMessage       = Evaluator deletion
+DigiriskEvaluatorData        = Configurable data of the evaluators
+EvaluatorDuration            = Duration of the assessment by the evaluator
+EvaluatorDurationDescription = The time the evaluator takes to carry out their risk assessment
+NbEmployeesInvolved          = Employees involved
+NbEmployees                  = Employees
+NbEmployeesInvolvedTooltip   = Unique employees (evaluators)
+NbEmployeesTooltip           = If the centralized management of users and groups on the main entity is enabled.<br>The number of employees is the number of users shared/assigned to a group plus the number of administrators of the main entity
+NbEmployeesConfTooltip       = The number of employees was entered manually
+
+
+#
+# DigiriskStandard - Digirisk standard
+#
+
+# Data
+DigiriskStandardInformation = Information
+Digiriskstandard            = Digirisk standard
+DigiriskStandardMin         = Digirisk standards
+TheDigiriskstandard         = the Digirisk standard
+
+
+#
+# RisksAnalysis - Risk analysis
+#
+
+# Data
+RiskAnalysis = Risk analysis
+UpdateData   = Update
+
+#
+# Risks
+#
+
+# Rights
+RisksMin = risks
+
+# Data
+Risks                                    = Risks
+Risk                                     = Risk
+Riskprofessionals                        = Occupational risks
+RiskCreated                              = Risk creation
+RiskModified                             = Risk modification
+RiskDeleted                              = Risk deletion
+RiskConfig                               = Risk data setup
+TheRisk                                  = The risk
+RiskWellCreated                          = Risk created
+RiskNotCreated                           = Error while creating the risk
+RiskWellEdited                           = Risk edited
+RiskNotEdited                            = Error while editing the risk
+RiskList                                 = Risks listing
+AddRiskTitle                             = Adding the risk
+AddRiskButton                            = Add the risk
+EditRisk                                 = Risk editing
+LinkedRisk                               = Linked risk
+RiskCategory                             = Cat.
+RiskCategoryEdit                         = Risk category
+RiskCategoryEditDescription              = Enable editing the category of an existing risk
+HowToEditRiskCategory                    = To change the risk category, click the category pictogram
+DigiriskElementRisksList                 = List of risks
+DigiriskElementRisk                      = Risks
+RiskDescriptionNotEnabled                = The risk description field is not enabled
+HowToEnableRiskDescription               = To enable the risk description field, go to "Module setup -> Risk assessment document"
+HowToEnableRiskCategoryEdit              = To enable risk category editing, go to "Module setup -> Risk assessment document"
+SortRisksListingsByEvaluation            = Sort the risks by assessment
+SortRisksListingsByEvaluationDescription = Enable the automatic sorting of risks by assessment in the listings
+ListingHeaderEvaluation                  = List of assessments
+RiskDescription                          = Risk description
+RiskDescriptionDescription               = Enable the risk description field
+RiskDescriptionNotActivated              = Please enable the risk description field in Module setup / Risk analysis / Risks
+AddRisk                                  = Add a risk
+MoveRisk                                 = Move the risk
+MoveRisks                                = Move the risks
+MoveRisksDescription                     = Allows moving risks from one grouping or work unit to another
+SetConfToMoveRisk                        = You must first allow moving risks in "Module setup -> Risk assessment document"
+RiskDescriptionPrefill                   = Prefill the description
+RiskDescriptionPrefillDescription        = Prefill the risk description with the category name
+DigiriskElementSharedRisksList           = List of shared risks
+ImportSharedRisks                        = Import shared risks
+SelectAllSharedRisksOfElement            = Select all the risks of this element
+AlreadyImported                          = Already imported
+ShowSharedRisks                          = Shared risks
+ShareRisk                                = Enable risk sharing
+RISKSharing                              = Risk sharing
+RISKSharingDescription                   = Selection of the entities that will share their risks with this entity.
+ShowSharedRisksDescription               = Show the shared risks in the documents and the listings
+UnlinkSharedRisk                         = Unlink the shared risk
+RiskWellUnlinkShared                     = Risk unlinked
+RiskNotUnlinkShared                      = Error while unlinking the risk
+HasBeenUnlinkSharedM                     = has been unlinked
+HasNotBeenUnlinkSharedM                  = has not been unlinked
+RiskSharedTooltip                        = This option allows sharing the risks. <br> INFO: if you want to be able to display the tasks, you must enable the project sharing option.
+ShowInheritedRisksInListings             = Inherited risks - Listings <br> (coming from the upper levels)
+ShowInheritedRisksInListingsDescription  = Inherited risks are those defined at an upper level (e.g. site or GP) and automatically applied to the GP/UT. <br> Enable this option to show them in the listings
+ShowInheritedRisksInDocuments            = Inherited risks - Documents <br> (coming from the upper levels)
+ShowInheritedRisksInDocumentsDescription = Inherited risks are those defined at an upper level (e.g. site or GP) and automatically applied to the GP/UT. <br> Enable this option to show them in the documents
+DigiriskElementInheritedRisksList        = List of inherited risks
+ConfirmImportSharedRisks                 = Please choose the shared risks to import
+RisksRepartition                         = Breakdown of risks by assessment
+ShowRiskOrigin                           = Show the risk origin
+ShowRiskOriginDescription                = Show the origin of the risks in the documents (Risk assessment document, Grouping, Work units, Risks listing with actions and with photos, etc.).
+SharedRiskImportWithSuccess              = Risk imported successfully
+RiskImport                               = Risk import
+RiskUnlink                               = Shared risk deletion
+RiskDeleted                              = The risk %s has been deleted
+RiskSharedWithEntityRefLabel             = Sharing of the risk %s with
+RiskUnlinkedFromEntityRefLabel           = Unlinking of the risk %s from
+TheDigiriskelement                       = the Digirisk element
+DefaultProjectContactType                = Default role assigned to the risk assessment document project
+DefaultTaskContactType                   = Default role assigned to the risk assessment document project tasks
+RiskListParentView                       = Show all the parent elements
+RiskListParentViewDescription            = Show all the parent elements of a risk in the risk list and in the documents
+CategoryOnRisk                           = Show the tags/categories on the risks
+CategoryOnRiskDescription                = Allows assigning tags/categories to the risks and displaying them - handle with care
+AddPsychosocialRisk                      = Add a psychosocial risk
+AddPsychosocialRiskTitle                 = Adding a psychosocial risk
+AddPsychosocialRiskButton                = Add the psychosocial risk
+AddSelectedPsychosocialRisks             = Add the selected psychosocial risks
+SocialRelationsAtWork                    = Social relations at work
+WorkIntensityAndTime                     = Work intensity and working time
+EmotionalRequirements                    = Emotional demands
+Autonomy                                 = Autonomy
+MeaningOfWork                            = Meaning of work
+WorkSituationInsecurity                  = Insecurity of the work situation
+PreventionContextInCompany               = Prevention context in the company
+RPSImpactOnCompanyAndEmployees           = Impact of psychosocial risks on the company and the employees
+PsychosocialRisksFactors                 = Psychosocial risk factors
+CompanyPreventionInformations            = Information about prevention in the company
+Weak                                     = Low
+Moderate                                 = Moderate
+High                                     = High
+Extreme                                  = Extreme
+HereIsTheWorkStationDescription          = Here is the description of the workstation
+ImageAnalysis                            = Image analysis
+TextAnalysis                             = Text analysis
+AnalyzeText                              = Analyze the text
+EnterTextForAnalysis                     = Enter the text to analyze
+AIRiskAnalysis                           = AI risk analysis
+AnalysisInProgress                       = Analysis in progress...
+
+# Stats
+GreyRisk                                         = Low risk
+OrangeRisk                                       = Risk to plan
+RedRisk                                          = Risk to handle
+BlackRisk                                        = Unacceptable risk
+RisksNotAssessed                                 = Risks not assessed
+RisksRepartitionByDangerCategories               = Breakdown of risks by hazard category
+RiskListsByDangerCategories                      = List of risks by hazard category
+DigiriskElementsRepartitionByDepth               = Breakdown of the tree of the level %s groupings
+RisksRepartitionByDangerCategoriesAndCriticality = Breakdown of risks by hazard category and criticality
+NumberOfRisks                                    = Number of risks
+DangerCategories                                 = Hazard categories
+RisksRepartitionByDigiriskElement                = Breakdown of risks by grouping / work unit %s
+
+
+
+#
+# RiskEnvironmentals - Environmental risks
+#
+
+# Data
+Environment                                    = Environment
+Riskenvironmental                              = Environmental risk
+RiskEnvironmentals                             = Environmental risks
+Riskenvironmentals                             = Environmental risks
+RiskEnvironmentalsMin                          = environmental risks
+AddRiskenvironmentalTitle                      = Adding the environmental risk
+DigiriskElementRiskenvironmentalsList          = List of environmental risks
+DigiriskElementInheritedRiskenvironmentalsList = List of inherited environmental risks
+DigiriskElementSharedRiskenvironmentalsList    = List of shared environmental risks
+ImportSharedRiskenvironmentals                 = Import shared environmental risks
+SelectAllSharedRiskenvironmentalsOfElement     = Select all the environmental risks of this element
+ConfirmImportSharedRiskenvironmentals          = Please choose the shared environmental risks to import
+EnvironmentDescription                         = Planning - Actions to implement to address risks and opportunities
+
+#
+# ListingRisksEnvironmentalAction - Environmental risks listing with corrective actions
+#
+
+# Right
+ListingRisksEnvironmentalActionMin = Environmental risks listing with corrective actions
+
+# Data
+ListingRisksEnvironmentalAction            = Environmental risks listing with corrective actions
+Listingrisksenvironmentalaction            = Environmental risks listing with corrective actions
+ListingRisksEnvironmentalActionGenerated   = Generation of the environmental risks listing with corrective actions
+listingrisksenvironmentalaction.odt        = Environmental risks listing with corrective actions
+listingrisksenvironmentalaction_custom.odt = Custom environmental risks listing with corrective actions
+
+#
+# ListingRisksEnvironmentalDocument - Environmental risks listing with documents
+#
+
+# Data
+ListingRisksEnvironmentalDocument = Environmental risks listing
+
+
+
+#
+# RiskAssessment - Assessment
+#
+
+# Data
+RiskAssessment                              = Assessment
+Riskassessment                              = Assessment
+RiskAssessments                             = Assessments
+RiskAssessmentCreated                       = Assessment creation
+RiskAssessmentModified                      = Assessment modification
+RiskAssessmentDeleted                       = Assessment deletion
+RiskAssessmentConfig                        = Assessment data setup
+TheRiskAssessment                           = The assessment
+LastRiskAssessment                          = Last risk assessment
+RiskAssessmentWellCreated                   = Assessment created
+RiskAssessmentNotCreated                    = Error while creating the assessment
+RiskAssessmentWellEdited                    = Assessment edited
+RiskAssessmentNotEdited                     = Error while editing the assessment
+RiskAssessmentWellDeleted                   = Assessment deleted
+RiskAssessmentNotDeleted                    = Error while deleting the assessment
+EvaluationCreate                            = Adding the assessment
+EvaluationEdit                              = Assessment editing
+EvaluationMethod                            = Assessment method
+lastEvaluationOn                            = Last assessment on
+DeleteEvaluation                            = Are you sure you want to delete the assessment
+DigiriskRiskAssessmentData                  = Configurable data of the assessments
+MultipleRiskAssessmentMethodName            = Assessment methods
+MultipleRiskAssessmentMethodDescription     = Enable changing the assessment method
+AdvancedRiskAssessmentMethod                = Advanced assessment method
+AdvancedRiskAssessmentMethodDescription     = Enable the advanced assessment method
+RiskAssessmentList                          = List of the risk assessments
+EditRiskAssessment                          = Edit the assessment
+ShowAllRiskAssessments                      = See all the assessments
+ShowAllRiskAssessmentsDescription           = Show the complete list of the risk assessments in the risk list
+ParentRisk                                  = Parent risk
+RiskAssessmentDate                          = Assessment date
+SimpleEvaluation                            = Simple assessment
+AdvancedEvaluation                          = Advanced assessment
+CalculatedEvaluation                        = Calculated assessment
+SelectEvaluation                            = Tick the boxes to calculate your assessment
+EvaluationList                              = List of the risk assessments
+HowToSetMultipleRiskAssessmentMethod        = To configure the multiple use of the assessment methods, go to Module setup - Risk analysis - Assessment
+NoFileLinked                                = No linked photo
+AddRiskAssessment                           = Add a risk assessment
+AddRiskAssessmentTask                       = Add a task to the risk
+ListRiskAssessmentTask                      = List of the risk tasks
+ShowRiskAssessmentDate                      = Assessment date
+ShowRiskAssessmentDateDescription           = Replaces the creation date with the assessment start date in the sheet and the documents
+RiskAssessmentHideDateInDocument            = Hide the assessment date in the documents
+RiskAssessmentHideDateInDocumentDescription = Hide the assessment date from the "Assessment information" column in the documents
+RiskTaskComplete                            = Task %s completed
+
+# Stats
+TasksRepartition = Breakdown of tasks by declared actual progress
+TaskAt0Percent   = Task at 0
+TaskInProgress   = Task in progress
+TaskAt100Percent = Task at 100
+
+
+#
+# RiskSign - Risk sign
+#
+
+# Rights
+RiskSignsMin = risk signs
+
+# Data
+RiskSign                           = Risk sign
+RiskSignCreated                    = Risk sign creation
+RiskSignModified                   = Risk sign modification
+RiskSignDeleted                    = Risk sign deletion
+TheRiskSign                        = The risk sign
+RiskSignConfig                     = Risk sign data setup
+RiskSignWellCreated                = Risk sign created
+RiskSignNotCreated                 = Error while creating the risk sign
+RiskSignWellEdited                 = Risk sign edited
+RiskSignNotEdited                  = Error while editing the risk sign
+RiskSignWellDeleted                = Risk sign deleted
+RiskSignNotDeleted                 = Error while deleting the risk sign
+RiskSignCategory                   = Category
+RiskSignImport                     = Risk sign import
+RiskSignUnlink                     = Shared risk sign deletion
+AddRiskSignTitle                   = Adding a risk sign
+AddRiskSignButton                  = Add the risk sign
+EditRiskSign                       = Risk sign editing
+DeleteRiskSignMessage              = Risk sign deletion
+DigiriskElementRiskSignList        = List of risk signs
+RiskSigns                          = Risk signs
+DigiriskElementSharedRiskSignsList = List of shared risk signs
+ImportSharedRiskSigns              = Import shared risk signs
+SelectAllSharedRiskSignsOfElement  = Select all the risk signs of this element
+AlreadyImportedF                   = Already imported
+ShowSharedRiskSigns                = Shared risk signs
+ShowSharedRiskSignsDescription     = Show the shared risk signs in the documents and the listings
+DigiriskElementSharedRiskSign      = Shared risk signs
+SharedRiskSigns                    = Shared risk signs
+ShareRisksign                      = Enable risk sign sharing
+RISKSIGNSharing                    = Risk sign sharing
+RISKSIGNSharingDescription         = Selection of the entities that will share their risk signs with this entity.
+UnlinkSharedRiskSign               = Unlink the shared risk sign
+RiskSignWellUnlinkShared           = Risk sign unlinked
+RiskSignNotUnlinkShared            = Error while unlinking the risk sign
+HasBeenUnlinkSharedF               = has been unlinked
+HasNotBeenUnlinkSharedF            = has not been unlinked
+RiskSignSharedTooltip              = This option allows sharing the risk signs. <br> INFO: if you want to be able to display the tasks, you must enable the project sharing option.
+ShowInheritedRiskSigns             = Inherited risk signs
+ShowInheritedRiskSignsDescription  = Show the inherited risk signs in the documents and the listings
+DigiriskElementInheritedRiskSignsList = List of inherited risk signs
+ConfirmImportSharedRiskSigns       = Please choose the shared risk signs to import
+RiskSignSharedWithEntityRefLabel   = Sharing of the risk sign %s with
+RiskSignUnlinkedFromEntityRefLabel = Unlinking of the risk sign %s from
+
+#
+# Tasks - Task
+#
+
+# Data
+ActionPlan                               = Action plan
+Task                                     = Task
+TaskCreatedEvent                         = Task creation
+TaskModifiedEvent                        = Task modification
+TaskDeletedEvent                         = Task deletion
+TheTask                                  = The task
+TaskConfig                               = Task data setup
+TaskWellCreated                          = Task created
+TaskNotCreated                           = Error while creating the task
+TaskWellEdited                           = Task edited
+TaskNotEdited                            = Error while editing the task
+TaskWellDeleted                          = Task deleted
+TaskNotDeleted                           = Error while deleting the task
+TasksManagement                          = Task management
+SelectProject                            = Project choice
+DUProject                                = Project linked to the risk tasks
+EnvironmentProject                       = Project linked to the environmental risk tasks
+NoTaskLinked                             = No task in progress
+TaskList                                 = List of the risk tasks
+TaskCreate                               = Adding the task
+TaskEdit                                 = Task editing
+HowToSetDUProject                        = To configure the project choice, go to Module setup - Risk analysis - Task
+DeleteTask                               = Are you sure you want to delete the task
+ListingHeaderTask                        = List of tasks
+ListingHeaderTaskTooltip                 = Enable project sharing to display the tasks
+TasksManagementDescription               = Enable task management
+TaskManagementNotActivated               = Please enable task management in Module setup / Risk analysis / Task
+DigiriskProgress                         = Progress
+ShowTaskStartDate                        = Task start date
+ShowTaskStartDateDescription             = Replaces the creation date with the task start date in the sheet and the documents
+ShowTaskEndDate                          = Task end date
+ShowTaskEndDateDescription               = Show the task end date
+ShowTasksDone                            = Completed tasks
+ShowTasksDoneDescription                 = Show the tasks completed at 100
+ShowTasksDoneDescriptionExtend           = on the risk lists
+ShowTaskCalculatedProgress               = Task progress
+ShowTaskCalculatedProgressDescription    = Show the calculated progress of the task instead of the declared progress
+ShowAllTasks                             = All the tasks of a risk in the listings
+ShowAllTasksDescription                  = Show all the tasks in the task list of a risk in the listings
+DeleteTaskTimeSpent                      = Are you sure you want to delete %s mins of time spent on the task
+TaskTimeSpentEdit                        = Editing the time spent on the task
+TheTaskTimeSpent                         = The time spent
+TaskTimeSpentCreated                     = Time spent creation
+TaskTimeSpentModified                    = Time spent modification
+TaskTimeSpentDeleted                     = Time spent deletion
+TaskTimeSpentWellCreated                 = Time spent created
+TaskTimeSpentNotCreated                  = Error while creating the time spent
+TaskTimeSpentWellEdited                  = Time spent edited
+TaskTimeSpentNotEdited                   = Error while editing the time spent
+TaskTimeSpentWellDeleted                 = Time spent deleted
+TaskTimeSpentNotDeleted                  = Error while deleting the time spent
+OnTheTask                                = on the task
+TaskTimeSpentDuration                    = Duration of the time spent
+TaskTimeSpentDurationDescription         = The time spent added by default to each task
+NoTaskShared                             = No shared task
+WarningTaskLabel                         = Warning, you have exceeded the maximum number of characters allowed (255)
+ErrorRecordHasSubTasks                   = The task has children
+TotalConsumedTime                        = Total time spent on the project
+TotalConsumedTimeAmount                  = Cost of the time spent
+NbTasks                                  = Number of tasks
+TotalProgress                            = Overall actual progress of the tasks
+TotalBudget                              = Sum of the task budgets
+TaskTimeSpentDate                        = Time spent date
+StartDateCannotBeAfterEndDate            = The end date cannot be earlier than the start date
+TasksFromProject                         = The tasks displayed come from the project set as "Risk assessment document project"
+TaskHideRefInDocument                    = Hide the reference
+TaskHideRefInDocumentDescription         = Hide the task reference in the documents
+TaskHideResponsibleInDocument            = Hide the responsible
+TaskHideResponsibleInDocumentDescription = Hide the task responsible in the documents
+TaskHideDateInDocument                   = Hide the date
+TaskHideDateInDocumentDescription        = Hide the task start and end dates in the documents
+TaskHideBudgetInDocument                 = Hide the budget
+TaskHideBudgetInDocumentDescription      = Hide the task budget in the documents
+
+#
+# DigiAI - DigiAI
+#
+
+# Data
+WelcomeToDigiAI = Welcome to DigiAI
+UploadAnImage = Upload an image
+OpenAIApiKey = OpenAI API key
+OpenAIApiKeyDescription = To use DigiAI, you must have an OpenAI API key. You can get one by creating an account on <a href="https://platform.openai.com/signup" target="_blank">https://platform.openai.com/signup</a>. Once registered, you can generate an API key in the "API Keys" section of your dashboard.
+
+#
+# Ticket - Ticket public interface
+#
+
+# Rights
+TicketTagsConfig                         = Editing the occupational health and safety registers
+
+# Data
+Register                                 = Register
+Send                                     = Send
+TicketSent                               = Ticket sent
+FilesLinked                              = Photos / Attachments
+AddDocument                              = Add a document
+LastnamePlaceholder                      = Example: Smith
+FirstnamePlaceholder                     = Example: John
+PhonePlaceholder                         = 00.00.00.00.00
+LocationPlaceholder                      = Example: Office A
+ServicePlaceholder                       = Example: Refuse collector
+Location                                 = Location
+CategoriesCreated                        = Ticket category creation
+ExtrafieldsCreated                       = Ticket extrafield creation
+AnticipatedLeave                         = Early departure
+DGI                                      = Serious and imminent danger
+SST                                      = Occupational health and safety
+PresquAccident                           = Near miss
+Accident                                 = Accident
+EnhancementSuggestion                    = Improvement suggestion
+MaterialProblem                          = Material problem
+HumanProblem                             = Human problem
+Others                                   = Other
+AccidentWithoutDIAT                      = Minor accident
+AccidentWithDIAT                         = Workplace accident
+Environment                              = Environment
+Quality                                  = Quality
+NonCompliance                            = Non-compliance
+FirstName                                = First name
+LastName                                 = Last name
+Phone                                    = Phone
+DeclarationDate                          = Declaration
+DigiriskTicketPublicAccess               = A public interface requiring no login is available at the following URL
+TicketActivatePublicInterface            = Enable the public interface
+GenerateExtrafields                      = Generation of the default ticket extrafields
+GenerateTicketCategories                 = Generation of the default ticket categories
+AlreadyGenerated                         = Already generated
+NotGenerated                             = Not generated yet
+NotCreated                               = Not created yet
+ExtrafieldsGeneration                    = This option generates the default ticket extrafields. The extrafields created will be: <br> Last name, First name, Phone, GP/UT, Location & Date
+CategoriesGeneration                     = This option generates the default ticket categories. The categories created will be: <br> - Register <br> - - Accident <br> - - - Near miss, Minor accident, Workplace accident <br> - - Occupational health & safety <br> - - - Early departure, Others, Human problem, Material problem <br> - - Serious and imminent danger <br> - - Quality <br> - - - Non-compliance, Improvement suggestion <br> - - Environment <br> - - - Non-compliance, Others
+TicketSuccess                            = Your register entry has been sent to the prevention department under the number:
+TicketPublicAccess                       = Return link to the ticket public interface:
+TicketShowCompanyLogo                    = Show the company logo in the public interface
+TicketShowCompanyLogoHelp                = Enable this option to hide the company logo on the public interface pages
+YouMustNotifyYourHierarchy               = You are <b>required</b> to inform your management
+GoBackToTicketCreation                   = Go to the ticket tracking page
+SendEmailOnTicketSubmit                  = Send emails on creation
+CatTicketsList                           = List of the ticket tags/categories
+SendEmailTo                              = Email address to notify
+SendEmailOnTicketSubmitHelp              = Enable the automatic sending of an email when a ticket is created
+MultipleEmailsSeparator                  = To assign several email addresses to notify, separate them with a ";". For example: "aaaa@bbb.cc;dddd@eee.ff"
+TicketCategories                         = Ticket categories
+TicketDocumentsConfig                    = Ticket documents
+TicketExtrafields                        = Ticket extrafields
+MainCategorySetting                      = This option sets the category whose subcategories will appear in the public interface
+TicketCategoriesInDocumentsSetting       = This option sets the ticket categories displayed in the ticket list of the documents (Risk assessment document, grouping sheet, etc.). If no category is selected, all the categories are displayed
+ParentCategorySetting                    = This option sets the title of the parent category for the ticket public interface
+ChildCategorySetting                     = This option sets the title of the child category for the ticket public interface
+TicketManagement                         = Ticket management
+MainCategory                             = Main category choice
+TicketCategoriesInDocuments              = Categories displayed in the documents
+ParentCategoryLabel                      = Parent category title
+ChildCategoryLabel                       = Child category title
+TicketPublicInterfaceEnabled             = The ticket public interface has been enabled
+TicketPublicInterfaceDisabled            = The ticket public interface has been disabled
+TicketPublicInterface                    = Public interface
+EmailsToNotifySet                        = The email addresses to notify have been saved
+MainCategorySet                          = The main category has been set
+TicketCategoriesInDocumentsSet           = The categories displayed in the documents have been set
+ParentCategoryLabelSet                   = The parent category title has been set
+ChildCategoryLabelSet                    = The child category title has been set
+TicketPublicInterfaceConfigDocumentation = To configure the ticket public interface, see the documentation
+ParentCategory                           = Parent category
+TSProject                                = Project linked to the tickets
+TicketDescription                        = Tickets project
+TicketProjectUpdated                     = The default ticket project has been updated
+QRCodeAlreadyGenerated                   = QR code generated
+GenerateQRCode                           = Generate the QR code
+CompanyQRCodeGeneration                  = Entity QR code generation
+QRCodeGeneration                         = QR code generation
+MultiCompanyQRCodeGeneration             = Multi-entity QR code generation
+TicketCreationMailWellSent               = Ticket creation confirmation email sent
+TicketCreationMailSent                   = The ticket creation email has been sent to %s
+HowToSetupTicketCategories               = To configure the ticket categories, please click this link:
+ConfigTicketCategories                   = Ticket categories setup
+NewTicketSubmitted                       = A ticket has been submitted through the public interface
+ANewTicketHasBeenSubmitted               = New safety register entry created for %s
+TicketCreationSubject                    = Ticket creation through the Digirisk public interface
+TicketDocumentCustomDigiriskTemplate     = Custom ODT of the ticket sheets
+HowToSetupDigiriskElement                = To configure the Digirisk elements (groupings/work units), please click this link:
+ConfigDigiriskElement                    = Digirisk elements setup
+ErrorFieldEmail                          = Error: the email must match the following format: <b>'aaa@aaa.fr'</b>
+ErrorFieldPhone                          = Error: the phone must match the following format: <b>'0XXXXXXXXXXX'</b> or <b>'+33XXXXXXXXX'</b>
+TicketEmailRequired                      = Email required to create a ticket
+TicketEmailRequiredHelp                  = Enable this option to make entering an email mandatory to create a ticket in the public interface
+WelcomeToPublicTicketInterface           = Welcome to the ticket public interface
+PleaseSelectAnEntity                     = Please select an entity:
+ShowSelectorOnTicketPublicInterface      = Show the multi-entity selector on the ticket public interface instead of the entity list
+ShowSelectorOnTicketPublicInterfaceHelp  = Show the multi-entity selector on the ticket public interface instead of the list of entities with their logo
+MultiEntityPublicInterface               = Multi-company ticket public interface
+TicketCategoriesNotCreated               = You have not created any ticket category
+TicketPublicInterfaceQRCode              = QR code of the ticket public interface
+MultiEntityTicketPublicInterfaceQRCode   = QR code of the multi-company ticket public interface
+PublicInterfaceConfiguration             = Visible / required fields of the public interface
+TicketNumber                             = Ticket no.
+FromAndDate                              = Origin and date
+AuthorRequest                            = Requester
+DateCloture                              = Closing date
+
+PublicInterfaceUseSignatory              = Signature required to submit this register entry
+ValidateText                             = Terms to accept for the signature
+TicketPublicInterfaceShowCategory        = Show the category description
+EmailTemplate                            = Email template
+EmailTemplateDescription                 = Email template
+
+OpenInNewTab                             = Open in a new tab
+TicketDigiriskElementRequired            = GP/UT required to create a ticket
+TicketDigiriskElementRequiredHelp        = Enable this option to make selecting a GP/UT mandatory to create a ticket in the public interface
+TicketDigiriskElementHideRef             = Hide the GP/UT reference in the department selector of the public interface
+TicketDigiriskElementHideRefHelp         = Enable this option to hide the GP/UT reference in the public interface
+TicketDigiriskelementVisible             = Show the GP/UT field to create a ticket
+TicketServiceVisible                     = Show the GP/UT field to create a ticket
+TicketDigiriskelementVisibleHelp         = Enable this option to show the GP/UT field in the public interface and make it mandatory if needed
+TicketServiceVisibleHelp                 = Enable this option to show the GP/UT field in the public interface and make it mandatory if needed
+TicketPhotoVisible                       = Show the Photo field to create a ticket
+TicketPhotoVisibleHelp                   = Enable this option to show the Photo field in the public interface
+TicketEmailVisible                       = Show the Email field to create a ticket
+TicketEmailVisibleHelp                   = Enable this option to show the Email field in the public interface and make it mandatory if needed
+TicketLastnameVisible                    = Show the Last name field to create a ticket
+TicketLastnameVisibleHelp                = Enable this option to show the Last name field in the public interface and make it mandatory if needed
+TicketFirstnameVisible                   = Show the First name field to create a ticket
+TicketFirstnameVisibleHelp               = Enable this option to show the First name field in the public interface and make it mandatory if needed
+TicketPhoneVisible                       = Show the Phone field to create a ticket
+TicketPhoneVisibleHelp                   = Enable this option to show the Phone field in the public interface and make it mandatory if needed
+TicketLocationVisible                    = Show the Location field to create a ticket
+TicketLocationVisibleHelp                = Enable this option to show the Location field in the public interface and make it mandatory if needed
+TicketDateVisible                        = Show the Date field to create a ticket
+TicketDateVisibleHelp                    = Enable this option to show the Date field in the public interface and make it mandatory if needed
+QRCodeGenerated                          = QR code generated
+FkTicket                                 = Linked ticket
+PublicTicket                             = Ticket public interface
+TicketPublicInterfaceForbidden           = Access to the ticket public interface is forbidden
+DefaultUserGroup                         = Default group
+DefaultUserGroupDescription              = Default group in the group selectors
+ConfigureDefaultUserGroup                = Configure the default group
+RegisterSigned                           = Register entry signed
+
+#Public interface
+TicketPublicInterfaceShowCategoryDescription     = Show the ticket category description in the public interface
+TicketPublicInterfaceShowCategoryDescriptionHelp = Enable this option to show the ticket category description in the public interface
+
+
+# Stats
+TicketStatistics    = Ticket statistics
+ExportCSV           = CSV export
+GenerateCSV         = Generate the CSV file
+SuccessGenerateCSV  = CSV file %s generated successfully
+ErrorMissingData    = Error: the CSV file could not be generated, the data sent to the file is incorrect. <br> Please check that you do have GP/UT assigned to tickets.
+CSVFileExport       = Export of the register entries in CSV format associated with GP/UT
+ThirdPartyHelp      = If the "Third party" filter is empty, no third party is used for the search
+GP/UTHelp           = By default, the filter takes all the GP/UT
+CategoryTicketHelp  = By default, the filter takes all the categories
+CreatedByHelp       = If the "Created by" filter is empty, no user is used for the search
+AssignedToHelp      = If the "Assigned to" filter is empty, no user is used for the search
+StatusHelp          = By default, the filter takes all the statuses<br>
+ConcernedTimePeriod = Period taken into account
+LessThan            = Less than
+MoreThan            = More than
+Comparator          = Comparator
+RangeNumber         = Quantity
+TimeRange           = Time unit
+RangeLabel          = Constraint name
+Inferior            = Less than
+Superior            = Greater than
+TimeRangeAdded      = Constraint added
+TimeRangeDeleted    = Constraint deleted
+
+NumberOfTicketsByMainCategorieAndDigiriskElement    = Number of register entries by category and by GP
+NumberOfTicketsByMainSubCategorieAndDigiriskElement = Number of register entries by subcategory and by GP
+NumberOfTicketsByYear                           = Number of tickets by year
+
+# Ticket Management Dashboard
+TicketManagementDashboard                 = Ticket management dashboard
+RunningTicket                             = Tickets in progress
+NbOfOpenedTicket                          = Number of open tickets
+OldestTicket                              = Oldest ticket
+OldestTicketDescription                   = Oldest ticket with the time elapsed since its creation
+OldestMessageTicket                       = Oldest ticket with a message
+OldestMessageTicketDescription            = Oldest ticket with a message and the time elapsed since the message was created
+MeanAnswerTime                            = Average answer time
+MeanAnswerTimeDescription                 = Average time between the opening and the closing, calculated on closed tickets only
+MeanFirstResponseTime                     = Average first response time
+MeanFirstResponseTimeDescription          = Average time between the ticket opening and the first message visible to the reporter. Internal notes do not count, and tickets without a public message are excluded from the calculation
+NbTicketPerUser                           = Average number of tickets assigned per person
+NbExchangePerTicket                       = Number of exchanges per ticket
+TicketRepartitionPerUserAndMeanAnswerTime = Breakdown of tickets by user and average answer time
+TopSocietyWithMostTickets                 = Top %s of the companies with the most tickets
+TicketsCreatedVersusClosedByMonth         = Tickets created and closed over the last %s months
+TicketsCreated                            = Created
+TicketsClosed                             = Closed
+OpenTicketsByStatus                       = Breakdown of open tickets by status
+OpenTicketBacklogAge                      = Age of the open tickets (since creation)
+BacklogAgeUnderDays                       = Less than %s days
+BacklogAgeBetweenDays                     = From %s to %s days
+BacklogAgeOverDays                        = More than %s days
+ShowSelectedDateTypes                     = Select the type of date to display
+
+# Email
+The                            = On
+TicketMessage                  = Register entry message
+SeeTicketUrl                   = See the ticket
+AutoNotificationTicket         = Email notification sent automatically by
+TicketPublicInterfaceOtherName = Management interface for the occupational health and safety and serious imminent danger registers
+
+
+
+# Ticket document
+
+# Data
+TicketDocument                 = Ticket sheet
+Ticketdocument                 = Ticket sheet
+ticketdocument.odt             = Ticket sheet
+ticketdocument_custom.odt      = Custom ticket sheet
+ticketdocument_events.odt      = Ticket sheet with events
+ticketdocument_sign.odt        = Ticket sheet with signature
+ticketdocument_event_sign.odt  = Ticket sheet with event and signature
+TicketSuccessMessage           = Ticket success message
+TicketSuccessMessageSet        = The message has been changed
+TicketDocumentPDF              = FT-A4-LANDSCAPE
+TicketDocumentPDFDescription   = Show the ticket sheet
+GeneratedTicketDocumentDate    = Export date of this ticket
+
+
+# Project document
+
+# ODT Template
+DigiriskTemplateDocumentProject = Digirisk project sheet document templates
+DocumentModelPapripactA3Paysage = Document templates of the forecast report on the project tasks
+PapripactFullName               = Annual Occupational Risk Prevention and Working Conditions Improvement Program
+
+# Register Document
+
+RegisterDocument     = Register of minor accidents
+Registerdocument     = Register of minor accidents
+RegisterDocumentsMin = registers of minor accidents
+registerdocument.odt = Register of minor accidents
+
+#
+# Tools
+#
+
+# Data
+Tools                                        = Tools
+DigiriskDataMigration                        = Migration data management
+DataMigrationImport                          = Import of the Digirisk tree data
+DataMigrationImportDescription               = Import of the Digirisk WordPress tree data in ZIP format
+DataMigrationImportRisks                     = Import of the Digirisk risk data
+DataMigrationImportRisksDescription          = Import of the Digirisk WordPress risk data in ZIP format
+ErrorFileNotWellFormatted                    = The file is not in the right format or is empty. You must attach an import file coming from Digirisk WordPress named DATE_OBJET_export.json
+ErrorFileNotWellFormattedZIP                 = The file is not in the right format or is empty. You must attach an import file coming from Digirisk WordPress named DATE_OBJET_export.zip
+ErrorJsonBadFormatted                        = The JSON file is not well formatted
+SuccessImport                                = Data imported successfully
+DataMigrationImportRiskSigns                 = Import of the Digirisk risk sign data
+DataMigrationImportRiskSignsDescription      = Import of the Digirisk WordPress risk sign data in ZIP format
+DataMigrationImportGlobal                    = Import of the Digirisk global data <br> (Tree, risks and risk signs)
+DataMigrationImportGlobalDescription         = Import of the Digirisk WordPress global data in ZIP format <br> (Tree, risks and risk signs)
+DataMigrationExportGlobal                    = Export of the Digirisk global data <br> (Tree, risks and risk signs)
+DataMigrationExportGlobalDescription         = Export of the Digirisk Dolibarr global data in ZIP format <br> (Tree, risks and risk signs)
+DataMigrationExportTree                      = Export of the Digirisk tree <br> (Tree only)
+DataMigrationExportTreeDescription           = Export of the Digirisk Dolibarr tree in ZIP format <br> (GP/UT visible from the current entity, without the risks or the risk signs)
+DataMigrationImportGlobalDolibarrDescription = Import of the Digirisk Dolibarr global data in ZIP format <br> (Tree, risks and risk signs)
+DataMigrationTreeAlreadyImported             = The tree data import has already been done
+DataMigrationRisksAlreadyImported            = The risk data import has already been done
+DataMigrationRiskSignsAlreadyImported        = The risk sign data import has already been done
+DataMigrationGlobalAlreadyImported           = The global data import (tree, risks and risk signs) has already been done
+AdvancedImport                               = Advanced import
+AdvancedImportDescription                    = Allows importing each element independently (tree, risks and risk signs)
+DataMigrationWordPressToDolibarr             = Data migration from WordPress to Dolibarr
+DataMigrationDolibarrToDolibarr              = Data migration from Dolibarr to Dolibarr
+RepairRisks                                  = Repair the risks
+NumberOfRisksCorrupted                       = You have %s risk(s) with a corrupted category, go to the "Tools" page to repair them
+NoRiskToRepair                               = No risk to repair
+DigiriskElementSuccessfullyRepaired          = Digirisk elements (GP/UT) repaired successfully
+RiskSuccessfullyRepaired                     = Risks repaired successfully
+RiskAssessmentSuccessfullyRepaired           = Assessments repaired successfully
+CorruptedCategoryOnRiskList                  = List of the risks with a corrupted category
+
+# Clean
+Clean                                          = Clean
+CleanObject                                    = Clean the data
+CleanDigiriskElementExistParentDigiriskElement = %d Digirisk elements (GP/UT) have an invalid parent
+CleanDigiriskElement                           = Clean the Digirisk elements (GP/UT)
+CleanRiskFkElement                             = %d risks have an invalid GP/UT
+CleanRiskStatus                                = %d risks have an invalid status
+CleanRiskExistFkElement                        = %d risks are orphaned
+CleanRiskExistRiskAssessment                   = %d risks have no assessment
+CleanRisk                                      = Clean the risks
+CleanRiskAssessmentStatus                      = %d assessments have an invalid status
+CleanRiskAssessmentCotation                    = %d assessments have an empty rating
+CleanRiskAssessmentExistFkRisk                 = %d assessments are orphaned
+CleanRiskAssessment                            = Clean the assessments
+NoDigiriskElementToClean                       = No Digirisk element (GP/UT) to clean
+NoRiskToClean                                  = No risk to clean
+NoRiskAssessmentToClean                        = No assessment to clean
+
+
+#
+# Other
+#
+
+# Data
+AT = to
+
+LabourInspectorName                 = DREETS
+UrlLabourInspector                  = https://travail-emploi.gouv.fr/ministere/organisation/article/dreets-directions-regionales-de-l-economie-de-l-emploi-du-travail-et-des
+IDCCTooltip                         = This field comes from the Digirisk module for Dolibarr <br> The collective agreement nomenclature comes from travail-emploi.gouv.fr
+NoEmailContact                      = No email on this contact
+AddMedia                            = Add a media
+NoMediaLinked                       = No linked media
+UserGroup                           = User group
+ReaderGroup                         = Reader group
+UserCreated                         = The user has been created
+GetAPI                              = Use of the Digirisk API routes with the GET method
+PostAPI                             = Use of the Digirisk API routes with the POST method
+MinimizeMenu                        = Collapse the menu
+ActionsLine                         = Actions
+PhotoWellSent                       = The photo has been added to the media library
+PhotoNotSent                        = The photo was not sent correctly
+PhotoWellSaved                      = The media has been added
+PhotoNotSaved                       = The media has not been added
+UseCaptcha                          = Graphical code (CAPTCHA)
+UseCaptchaDescription               = Use of the graphical code (CAPTCHA) on the public interface pages
+GP/UTParticipation                  = GP/UT participation
+LabourDoctorName                    = AMETRA
+LabourDoctorFirstName               = Occupational
+LabourDoctorLastName                = physician
+DashBoard                           = Dashboard
+Close                               = Close
+DateRange                           = Date range
+UseDateRange                        = Use the date range
+SiretNumber                         = Siret no.
+Society                             = Company
+MulticompanyTransverseModeEnabled   = The centralized management of users and groups on the main entity is enabled.<br>You therefore cannot create a user or a group on this entity.<br>Please go to the main entity to add it.
+ManuelInputNBEmployees              = Enter the number of employees manually
+ManuelInputNBEmployeesDescription   = If the option is enabled, you can enter the number of employees manually in the company setup.<br>Otherwise the number of employees is calculated.<br>See the documentation for more information.
+ManuelInputNBWorkedHours            = Enter the number of hours worked manually
+ManuelInputNBWorkedHoursDescription = If the option is enabled, you can enter the number of hours worked manually in the company setup.<br>Otherwise the number of hours worked is calculated.<br>See the documentation for more information.
+ShowPatchNoteAgain                  = Show the release note again
+ShowPatchNoteAgainDescription       = If the option is enabled, the release note of the current version appears again on the Digirisk home page.<br>(Requires the "Show the release notes from GitHub" option to be enabled to be visible.)
+HowToConfigureSetupConf             = To configure the company data linked to Digirisk,<br>please go to Digirisk - Setup - Settings
+LabourDoctorNameFull                = Physicians association
+PermissionInheritedFromConfig       = The permissions are inherited from the general setup or from the parent setup
+CategorieManagement                 = Category management
+ShowSelectedRiskTypes               = Select the risk types to display
+CharRemaining                       = Characters remaining
+NumberOfLinkedFiles                 = Number of attached files
+ChooseAnImage                       = Choose an image
+
+# Action Plan - Gantt / Kanban
+ActionPlanGantt                     = Gantt chart
+ActionPlanKanban                    = Kanban
+ActionPlanView                      = Action plan
+ColumnDraft                         = Draft
+ColumnInProgress                    = In progress
+ColumnInControl                     = To be checked
+ColumnDone                          = Done
+NoTasks                             = No corrective action
+ActionPlanGlobalProgress            = Overall PAPRIPACT progress
+ActionPlanGlobalProgressInfo        = Average progress of %s corrective action(s)
+KanbanLoadMore                      = Show more (%s)
+KanbanDisplay                       = Kanban display
+KanbanPageSize                      = Number of cards per column
+KanbanPageSizeDesc                  = Number of corrective actions displayed straight away in each column; the following ones are loaded with the "Show more" button (improves performance on large volumes)
+KanbanDraftMax                      = "Draft" column threshold
+KanbanDraftMaxDesc                  = Maximum progress (%) for an action to stay in the "Draft" column
+KanbanProgressMax                   = "In progress" column threshold
+KanbanProgressMaxDesc               = Maximum progress (%) for the "In progress" column
+KanbanControlMax                    = "To be checked" column threshold
+KanbanControlMaxDesc                = Maximum progress (%) for the "To be checked" column; beyond that the action moves to "Done"
+PlannedWorkload                     = Planned workload
+TimeSpent                           = Time spent
+LinkedRisk                          = Linked risk
+TaskMovedTo                         = Task moved to %s
+
+AddCategory                        = Add a category
+SelectCategory                     = Choose a category
+DateEndBeforeStart                 = End date earlier than the start date
+InternalUsers                      = Internal users
+ExternalContacts                   = External contacts
+AddContributor                     = Add a contributor
+RemoveContact                      = Remove the contact
+ColumnWidth                        = Width
+ColumnGap                          = Spacing
+ActionPlanExportCsv                = Download the PAPRIPACT as a CSV file
+ActionPlanExportA3                 = Download the PAPRIPACT as an A3 landscape PDF
+ActionPlanExportGantt              = Download the Gantt chart as a PNG image
+ActionPlanDisplayedProject         = Displayed project
+ActionPlanChangeProject            = Change project
+ActionPlanDefaultProject           = Risk assessment document (default)
+ActionPlanNoProjectConfigured      = No project configured
+
+# ActionPlan — ActionComm logging
+ActionPlanLogging                  = Action plan — Modification history
+ActionPlanLoggingDescription       = Enable the creation of events on Kanban changes
+ActionPlanLogLabel                 = Label change
+ActionPlanLogLabelDesc             = Create an event when the label of a task is changed
+ActionPlanLogWorkload              = Workload change
+ActionPlanLogWorkloadDesc          = Create an event when the planned workload is changed
+ActionPlanLogBudget                = Budget change
+ActionPlanLogBudgetDesc            = Create an event when the budget is changed
+ActionPlanLogContributorAdd        = Contributor added
+ActionPlanLogContributorAddDesc    = Create an event when a contributor is added
+ActionPlanLogContributorRemove     = Contributor removed
+ActionPlanLogContributorRemoveDesc = Create an event when a contributor is removed
+ActionPlanLogProgress              = Progress change
+ActionPlanLogProgressDesc          = Create an event when the progress is changed
+ActionPlanLogTag                   = Tag change
+ActionPlanLogTagDesc               = Create an event when a tag is added or removed
+ActionPlanLogDateStart             = Start date change
+ActionPlanLogDateStartDesc         = Create an event when the start date is changed
+ActionPlanLogDateEnd               = End date change
+ActionPlanLogDateEndDesc           = Create an event when the end date is changed
+ActionPlanTaskLabelChanged         = Label changed: "%s" → "%s"
+ActionPlanTaskWorkloadChanged      = Workload changed: %s → %s
+ActionPlanTaskBudgetChanged        = Budget changed: %s → %s
+ActionPlanTaskContributorAdded     = Contributor added: %s
+ActionPlanTaskContributorRemoved   = Contributor removed: ID %s
+ActionPlanTaskProgressChanged      = Progress changed: %s%% → %s%%
+ActionPlanTaskTagAdded             = Tag added: %s
+ActionPlanTaskTagRemoved           = Tag removed: ID %s
+ActionPlanTaskDateStartChanged     = Start date changed: %s → %s
+ActionPlanTaskDateEndChanged       = End date changed: %s → %s
+
+# ===========================================================================
+# Action plan filters — issue #4907 (GP/UT, risk level, tags)
+# ===========================================================================
+ActionPlanElement                    = GP/UT
+ActionPlanFilterElementChildren      = With the sub-elements
+ActionPlanFilterElementChildrenHelp  = Include the corrective actions of the GP/UT below the selected one
+ActionPlanFilterScale                = Risk level
+ActionPlanFilterAllScales            = All levels
+ActionPlanFilterTags                 = Tags
+ActionPlanFilterCount                = %s corrective action(s) displayed out of %s
+ActionPlanDictionaries               = Kanban lists
+ActionPlanDictionariesDesc           = Manage the values offered in the action plan and Kanban lists
+ActionPlanTagDictionary              = Corrective action tags
+ActionPlanTagDictionaryDesc          = Tags (task categories) offered on the cards and in the action plan Kanban filter
+ActionPlanTicketDictionaries         = Ticket Kanban dictionaries
+ActionPlanTicketDictionariesDesc     = Types, groups and severities making up the ticket Kanban columns
+ActionPlanManageDictionary           = Manage
+
+# ===========================================================================
+# Ticket action card — issue #4443 (1-click tile UI)
+# ===========================================================================
+TicketActionCard                     = Ticket action
+TicketActionCardPickerIntro          = Select a ticket to perform a quick 1-click action.
+TicketActionCardStatusSection        = Status
+TicketActionCardAssignSection        = Assignment
+TicketActionCardContentSection       = Content
+TicketActionCardDangerSection        = Sensitive area
+TicketActionMarkRead                 = Mark as read
+TicketActionInProgress               = Set in progress
+TicketActionWaiting                  = Set on hold
+TicketActionClose                    = Close
+TicketActionCancel                   = Cancel the ticket
+TicketActionAssignSelf               = Assign to me
+TicketActionAssignOther              = Assign to...
+TicketActionAddMessage               = Add a message
+TicketActionLinkAccident             = Link an accident
+TicketActionOpenFull                 = Full details
+TicketActionMarkedRead               = Ticket marked as read
+TicketActionInProgressDone           = Ticket set in progress
+TicketActionWaitingDone              = Ticket set on hold
+TicketActionClosedDone               = Ticket closed
+TicketActionCancelledDone            = Ticket cancelled
+TicketActionAssignedSelfDone         = Ticket assigned to you
+TicketActionAssignedOtherDone        = Ticket assigned
+TicketActionCloseConfirm             = Confirm the closing
+TicketActionCancelConfirm            = Confirm the cancellation
+TicketActionCardRegistresSection      = Register information
+TicketMessageTitle                    = Message title
+TicketResponsibleAndProgress          = Responsible and progress
+TicketActionCardClassificationSection = Classification
+TicketActionCardDatesSection          = Key dates
+TicketActionCardIdentificationSection = Identification
+TicketActionCardOtherFieldsSection    = Other information
+TicketActionCardEventsSection         = Recent events
+TicketActionCardRelatedSection        = Linked objects
+UnknownFieldToUpdate                  = Unknown field: %s
+Saved                                 = Saved
+SeeAll                                = See all
+LayoutCustomize                       = Customize
+LayoutDone                            = Done
+LayoutControls                        = Layout controls
+LayoutWidthHalf                       = Half column
+LayoutWidthFull                       = Full column
+LayoutWidthSpan                       = Full width
+LayoutSaved                           = Layout saved
+LayoutReset                           = Reset
+LayoutResetTitle                      = Reset the layout (back to the default values)
+LayoutDensity                         = Display density
+LayoutDensityCompact                  = Compact
+LayoutDensityCozy                     = Cozy
+LayoutDensitySpacious                 = Spacious
+AddTag                                = Add a tag
+TagAdded                              = Tag added
+TagRemoved                            = Tag removed
+Preview                               = Preview
+OpenInNewTab                          = Open in a new tab
+FileDeleted                           = File deleted
+OtherTicket                           = other ticket
+OtherTickets                          = other tickets
+SeeOtherTicketsForThisCompany         = See the ticket history of this customer
+StatusTimeline                        = Status timeline
+WatchTicket                           = Watch this ticket
+UnwatchTicket                         = Stop watching this ticket
+TicketWatched                         = Ticket watched
+TicketUnwatched                       = Ticket removed from the watch list
+WatchedTicket                         = Watched ticket
+WatchedOnly                           = Watched only
+AllTickets                            = All
+NoWatchedTicket                       = No watched ticket
+FileUploaded                          = File uploaded
+UploadFile                            = Choose a file
+OrDropAnywhere                        = or drag and drop anywhere on the card
+Messages                              = Messages
+TypeYourReply                         = Type your reply…
+PrivateMessage                        = Private message
+Send                                  = Send
+NoMessageYet                          = No message yet
+BeFirstToReply                        = Be the first to reply
+MessagePosted                         = Message sent
+MessageEdited                         = Message edited
+MessageDeleted                        = Message deleted
+ConfirmDeleteMessage                  = Delete this message?
+ReplyByEmail                          = Send by email
+SentByMail                            = Sent by email
+MailSentToNRecipients                 = email sent to %d recipient(s)
+MailNotSent                           = email sending failed
+NoRecipientFound                      = no recipient found
+OriginalMessage                       = Original message
+JustNow                               = just now
+NMinAgo                               = %d min ago
+NHAgo                                 = %dh ago
+NDAgo                                 = %dd ago
+NAttachedFiles                        = %d attached file(s)
+Quote                                 = Quote
+NotAllowed                            = Action not allowed
+Private                               = Private
+Unknown                               = Unknown
+LayoutTagsMode                        = Tag display
+LayoutTagsModeChips                   = Full list (chips)
+LayoutTagsModeSelector                = Drop-down selector
+LayoutActionsMode                     = Action display
+LayoutActionsModeBar                  = Action bar
+LayoutActionsModeMenu                 = Menu (⋮)
+Move                                  = Move
+Hide                                  = Hide
+Show                                  = Show
+
+# ===========================================================================
+# Ticket kanban — admin logging config — issue #4753
+# ===========================================================================
+TicketKanban                           = Ticket Kanban
+TicketKanbanLogging                    = Ticket Kanban — Modification history
+TicketKanbanLoggingDescription         = Enable the creation of events on changes made in the Kanban
+TicketKanbanLogStatus                  = Status change
+TicketKanbanLogStatusDesc              = Create an event when the status of a ticket is changed through the Kanban
+TicketKanbanLogAssignee                = Assignee change
+TicketKanbanLogAssigneeDesc            = Create an event when the assignee of a ticket is changed through the Kanban
+TicketKanbanLogCategoryAdd             = Tag added
+TicketKanbanLogCategoryAddDesc         = Create an event when a tag is added to a ticket through the Kanban
+TicketKanbanLogCategoryRemove          = Tag removed
+TicketKanbanLogCategoryRemoveDesc      = Create an event when a tag is removed from a ticket through the Kanban
+TicketKanbanLogType                    = Type change
+TicketKanbanLogTypeDesc                = Create an event when the type of a ticket is changed through the Kanban
+TicketKanbanLogGroup                   = Group change
+TicketKanbanLogGroupDesc               = Create an event when the group of a ticket is changed through the Kanban
+TicketKanbanLogSeverity                = Severity change
+TicketKanbanLogSeverityDesc            = Create an event when the severity of a ticket is changed through the Kanban
+TicketKanbanLogSubject                 = Subject change
+TicketKanbanLogSubjectDesc             = Create an event when the subject of a ticket is changed through the Kanban
+TicketKanbanLogDeadline                = Deadline change
+TicketKanbanLogDeadlineDesc            = Create an event when the deadline of a ticket is changed through the Kanban
+TicketKanbanClosedLimit                = Closed ticket limit
+TicketKanbanClosedLimitDesc            = Maximum number of closed/cancelled tickets displayed in the Kanban (0 = unlimited)
+
+# ===========================================================================
+# Ticket — modification traceability — issue #4885
+# ===========================================================================
+TicketLogModifications                 = Modification traceability
+TicketLogModificationsDesc             = Create an event for every edit made from the ticket card (subject, message, registers, assignee, third party, project, progress, status, tasks, documents)
+TicketMessageEdited                    = Message edited
+TicketMessageDeleted                   = Message deleted
+TicketTaskCreated                      = Task created: %s
+TicketDocumentGenerated                = Document generated
+TicketFileDeleted                      = File deleted
+
+# Ticket quick creation drawer
+SelectNothing                          = — Select —
+QuickCreateTicket                      = Quickly create a ticket
+TicketSubjectPlaceholder               = Ticket title...
+TicketInitialMessage                   = Initial message
+OptionalDescription                    = Description (optional)...
+Unassigned                             = Unassigned
+QuickCreateAttachments                 = Attachments
+QuickCreateDropzone                    = Drag and drop or click to select
+QuickCreateDropzoneActive              = Drop here…
+QuickCreateAttachmentHint              = Accepted formats: images, PDF, docs. Max 10 MB per file.
+QuickCreateTicketSuccess               = Ticket %s created successfully.
 
 # MeteoVigilance - Météo-France weather warnings
 MeteoVigilance = Météo-France weather warning
@@ -76,13 +2033,6 @@ Conversation = Conversation
 PublicMessage = Public message
 ConvTo = To
 ConvCc = Cc
-PrivateMessage = Private message
-OriginalMessage = Original message
-SentByMail = Sent by email
-NoMessageYet = No message yet
-BeFirstToReply = Be the first to reply
-JustNow = just now
-Quote = Quote
 
 SaveNote = Save note
 
@@ -90,12 +2040,10 @@ AddRecipient = Add recipient
 NoRecipientFound = No recipient found
 
 AddFile = Add file
-NAttachedFiles = %s attached file(s)
 
 MentionAgents = Mention agents
 YouWereMentionedOnTicket = You were mentioned on ticket %s
 YouWereMentionedOnTicketBody = %s mentioned you on ticket %s:
-ConfirmDeleteMessage = Delete this message?
 
 Mentioned = Mentioned
 
@@ -151,6 +2099,11 @@ MobilePPSignatureEmailSentTo = Signature request sent to %s
 MobilePPExtSignatureTitle = Exterior company signature
 MobilePPExtEmailSentOn = Request sent to %s on %s
 MobilePPExtEmailNotSent = Signature request not sent: share the link or have them sign now
+MobilePPSpreadDefaultsTitle = Public display of the spread
+MobilePPSpreadShowCount = Show the number of signatories
+MobilePPSpreadShowName = Show the first name and the last name
+MobilePPSpreadShowContact = Show the phone and the email
+MobilePPSpreadHidePublicNote = Do not show the public note
 MobilePPExtAlreadySigned = Signed on %s
 MobilePPExtSignNow = Sign now
 MobilePPExtResendEmail = Send the email again
@@ -187,15 +2140,18 @@ MobilePPCertifications = Required certifications
 MobilePPAddCertification = Add a certification
 MobileCertifications = Certifications (mobile)
 MobilePPUploadCertPhoto = Upload a photo
-MobilePPErrorCreatingThirdparty = Error creating the third party.
-MobilePPErrorCreatingContact = Error creating the contact.
-MobilePPErrorUpdatingPlan = Error updating the prevention plan.
-MobilePPErrorCreatingPlan = Error creating the prevention plan.
+MobilePPErrorCreatingThirdparty = Error while creating the third party.
+MobilePPErrorCreatingContact = Error while creating the contact.
+MobilePPErrorUpdatingPlan = Error while updating the prevention plan.
+MobilePPErrorCreatingPlan = Error while creating the prevention plan.
 MobileSuccessViewDocument = View the document
+MobileSuccessPlanSentByEmailOn = Prevention plan sent by email on %s
+MobileSuccessExteriorSignedOn = Exterior company responsible (EE): Signed on %s
+MobileSuccessExteriorPendingSignature = Exterior company responsible (EE): Pending signature
 MobilePPDefaultsTitle = Default values (Mobile creation)
 MobilePPDefaultDateStartToday = Start date = today
 MobilePPDefaultDuration = Default period duration (days)
-MobilePPEmailAutoSend = Automatically send signature email on creation
+MobilePPEmailAutoSend = Automatically send the signature email on creation
 
 # Mobile fire permit quick creation
 MobileFPPreventionPlanHelp = The exterior company and the period of the selected plan are reused automatically.
@@ -216,7 +2172,7 @@ MobileFPViewPermit = View permit
 MobileFPCreateAnother = Create another permit
 
 # Digirisk PWA
-PwaApplication = Application
+PwaApplication = Mobile app
 PwaNavHome = Home
 PwaNavPreventionPlans = Plans
 PwaNavFirePermits = Permits
@@ -227,42 +2183,21 @@ PwaNavRemoveFavorite = Remove from favorites
 PwaHello = Hello %s
 PwaResultCount = %s result(s)
 AllStatus = All statuses
-
-# Libelles metier utilises par l'interface mobile, jusqu'ici traduits en francais seulement
-PreventionPlan = Prevention plan
-PreventionPlanLinked = Linked prevention plan
-ExtSocietyResponsible = Exterior company manager
-CSSCTIntervention = CSSCT intervention
-PriorVisitDate = Joint prior inspection date
-PriorVisitText = Inspection note
-UsedEquipment = Equipment used
 PwaTilePreventionPlanInProgress = Plans in progress
 PwaTilePreventionPlanToSign = Plans to sign
 PwaTileFirePermitInProgress = Permits in progress
 PwaTileFirePermitToSign = Permits to sign
 
-# Task mass actions
-MassValidateTasks = Validate tasks
+# Mass actions on tasks
+MassValidateTasks = Validate the tasks
 MassChangeTasksProject = Change project
 ConfirmMassValidateTasksQuestion = Are you sure you want to validate the %s selected task(s)? Only draft tasks will be validated.
 ConfirmMassChangeTasksProjectQuestion = Are you sure you want to attach the %s selected task(s) to the chosen project?
 MassValidateTasksSuccess = %s task(s) validated out of %s selected
 MassChangeTasksProjectSuccess = %s task(s) attached to project %s
 
-# Missing Saturne module
-SaturneModuleMissing = The Saturne module is required by Digirisk. Download it for free on the Dolistore (https://dolistore.com/en/modules/1906-Saturne.html) and install it before enabling Digirisk.
-
-# Ticket - modification traceability - issue #4885
-TicketLogModifications = Modification traceability
-TicketLogModificationsDesc = Create an event for every edit made from the ticket card (subject, message, registers, assignee, third party, project, progress, status, tasks, documents)
-TicketMessageEdited = Message edited
-TicketMessageDeleted = Message deleted
-TicketTaskCreated = Task created: %s
-TicketDocumentGenerated = Document generated
-TicketFileDeleted = File deleted
-
-# Plan de prevention PDF
-PreventionPlanLegalNotice = The prevention plan is a mandatory document preventing the risks caused by several companies working on the same site, as per article R4512-7 of the French labour code.
+# Prevention plan PDF
+PreventionPlanLegalNotice = The prevention plan is a mandatory document intended to prevent the risks caused by the interference between the activities of several companies on the same site, in accordance with article R4512-7 of the French Labor Code.
 PreventionPlanUserCompany = User company - EU
 PreventionPlanExteriorCompany = Exterior company - EE
 PreventionPlanUserCompanyResponsible = User company responsible (EU)
@@ -270,13 +2205,11 @@ PreventionPlanExteriorCompanyResponsible = Exterior company responsible (EE)
 EmergencyNumbers = Emergency numbers
 Firefighters = Firefighters
 AnyEmergency = Any emergency
-FirstAid = First aid
-PriorVisitIntro = The user company carried out a prior joint inspection on %s. During this visit the following points were presented by the user company:
-PriorVisitCheckList = Work places|Installations found there|Equipment made available to the exterior companies|Delimit the intervention area of the exterior companies|Mark the zones that may be dangerous for workers|Indicate the traffic lanes for workers, vehicles and machines of the exterior companies|Define the access ways to the premises used by the exterior companies
+PriorVisitIntro = Prior to the operation, the user company carried out a prior joint inspection on %s. During this visit the following points were presented by the user company (art. R. 4512-2 and R. 4512-3 of the French Labor Code):
+PriorVisitCheckList = Work places|Installations found there|Equipment possibly made available to the exterior companies|Delimit the intervention area of the exterior companies|Mark the zones of this area that may be dangerous for the workers|Indicate the traffic lanes that the workers may use, as well as the vehicles and machines of any kind belonging to the exterior companies|Define the access ways for the workers to the premises and facilities used by the exterior companies (in particular the sanitary facilities, collective changing rooms and catering areas)
 PriorVisitComments = The following comments were recorded:
-InterventionPeriodSentence = This plan starts on %s and ends on %s. Interventions will take place at the following times:
-RiskAnalysis = Analysis of actions, risks and prevention means
-RiskAnalysisIntro = You planned %s intervention(s) for this prevention plan: below are the planned actions, the risks involved and the prevention means.
+InterventionPeriodSentence = This plan starts on %s and ends on %s. The interventions will take place at the following times:
+RiskAnalysisIntro = You have planned %s intervention(s) for this prevention plan: below are the planned actions, the risks involved and the prevention resources put in place.
 PreventionPlanAttendants = Attendants: exterior company (EE) and subcontractors
 Morning = Morning
 Afternoon = Afternoon
@@ -286,118 +2219,70 @@ PreventionPlanRiskPhotos = Risk photos
 InterventionPeriodOnly = This plan starts on %s and ends on %s.
 
 DigiRisk=DigiRisk
-DigiriskIdentification=IDENTIFICATION & CHARACTERISTICS
+DigiriskIdentification=DESCRIPTION & CHARACTERISTICS
 DigiriskSecurity=SECURITY
 DigiriskUserManual=SIMPLIFIED USER MANUAL
-DigiriskQualification=QUALIFICATION & ENABLEMENT
+DigiriskQualification=QUALIFICATION & AUTHORIZATION
 DigiriskHygiene=HYGIENE & CLEANING
 DigiriskMaintenance=MAINTENANCE & CHECKS
-ClickToAddContent=Click to add content...
-
-AddProductRisk=Add product risk
-NewProductRisk=New product risk
-DangerCategory=Risk category
-SelectDangerCategory=Select a risk category
+DangerCategory=Risk family
+SelectDangerCategory=Choose a risk family
 DescribeRiskOnProduct=Describe the risk on this product...
 ConfirmDeleteProductRisk=Delete this risk?
+AddProductRisk=Add product risk
+ClickToAddContent=Click to add content...
 AddProtection=Add a protection
 
-SelectProtection=Select a protection (PPE)
-TechnicalSheet=Technical Sheet
+SelectProtection=Choose a PPE protection
+TechnicalSheet=Technical sheet
 DigiriskRisks=RISKS & PROTECTIONS
-MobileSuccessInteriorSignedOn=Interior responsible (EU) : Signed on %s
+MobileSuccessInteriorSignedOn=User company responsible (EU): Signed on %s
+
+MobileSuccessPlanSentByEmailOn = Prevention plan sent by email on %s
+MobileSuccessExteriorSignedOn = Exterior company responsible (EE): Signed on %s
+MobileSuccessExteriorPendingSignature = Exterior company responsible (EE): Pending signature
 
 MobilePPErrorInvalidEmail = Please respect the email format.
 MobilePPErrorInvalidPhone = Please respect the phone format.
-MobileSuccessExteriorPendingSignature = Exterior Company Responsible (EE) : Pending signature
+MobilePPExtSendEmail = Send the email
+MobilePPErrorMailServerNotConfigured = Your mail server is not configured, please contact your administrator.
+MobilePPDoliletterNotInstalled = The Doliletter module is not installed. Sharing prevention plans and fire permits will not be available (contact your administrator)
 
-# ===========================================================================
-# Action plan filters — issue #4907 (GP/UT, risk level, tags)
-# ===========================================================================
-ActionPlanElement                    = GP/WU
-ActionPlanFilterElementChildren      = With the sub elements
-ActionPlanFilterElementChildrenHelp  = Include the corrective actions of the GP/WU below the selected one
-ActionPlanFilterScale                = Risk level
-ActionPlanFilterAllScales            = All levels
-ActionPlanFilterTags                 = Tags
-ActionPlanFilterCount                = %s corrective action(s) displayed out of %s
-ActionPlanDictionaries               = Kanban lists
-ActionPlanDictionariesDesc           = Manage the values offered in the action plan and Kanban lists
-ActionPlanTagDictionary              = Corrective action tags
-ActionPlanTagDictionaryDesc          = Tags (task categories) offered on the cards and in the action plan Kanban filter
-ActionPlanTicketDictionaries         = Ticket Kanban dictionaries
-ActionPlanTicketDictionariesDesc     = Types, groups and severities making up the ticket Kanban columns
-ActionPlanManageDictionary           = Manage
+# Statuses and types for the tooltips
+preventionplan = Prevention plan
+Locked = Locked
+InProgress = In progress
+ValidatePendingSignature = Pending signature
+Archived = Archived
+
+ProductFIChaptersManagement=Customization of the instruction sheet chapters
+ProductFIChaptersManagementSub=Customization of the "Instruction sheet" tab and of the "Risks" tab in the product card
+DefaultContent=Default content
+CustomSvgUploaded=Custom SVG
+DeleteCustomSvg=Delete
+DefaultSvgUsed=Default SVG
+
+PwaTilePreventionPlanLocked = Validated plans
+PwaTileFirePermitLocked = Validated permits
 
 # ===========================================================================
 # Action plan Kanban columns dictionary — issue #5017
 # ===========================================================================
 ActionPlanColumnDictionary           = Action plan Kanban columns
-ActionPlanColumnDictionaryDesc       = Columns displayed on the PAPRIPACT Kanban when the dictionary mode is on: label, progress range, colour and icon
+ActionPlanColumnDictionaryDesc       = Columns displayed on the PAPRIPACT Kanban when the dictionary mode is on: label, progress range, color and icon
 KanbanColumnSource                   = Column source
-KanbanColumnSourceDesc               = Split the Kanban with the percentage thresholds below (historical behaviour) or with the column dictionary
+KanbanColumnSourceDesc               = Split the Kanban with the percentage thresholds below (historical behavior) or with the column dictionary
 KanbanColumnSourceThresholds         = Percentage thresholds (default)
 KanbanColumnSourceDictionary         = Column dictionary
 ActionPlanColumnProgressHelp         = Progress bounds covered by the column, from 0 to 100
-ActionPlanColumnColorHelp            = Hexadecimal colour of the column, for instance #3085d6
+ActionPlanColumnColorHelp            = Hexadecimal color of the column, for instance #3085d6
 ActionPlanColumnPictoHelp            = Font Awesome icon name, for instance fa-check
 Progress_min                         = Min. progress
 Progress_max                         = Max. progress
 Picto                                = Icon
 
-# ===========================================================================
-# Action plan — Kanban, Gantt, project selector and logs — issue #4751
-# ===========================================================================
-ActionPlanView                       = Action plan
-ActionPlanKanban                     = Kanban
-ActionPlanDisplayedProject           = Displayed project
-ActionPlanChangeProject              = Change project
-ActionPlanDefaultProject             = Risk assessment document (default)
-ActionPlanNoProjectConfigured        = No project configured
-ActionPlanGlobalProgress             = Overall PAPRIPACT progress
-ActionPlanGlobalProgressInfo         = Average progress of %s corrective action(s)
-ActionPlanExportA3                   = Download the PAPRIPACT as an A3 landscape PDF
-ActionPlanExportCsv                  = Download the PAPRIPACT as a CSV file
-ActionPlanExportGantt                = Download the Gantt chart as a PNG image
-ColumnDraft                          = Draft
-ColumnInProgress                     = In progress
-ColumnInControl                      = To be checked
-ColumnDone                           = Done
-ColumnWidth                          = Width
-ColumnGap                            = Spacing
-KanbanLoadMore                       = Show more (%s)
-LinkedRisk                           = Linked risk
-Responsible                          = Responsible
-PreventionOfficers                   = Prevention officers
-PreventionOfficer                    = Prevention officer
-Unassigned                           = Unassigned
-AddCategory                          = Add a category
-ExternalContacts                     = External contacts
-RemoveContact                        = Remove the contact
-ActionPlanLogLabel                   = Label change
-ActionPlanLogWorkload                = Workload change
-ActionPlanLogBudget                  = Budget change
-ActionPlanLogProgress                = Progress change
-ActionPlanLogTag                     = Tag change
-ActionPlanLogContributorAdd          = Contributor added
-ActionPlanLogContributorRemove       = Contributor removed
-ActionPlanTaskLabelChanged           = Label changed: "%s" → "%s"
-ActionPlanTaskWorkloadChanged        = Workload changed: %s → %s
-ActionPlanTaskBudgetChanged          = Budget changed: %s → %s
-ActionPlanTaskProgressChanged        = Progress changed: %s%% → %s%%
-ActionPlanTaskTagAdded               = Tag added: %s
-ActionPlanTaskTagRemoved             = Tag removed: ID %s
-ActionPlanTaskContributorAdded       = Contributor added: %s
-ActionPlanTaskContributorRemoved     = Contributor removed: ID %s
-
-# Ticket categories printed in documents - issue #3677
-TicketDocumentsConfig                = Ticket documents
-TicketCategoriesInDocuments          = Categories displayed in documents
-TicketCategoriesInDocumentsSetting   = This option restricts the ticket categories displayed in the ticket list of documents (Single Document, groupment sheet, etc.). When no category is selected, all of them are displayed
-TicketCategoriesInDocumentsSet       = Categories displayed in documents have been set
-
 # Time spent report
-GenerateTimeSpentReport = Generate time spent report (PDF)
+GenerateTimeSpentReport = Generate the time spent report (PDF)
 TimeSpentReport = Time spent report
 TimeSpentReportUsersHelp = Leave empty to include every user who booked time on this project.
 TimeSpentReportSummary = Summary by user
@@ -406,9 +2291,6 @@ TimeSpentReportGeneratedAt = Generated on
 TimeSpentReportWholePeriod = Since the beginning of the project
 TimeSpentReportNoData = No time spent matches the selected users and period.
 TimeSpentDocumentPDFDescription = Time spent on a project, grouped by user
-
-# Risk list dashboard - issue #4388
-RisksNotAssessed                     = Risks not assessed
 
 # Mobile fire permit parity with the prevention plan - issue #5042
 MobileProgress = Progress
@@ -429,8 +2311,8 @@ MobilePPMotif = Reason for the intervention
 MobilePPSchedules = Intervention schedules
 MobilePPConfigHours = Set your opening hours here
 MobilePPCopyCompanyHours = Copy the company opening hours
-FirePermitUserCompany = User company - UC
-FirePermitExteriorCompany = Exterior company - EC
+FirePermitUserCompany = User company - EU
+FirePermitExteriorCompany = Exterior company - EE
 MobileFPMotif = Reason for the work
 MobileFPMotifPlaceholder = E.g. welding on framework
 MobileFPNoMotif = No reason given
@@ -448,79 +2330,58 @@ MobileFPDefaultDateStartToday = Start date = today
 MobileFPDefaultDuration = Default period duration (days)
 firepermit = Fire permit
 ErrorRecordIsLocked = This record is locked, it can no longer be edited.
-ExtSociety = Exterior company
-FirePermit = Fire permit
-SelectUser = Select a user
-MobilePPErrorMailServerNotConfigured = Your mail server is not configured, please contact your administrator.
-MobilePPExtSendEmail = Send the email
 MobilePPEmailTemplateExt = Email template for the exterior company responsible
 MobilePPEmailTemplateInt = Email template for the exterior company attendants
 
-# Shared risks/signages import modal - issue #4615
-SelectAllSharedRisksOfElement              = Select all the risks of this element
-SelectAllSharedRiskenvironmentalsOfElement = Select all the environmental risks of this element
-SelectAllSharedRiskSignsOfElement          = Select all the signages of this element
-
-# Risk assessment document archive errors - issue #3702
-GroupmentDocument                          = Groupment sheet
-WorkUnitDocument                           = Work unit sheet
-ErrorFailToFetchDigiriskElements           = Error: unable to fetch the groupments and work units to include in the ZIP archive
-ErrorNoDocumentModelFound                  = Error: no document model available for <b>%s</b>
-ErrorFailToGenerateDigiriskElementDocument = Error: generation of the <b>%s</b> document failed, it is missing from the ZIP archive
-
 #
-# ListingRisksDocument PDF - Risk listing as a PDF
+# ListingRisksDocument PDF - Risks listing in PDF format
 #
 
-ListingRisksDocumentPDF            = Risk listing PDF
-ListingRisksDocumentPDFDescription = Risk listing as a native PDF, opening on the mini single risk assessment document of the element
-ListingRisksDocumentPDFTitle       = Single risk assessment document
+ListingRisksDocumentPDF            = Risks listing PDF
+ListingRisksDocumentPDFDescription = Risks listing as a native PDF, opening on the element mini risk assessment document
+ListingRisksDocumentPDFTitle       = RISK ASSESSMENT DOCUMENT
 ListingRisksEstablishment          = Establishment
-ListingRisksCoverContent           = Content
+ListingRisksCoverContent           = Contents
 ListingRisksCoverHierarchy         = Hierarchy
-ListingRisksCoverDuerpFollowUp     = Risk assessment follow-up
+ListingRisksCoverDuerpFollowUp     = Risk assessment document follow-up
 ListingRisksCoverEmergencyNumbers  = Emergency numbers
-ListingRisksCoverReportIncident    = Report an accident or an issue
-ListingRisksCoverRegisters         = Occupational health and safety registers
-ListingRisksCoverIllustration      = Illustration picture
-NoPreventionOfficerAssigned        = No prevention officer assigned
+ListingRisksCoverReportIncident    = Report an accident or a problem
+ListingRisksCoverRegisters         = Occupational health and safety and serious imminent danger registers
+ListingRisksCoverIllustration      = Illustration image
+NoPreventionOfficerAssigned        = No prevention officer appointed
 NoEmergencyNumberConfigured        = No emergency number configured
-NoResponsibleAssigned              = No responsible assigned
-ListingRisksLegalTitle             = Legal framework
+NoResponsibleAssigned              = No responsible person appointed
+ListingRisksLegalTitle             = Regulatory framework
 RiskDefinitionTitle                = Definition of a risk
-RiskDefinitionText                 = Risk: exposure of a person to a danger. Taking a risk means exposing oneself to a danger and assuming the consequences.
-DangerDefinitionTitle              = Definition of a danger
-DangerDefinitionText               = Danger: anything that threatens the safety or the life of a person, or that may compromise a situation or an activity.
-SingleDocumentTitle                = The single risk assessment document
-SingleDocumentText                 = The single risk assessment document is ruled by articles R4121-1 to R4121-4 of the French labour code. The general prevention principles set the order in which risks must be dealt with.
-PreventionPrinciplesTitle          = General prevention principles - Article L4121-2
-PreventionPrinciplesIntro          = The employer implements the measures of article L. 4121-1 on the basis of the following general prevention principles:
+RiskDefinitionText                 = Risk: n. masc. Danger or drawback one is exposed to. To do something at one's own risk, taking full responsibility for the consequences. A calculated risk. To take risks: to expose oneself to a danger.
+DangerDefinitionTitle              = Definition of a hazard
+DangerDefinitionText               = Hazard: n. masc. (from popular Latin dominiarium "power", from dominus "master"; originally the fact of being at someone's mercy). What threatens the safety or the life of someone; what may compromise a situation, an undertaking, etc.
+SingleDocumentTitle                = The risk assessment document
+SingleDocumentText                 = The risk assessment document is governed by articles R4121-1 to 4 of the French Labor Code. The general principles of prevention set the order in which risks must be dealt with.
+PreventionPrinciplesTitle          = The general principles of prevention - Article L4121-2
+PreventionPrinciplesIntro          = The employer implements the measures provided for in article L. 4121-1 on the basis of the following general principles of prevention:
 PreventionPrinciple1               = Avoid risks.
 PreventionPrinciple2               = Assess the risks that cannot be avoided.
-PreventionPrinciple3               = Fight risks at their source.
-PreventionPrinciple4               = Adapt the work to the individual, especially regarding workstation design, the choice of work equipment and of working and production methods, so as to limit monotonous and machine-paced work and reduce its effects on health.
+PreventionPrinciple3               = Combat risks at source.
+PreventionPrinciple4               = Adapt the work to the individual, especially as regards the design of workstations and the choice of work equipment and working and production methods, with a view in particular to limiting monotonous work and work at a predetermined rate and to reducing their effects on health.
 PreventionPrinciple5               = Take account of the state of the art.
-PreventionPrinciple6               = Replace what is dangerous by what is not, or by what is less dangerous.
-PreventionPrinciple7               = Plan prevention as a coherent whole covering technology, work organisation, working conditions, social relationships and the influence of ambient factors, including risks related to moral and sexual harassment and to sexist behaviour.
-PreventionPrinciple8               = Give collective protective measures priority over individual ones.
-PreventionPrinciple9               = Give workers appropriate instructions.
+PreventionPrinciple6               = Replace what is dangerous by what is not dangerous or by what is less dangerous.
+PreventionPrinciple7               = Plan prevention by integrating, into a coherent whole, technology, work organisation, working conditions, social relations and the influence of ambient factors, in particular the risks linked to psychological harassment and sexual harassment, as well as those linked to sexist behaviour.
+PreventionPrinciple8               = Give priority to collective protective measures over individual protective measures.
+PreventionPrinciple9               = Give appropriate instructions to the workers.
 ListingRisksCotationMethodTitle    = Rating calculation method
-ListingRisksCotationMethodText     = The rating of a risk is a mark from 0 to 100 given during its assessment. The risk level shown in the listing derives directly from it, according to the grid below.
+ListingRisksCotationMethodText     = The rating of a risk is a score from 0 to 100 given when it is assessed. The risk level shown in the listing follows directly from it, according to the grid below.
 ListingRisksCotationLevel          = Level
 ListingRisksCotationRange          = Rating
 ListingRisksCotationMeaning        = Meaning
 ListingRisksCotationAction         = What to do
-ListingRisksCotationAction1        = Keep the existing prevention measures in place.
+ListingRisksCotationAction1        = Maintain the prevention measures in place.
 ListingRisksCotationAction2        = Add an action to the annual prevention programme.
-ListingRisksCotationAction3        = Start a prevention action in the short term.
+ListingRisksCotationAction3        = Start a short-term prevention action.
 ListingRisksCotationAction4        = Act immediately, the exposure must stop.
-ListingRisksListTitle              = Risk list
+ListingRisksListTitle              = List of risks
 ListingRisksActionPlan             = Actions of the annual prevention programme
-ListingRisksCotationColumn         = Rating
+ListingRisksCotationColumn         = Rat.
 ListingRisksRiskColumn             = Risk
-ListingRisksAssessmentColumn       = Assessment details
+ListingRisksAssessmentColumn       = Assessment information
 NoRiskAssessed                     = No risk assessed on this perimeter
-GreyRisk                           = Low risk
-OrangeRisk                         = Risk to be planned
-RedRisk                            = Risk to be handled
-BlackRisk                          = Unacceptable risk

--- a/langs/es_ES/digiriskdolibarr.lang
+++ b/langs/es_ES/digiriskdolibarr.lang
@@ -1,0 +1,2387 @@
+# Copyright (C) 2021-2023 EVARISK <technique@evarisk.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#
+# Genérico
+#
+
+# Module label 'ModuleDigiriskdolibarrName'
+ModuleDigiriskdolibarrName = Digirisk
+
+# Module description 'ModuleDigiriskdolibarrDesc'
+ModuleDigiriskdolibarrDesc = Digirisk para Dolibarr
+
+# Módulo Saturne ausente
+SaturneModuleMissing = El módulo Saturne es necesario para Digirisk. Descárguelo gratuitamente en Dolistore (https://dolistore.com/es/modules/1906-Saturne.html) e instálelo antes de activar Digirisk.
+
+# Columna de las imágenes de tutorial de las páginas de configuración
+TutoImage = Imagen
+
+#
+# Página de administración
+#
+
+# Datos
+DigiriskdolibarrSetup       = Configuración del módulo Digirisk
+DigiriskdolibarrSetupPage        = Página de configuración del módulo Digirisk
+AgendaModuleRequired        = Para garantizar la trazabilidad de las acciones en Digirisk, asegúrese de que el módulo Agenda está activado
+DigiriskDolibarrDescription = Digirisk para Dolibarr
+HowToSetupOtherModules      = Para disponer de más funcionalidades en Digirisk, puede activar numerosos módulos (gestión de proveedores, de facturas, etc.) en este enlace:
+ConfigMyModules             = Configuración de los módulos
+AvoidLogoProblems              = Para evitar cualquier problema con los logotipos en los documentos generados, consulte estos consejos de configuración:
+LogoHelpLink                = https://wiki.dolibarr.org/index.php?title=Premiers_paramétrages
+SecurityConfiguration       = Configuración de los datos de seguridad
+SocialConfiguration          = Configuración de los datos sociales
+Uncompleted                     = Sin completar
+DigiriskData                 = Datos configurables de Digirisk
+DigiriskManagement          = Redirección tras la conexión al sitio
+DigiriskDescription          = Redirección a la página de bienvenida de Digirisk por defecto en lugar de la de Dolibarr.
+HowToSetupIHM                   = Para disponer de más opciones sobre la visualización de Dolibarr (configuración de la imagen de fondo, etc.), puede acceder a este enlace:
+ConfigIHM                    = Configuración de la visualización
+ConfigDico                     = Acceder a la página de configuración de los diccionarios
+LinkedProject               = Proyecto vinculado
+DigiriskUpdate                  = Actualización de Digirisk:
+Security                       = Seguridad
+HowToSharedElement          = Para más información sobre la configuración de los elementos compartidos, acceda a este enlace:
+
+HowToSharedElementLink        = https://wiki.dolibarr.org/index.php?title=Module_Digirisk#Configuration
+ConfigSharedElement         = Configuración de los elementos compartidos (riesgos/señalizaciones)
+DisabledSharedElement       = Opción desactivada porque Multiempresa no está activado o la configuración de los elementos compartidos (riesgos/señalizaciones) no se ha realizado
+DigiriskEventAutoDesc       = Defina aquí los eventos para los que Digirisk creará automáticamente una entrada en la agenda. Cada evento contiene la información relativa a la acción realizada.
+DigiriskActionsEvents       = Eventos para los que Digirisk debe insertar automáticamente un evento en la agenda.
+DigiriskDolibarr            = Digirisk
+Create                      = Crear
+
+# Ticket
+MultiCompanyTicketPublicInterfaceConfig = Configuración de la interfaz pública de tickets multiempresa
+Subtitle                                = Subtítulo
+
+# DigiriskElement
+DigiriskElementDepthGraph            = Nivel de profundidad en los gráficos de los elementos Digirisk
+DigiriskElementDepthGraphDescription = Esta opción permite elegir el nivel de profundidad en los gráficos de los elementos Digirisk <br> Por defecto: nivel 1
+
+# WHSRegister = Registro de seguridad y salud laboral
+TicketsPublicInterfaceConfig         = Configuración de la interfaz pública de tickets
+WHSRegister                          = Registro de seguridad y salud laboral
+CurrentTicketPublicInterfaceURL      = URL de la interfaz pública de tickets
+MulticompanyTicketPublicInterfaceURL = URL de la interfaz pública de tickets multiempresa
+OriginURL                            = URL de origen
+ShortURL                             = URL acortada
+ExternalURL                          = URL externa
+AddExtraField                        = Crear un campo adicional
+IfEmptyVisibleAllCategories          = Si está vacío, visible en todas las categorías
+
+# DigiQuali Sheet - Modelos
+LinkDigiriskdolibarr_digiriskstandard                 = Activar el vínculo con las entidades principales de Digirisk Standard
+LinkDigiriskdolibarr_digiriskstandardDescription      = Permite vincular las entidades estándar de Digirisk con los modelos
+LinkDigiriskdolibarr_digiriskelement                  = Activar el vínculo con las agrupaciones y unidades de trabajo
+LinkDigiriskdolibarr_digiriskelementDescription       = Permite vincular las agrupaciones y unidades de trabajo con los modelos
+LinkDigiriskdolibarr_risk                             = Activar el vínculo con los riesgos
+LinkDigiriskdolibarr_riskDescription                  = Permite vincular los riesgos con los modelos
+LinkDigiriskdolibarr_riskassessment                   = Activar el vínculo con las evaluaciones
+LinkDigiriskdolibarr_riskassessmentDescription        = Permite vincular las evaluaciones con los modelos
+LinkDigiriskdolibarr_evaluator                        = Activar el vínculo con los evaluadores
+LinkDigiriskdolibarr_evaluatorDescription             = Permite vincular los evaluadores con los modelos
+LinkDigiriskdolibarr_risksign                         = Activar el vínculo con las señalizaciones
+LinkDigiriskdolibarr_risksignDescription              = Permite vincular las señalizaciones con los modelos
+LinkDigiriskdolibarr_preventionplan                   = Activar el vínculo con los planes de prevención
+LinkDigiriskdolibarr_preventionplanDescription        = Permite vincular los planes de prevención con los modelos
+LinkDigiriskdolibarr_firepermit                       = Activar el vínculo con los permisos de fuego
+LinkDigiriskdolibarr_firepermitDescription            = Permite vincular los permisos de fuego con los modelos
+LinkDigiriskdolibarr_accident                         = Activar el vínculo con los accidentes
+LinkDigiriskdolibarr_accidentDescription              = Permite vincular los accidentes con los modelos
+LinkDigiriskdolibarr_accidentinvestigation            = Activar el vínculo con las investigaciones de accidente
+LinkDigiriskdolibarr_accidentinvestigationDescription = Permite vincular las investigaciones con los modelos
+
+#
+# DigiriskDolibarr
+#
+
+# Permiso
+LireDigirisk                 = Consultar el panel de control de Digirisk
+ReadDigirisk                 = Consultar el panel de control de Digirisk (lectura)
+YouDontHaveTheRightToSeeThis = No tiene permiso para ver las agrupaciones y unidades de trabajo
+CanNotDoThis                 = No tiene permiso para hacer esto
+EnableDigiriskdolibarr       = Active el módulo DigiriskDolibarr para acceder a esta página
+
+# Datos
+DigiriskMenu          = Añada información sobre su empresa/organización. Haga clic en el botón "Guardar" al final de la página para conservarla
+DigiriskConfigSociety = Configuración de la empresa
+PermissionDenied      = Permiso denegado
+AddUser               = Crear un usuario
+StartDate             = Fecha de inicio
+EndDate               = Fecha de fin
+NoPhoneNumber         = Sin número de teléfono
+HasBeenCreatedF       = ha sido creada
+HasBeenCreatedM       = ha sido creado
+HasNotBeenCreatedF    = no ha sido creada
+HasNotBeenCreatedM    = no ha sido creado
+YourDocuments         = Documentos
+NoData                = N/D
+HasBeenEditedF        = ha sido editada
+HasBeenEditedM        = ha sido editado
+HasNotBeenEditedF     = no ha sido editada
+HasNotBeenEditedM     = no ha sido editado
+
+HasBeenDeletedF    = ha sido eliminada
+HasBeenDeletedM    = ha sido eliminado
+HasNotBeenDeletedF = no ha sido eliminada
+HasNotBeenDeletedM = no ha sido eliminado
+
+DigiriskUserGroup                 = Digirisk - Usuarios
+DigiriskUserGroupDescription      = El grupo de usuarios de DigiRisk tiene permiso para consultar y modificar los objetos relativos a DigiRisk
+DigiriskAdminUserGroup            = DigiRisk - Administradores
+DigiriskAdminUserGroupDescription = El grupo de administradores tiene todos los permisos sobre DigiRisk y los módulos necesarios
+DigiriskReaderGroup               = DigiRisk - Lectores
+DigiriskReaderGroupDescription    = El grupo de lectores tiene todos los permisos de solo lectura sobre DigiRisk y los módulos necesarios
+
+ContractType              = Tipo de contrato
+Apprentice/Student        = Aprendiz/Estudiante
+Interim                   = Trabajador temporal
+ProfessionalQualification = Cualificación profesional
+DigiriskDocumentation     = Documentación de Digirisk
+
+SelectUser               = Seleccionar un usuario
+LabourInspectorFirstName = Inspector de
+LabourInspectorLastName  = trabajo
+LabourInspector          = Inspector de trabajo
+LabourInspectorSociety   = Tercero Inspector de trabajo
+LabourInspectorAssigned  = Inspector de trabajo
+
+SocieteSchedules = Horario de la empresa
+weekDayDefault   = Ver sitio web
+weekEndDefault   = Cerrado Cerrado
+
+#
+# DigriskDocuments - Documentos Digirisk
+#
+
+# Datos
+DigiriskDocuments              = Documento Digirisk
+Responsible                    = Responsable
+ContactsAction                 = Contactos de la acción
+PERCOTooltip                   = Si su empresa dispone de un plan de ahorro para la jubilación colectivo (PERCO), marque esta casilla
+PEETooltip                     = Si su empresa dispone de un plan de ahorro de empresa (PEE), marque esta casilla
+ShowPictoName                  = Mostrar el nombre del pictograma de peligro
+ShowPictoNameDescription       = Mostrar el nombre del pictograma de peligro del riesgo en los documentos <br> Útil si desea trasladar la tabla a una hoja de cálculo
+RiskAssessmentColor            = Color de las evaluaciones
+RiskAssessmentColorDescription = Muestra el color de las evaluaciones en el documento Papripact-A3-Horizontal
+
+#
+# LegalDisplay - Información legal obligatoria
+#
+
+# Permiso
+LegalDisplaysMin = Información legal obligatoria
+
+# Datos
+LegalDisplay             = Información legal obligatoria
+Legaldisplay             = Información legal obligatoria
+HowToSetDataLegalDisplay = Para configurar los datos de la información legal obligatoria, vaya a Inicio - Configuración - Empresa/Organización - Seguridad
+
+LegalDisplayDocumentGenerated       = Generación de la información legal obligatoria
+LabourDoctor                        = Médico del trabajo
+LabourInspector                     = Inspector de trabajo
+FireBrigade                         = Bomberos
+AllEmergencies                      = Cualquier emergencia
+RightsDefender                      = Defensor de los Derechos
+PoisonControlCenter                 = Centro de Toxicología
+Police                              = Policía de emergencias
+SafetyInstructions                  = Instrucciones de seguridad
+ResponsibleToNotify                 = Responsable al que avisar
+PreventionOfficers                  = Responsables de prevención
+PreventionOfficer                   = Responsable de prevención
+LocationOfDetailedInstructions      = Ubicación de la instrucción detallada
+LocationOfDetailedInstructionsValue = Sin instrucción detallada en este centro
+FirstAid                            = Primeros auxilios
+FirstAidValue                       = <h2>Lista de los socorristas laborales presentes en el centro (Nombre, Empresa, Teléfono)</h2><br><br>Cada equipo debe estar constituido de forma que se puedan prestar los primeros auxilios a cualquier miembro del equipo en cualquier circunstancia.<br />Los socorristas laborales deben estar claramente identificados y ser conocidos por todos.<h2>Cómo actuar en caso de accidente</h2><br><br><h3>Accidente leve</h3><br><ul><li> - Atención prestada por los socorristas laborales</li><br><li> - Disponibilidad de un botiquín</li></ul><br><br>Cada máquina está equipada con al menos un botiquín que permite atender heridas leves.<br><br><h3>Accidente grave</h3><br><ul><li> - Avisar al socorrista laboral presente en el centro</li><br><li> - Activar el procedimiento de emergencia</li><br><li> - Informar al responsable de la empresa usuaria, guardia de explotación 24 h</li><br><li> - Contactar en caso de accidente</li></ul><br><br>La empresa usuaria recuerda en anexo los números de emergencia. <br />
+AddPhoneNumber                      = Añadir un número de teléfono al usuario
+ConfigureLabourInspector            = Configurar un inspector de trabajo
+SocietyAdditionalDetails            = Información complementaria de la empresa
+GeneralMeansAtDisposal              = Medios generales puestos a disposición
+GeneralMeansAtDisposalValue         = <h2>Medios de socorro puestos a disposición</h2><br><ul><li> - Enfermería</li><br><li> - Nuestro personal socorrista está identificado en sus cascos y su equipo de trabajo con el distintivo de socorrista</li><br><li> - Botiquines para accidentes leves disponibles en cada centro</li></ul><br><br><h2>Instrucciones en caso de accidente leve</h2><br><ul><li> - Contactar con el socorrista más cercano</li><br><li> - Atención con el botiquín puesto a disposición</li><br><li> - Declaración en el centro:</li></ul><br><br><h2>Instrucciones en caso de accidente</h2><br><ul><li> - Llamada a bomberos: 18</li><br><li> - Emergencias sanitarias: 15</li><br><li> - Policía y Gendarmería: 17</li><br><li> - N&deg; de emergencia europeo: 112</li></ul><br><br><h2>Instrucciones en caso de incendio</h2><br>En caso de incendio, proceda en este orden:<br><ol><li> - Active la señal de alarma.</li><br><li> - Ataque el fuego (si no es demasiado importante) con un extintor.</li><br><li> - Si el fuego no se ha apagado tras el uso de un solo extintor, o si el fuego ya es demasiado importante, avise a los bomberos.</li><br><li> - Cierre las puertas y las ventanas antes de abandonar el local.</li><br><li> - Solicite la ayuda de los equipos formados.</li><br></ol>
+GeneralInstructions                 = Instrucciones generales
+GeneralInstructionsValue            = <h2>Todas las instalaciones</h2><br><br><p>Está terminantemente prohibido fumar, hacer fuego o utilizar una llama desnuda en y sobre las instalaciones.<br />Si la intervención requiere el uso de una llama viva (trabajos de soldadura, etc.), es imprescindible emitir un permiso de fuego (ver ejemplo en el anexo 9.5).<br />De manera general, el acceso a las instalaciones está prohibido a las personas no autorizadas.<br />Cada interviniente debe llevar consigo sus habilitaciones y certificados de formación. Debe poder mostrarlos en el centro a petición de la empresa usuaria.</p><br><br><h2>Habilitaciones</h2><br>Toda persona interviniente debe disponer de una copia de las siguientes habilitaciones:<br><ul><li> - Habilitación eléctrica en función de los trabajos a realizar</li><br><li> - Certificado de formación o habilitación para trabajos en altura y rescate en altura</li></ul><br>Y poder presentarla a simple petición de la empresa usuaria, del encargado de la intervención o de los trabajos, o de cualquier inspector jurado<br><br><h2>Protecciones individuales</h2><br>Toda persona interviniente debe poder disponer de los siguientes equipos de protección individual según los tipos de trabajo efectuados y las medidas de protección definidas en el análisis de riesgos.<br><br><h3>Trabajos diversos</h3><br><ul><li> - Casco diseñado para trabajos en altura (EN397) con barboquejo y/o que cumpla con el aislamiento eléctrico (entorno eléctrico)</li><br><li> - Calzado de seguridad</li><br><li> - Protecciones auditivas, en caso necesario</li><br><li> - Otros (a precisar): en función de los trabajos realizados y de los riesgos asociados.</li></ul><br><br><h3>Trabajos eléctricos</h3><br><ul><li> - Alfombra o banqueta aislante</li><br><li> - Guantes adaptados al nivel de tensión</li><br><li> - Cascos para trabajos eléctricos con pantalla facial (EN166)</li><br><li> - EPI reglamentarios para intervención en alta tensión (UTE C 18-510)</li></ul><br><br><h3>Otros</h3><br>Nota: las empresas externas deben proporcionar a sus intervinientes los EPI indicados anteriormente. En los centros de transformación hay disponibles una banqueta y una pértiga.<br><br><h3>Trabajos en altura</h3><br><ul><li> - EPI reglamentarios (arnés, casco, 2 cuerdas con absorbedor o cuerda doble en Y, mosquetones, anticaídas, etc.) con las verificaciones al día</li><br><li> - Sistema de evacuación automática:</li><br><li> - Cantidad: 1 kit de evacuación (previsto para 2 personas)</li><li>Ubicación: en la cesta elevadora</li><br><li> - Recuerde llevar un kit de evacuación adicional si hay más de dos personas en la cesta</li><br><li> - Otro (a precisar): anticaídas utilizado: HACA con referencia 0529 7103 (enganche esternal en el arnés)</li></ul><br><br>Los anticaídas deben ser compatibles con el sistema de aseguramiento rígido que equipa las máquinas. Los anticaídas deben cumplir con la última norma y haber superado con éxito los ensayos complementarios (pruebas adicionales CNB/P/11.073 de 13/10/2010) exigidos por el Dictamen del Ministerio de Trabajo de 28 de septiembre de 2010 para garantizar la conformidad con los requisitos de la directiva 89/686/CEE.
+RulesOfProcedure                    = Reglamento interno
+RulesOfProcedureValue               = Disponible en el tablón de anuncios obligatorio de la sala de descanso
+CollectiveAgreement                 = Convenios colectivos
+CollectiveAgreementValue            = Disponible en el sitio web del gobierno:<br /><a href="https://www.service-public.fr/particuliers/vosdroits/F78" target="_blank">https://www.service-public.fr/particuliers/vosdroits/F78</a>
+legaldisplay.odt                    = Información legal obligatoria
+legaldisplay_custom.odt             = Información legal obligatoria personalizada
+
+#
+# InformationsSharing - Difusión de información
+#
+
+# Permiso
+InformationsSharingsMin = Difusiones de información
+
+# Datos
+InformationsSharing                  = Difusión de información
+Informationssharing                  = Difusión de información
+InformationsSharingDocumentGenerated = Generación de la difusión de información
+HowToSetDataInformationsSharing      = Para configurar los datos de la difusión de información, vaya a Inicio - Configuración - Empresa/Organización - Social
+ConfigureSecurityAndSocialData       = Configurar los datos de la empresa
+LastMainDoc                          = Último documento generado
+
+ParticipationAgreement      = Acuerdos de participación en beneficios
+ParticipationAgreementValue = Sí, todos los empleados con un contrato de trabajo indefinido o temporal en vigor con la empresa, sea cual sea su naturaleza, podrán beneficiarse de la participación en beneficios.<br />No obstante, se exige una condición de antigüedad: 6 meses en la empresa.<br />Para determinar la antigüedad exigida, se tienen en cuenta todos los contratos de trabajo ejecutados durante el periodo de cálculo y durante los 12 meses anteriores.<br />La antigüedad se aprecia en la fecha de cierre del ejercicio correspondiente o en la fecha de salida en caso de extinción del contrato durante el ejercicio.
+TermsAndConditions          = Modalidades
+
+ESC                  = Comité Social y Económico
+StaffRepresentatives = Delegados de personal
+ElectionDate         = Fecha de elección
+ElectionDateCSE      = Fecha de elección del Comité Social y Económico
+ElectionDateDP       = Fecha de elección de los delegados de personal
+
+Titulars                       = Titulares
+Alternates                     = Suplentes
+informationssharing.odt        = Difusión de información
+informationssharing_custom.odt = Difusión de información personalizada
+ActionOnUser                   = Usuario afectado
+HarassmentOfficer              = Responsable de acoso
+HarassmentOfficerCSE           = Responsable de acoso del Comité Social y Económico
+ExceptionsToWorkingHours       = Excepciones a la jornada laboral
+PermanentDerogation            = Excepción permanente
+PermanentDerogationValue       = No
+OccasionalDerogation           = Excepción ocasional
+OccasionalDerogationValue      = Sí
+
+
+#
+# PreventionPlan - Plan de prevención
+#
+
+# Permiso
+PreventionPlansMin = planes de prevención
+
+# Datos
+
+PreventionPlan                                        = Plan de prevención
+Preventionplan                                        = Plan de prevención
+ThePreventionplan                                     = el plan de prevención
+PreventionPlanDocument                                = Plan de prevención
+Preventionplandocument                                = Plan de prevención
+PreventionPlanDocumentGenerated                       = Generación del plan de prevención
+PreventionPlanList                                    = Lista de los planes de prevención
+PreventionPlanLine                                    = riesgo(s)
+PreventionPlanLineCreated                             = Creación de riesgo en el plan de prevención
+PreventionPlanLineModified                            = Modificación de riesgo en el plan de prevención
+PreventionPlanLineDeleted                             = Eliminación de riesgo en el plan de prevención
+NewPreventionPlan                                     = Nuevo plan de prevención
+PriorVisit                                            = Inspección conjunta previa
+PriorVisitYesNo                                       = Visita preliminar realizada
+PriorVisitText                                        = Nota de la inspección
+CSSCTIntervention                                     = Intervención del CSSCT
+CSSCTInterventionText                                 = ¿Intervención del CSSCT?
+MasterWorker                                          = Responsable de la empresa usuaria
+MasterWorker                                          = Responsable de la empresa usuaria
+ExtSociety                                            = Empresa externa
+ExtSocietyResponsible                                 = Responsable de la empresa externa
+ExtSocietyResponsible                                 = Responsable de la empresa externa
+ExtSocietyAttendant                                   = Interviniente de la empresa externa
+ActionsDescription                                    = Descripción de las acciones
+INRSRisk                                              = Riesgo (INRS)
+PreventionMethod                                      = Medios de prevención
+PreventionplanSchedules                               = Horario del plan de prevención
+Attendants                                            = Participantes
+ModifyPreventionPlan                                  = Modificar el plan de prevención
+ActionsDescriptionTooltip                             = Descripción de las acciones realizadas por el interviniente
+INRSRiskTooltip                                       = Lista de las categorías de riesgo propuestas en el referencial del INRS
+PreventionMethodTooltip                               = Medio de prevención a implantar para limitar el riesgo
+LockPreventionPlan                                    = Bloquear el plan de prevención
+ConfirmLockPreventionPlan                             = ¿Está seguro de que desea bloquear el plan de prevención?<br>Este bloqueo permite congelar los datos y la generación del documento.
+AllSignatoriesMustHaveSigned                          = Todos los participantes deben haber firmado para bloquear el objeto
+ValidatePreventionPlan                                = Validar el plan de prevención
+ConfirmValidatePreventionPlan                         = ¿Está seguro de que desea validar el plan de prevención? <br> La validación permite a los participantes firmar el documento pero <b> impide añadir nuevos participantes o modificar el plan de prevención </b>.
+ReOpenPreventionPlan                                  = Reabrir el plan de prevención
+ConfirmReOpenPreventionPlan                           = ¿Está seguro de que desea reabrir el plan de prevención? La reapertura permite modificar el plan de prevención y añadir nuevos participantes pero <b>se perderán todas las firmas del documento</b>.
+PreventionPlanRiskList                                = Lista de los riesgos del plan de prevención
+ActionsPreventionPlanRisk                             = Acciones
+PreventionPlanDescription                             = Proyecto de los planes de prevención
+PriorVisitDate                                        = Fecha de la inspección conjunta previa
+AddPreventionPlanLine                                 = Adición del riesgo
+UpdatePreventionPlanLine                              = Actualización del riesgo
+DeletePreventionPlanLine                              = Eliminación del riesgo
+PreventionPlanDet                                     = Riesgo del plan de prevención
+Preventionplandet                                     = Riesgo del plan de prevención
+PreventionPlanMessage                                 = al plan de prevención
+PreventionPlanMustBeValidated                         = El plan de prevención debe estar validado para poder reabrirlo
+PreventionPlanMustBeInProgress                        = El plan de prevención debe estar en curso para acceder a esta funcionalidad
+PreventionPlanMustBeInProgressToValidate              = El plan de prevención ya está validado
+CSEMustBeAlerted3DaysBeforeVisit                      = El CSE debe ser avisado 3 días antes de la inspección conjunta previa (art. R. 4514-1 1°, R. 4514-3 y R. 4514-9 del Código de Trabajo francés)
+PreventionPlanData                                    = Datos del plan de prevención
+MasterWorkerDescription                               = El usuario utilizado por defecto como responsable de la empresa usuaria
+NoPreventionPlanRisk                                  = Ningún riesgo en el plan de prevención
+NoPreventionPlanLinked                                = Ningún plan de prevención vinculado
+PreventionPlanLinked                                  = Plan de prevención vinculado
+PreventionPlanManagement                              = Gestión de los planes de prevención
+PPRProject                                            = Proyecto vinculado a los planes de prevención
+NewLabelForClonePreventionPlan                        = Etiqueta del nuevo plan de prevención
+ClonePreventionPlanRisk                               = Clonar los riesgos del plan de prevención
+CloneAttendantsPreventionPlan                         = Clonar los participantes del plan de prevención
+CloneSchedulePreventionPlan                           = Clonar los horarios del plan de prevención
+ConfirmClonePreventionPlan                            = ¿Está seguro de que desea clonar el plan de prevención <b> %s </b>?
+preventionplandocument.odt                            = Plan de prevención
+preventionplandocument_custom.odt                     = Plan de prevención personalizado
+ErrorThirdPartyHasAtLeastOneChildOfTypePreventionPlan = El tercero está vinculado al menos a un hijo de tipo plan de prevención:
+ErrorContactHasAtLeastOneChildOfTypePreventionPlan    = El contacto está vinculado al menos a un hijo de tipo plan de prevención:
+ConfirmDeletePreventionPlan                           = ¿Está seguro de que desea eliminar este plan de prevención?
+PreventionPlanRole                                    = Los roles del plan de prevención
+
+# Email
+PreventionPlanLabel   = Resumen del plan de prevención
+PreventionPlanSubject = Correo del plan de prevención
+PreventionPlanContent = Adjunto encontrará el documento ODT del plan de prevención.
+
+# Disparadores
+PreventionPlanCreated          = Creación de plan de prevención
+PreventionPlanModified         = Modificación de plan de prevención
+PreventionPlanDeleted          = Eliminación de plan de prevención
+PreventionPlanInProgress       = Reapertura del plan de prevención
+PreventionPlanPendingSignature = Puesta a la espera de firma del plan de prevención
+PreventionPlanLocked           = Bloqueo del plan de prevención
+PreventionPlanArchived         = Archivado del plan de prevención
+PreventionPlanSentByMail       = Envío por correo del plan de prevención
+
+#
+# FirePermit - Permiso de fuego
+#
+
+# Permiso
+FirePermitMin  = permiso de fuego
+FirePermitsMin = permisos de fuego
+
+# Datos
+NewFirePermit                                     = Nuevo permiso de fuego
+ModifyFirePermit                                  = Modificar el permiso de fuego
+FirePermitList                                    = Lista de los permisos de fuego
+FirePermit                                        = Permiso de fuego
+Firepermit                                        = Permiso de fuego
+TheFirepermit                                     = el permiso de fuego
+FirePermitDocument                                = Permiso de fuego
+Firepermitdocument                                = Permiso de fuego
+FirePermitDocumentGenerated                       = Generación del permiso de fuego
+FirePermitCreated                                 = Creación de permiso de fuego
+FirePermitModified                                = Modificación de permiso de fuego
+FirePermitDeleted                                 = Eliminación de permiso de fuego
+FirePermitInProgress                              = Reapertura del permiso de fuego
+FirePermitPendingSignature                        = Puesta a la espera de firma del permiso de fuego
+FirePermitLocked                                  = Bloqueo del permiso de fuego
+FirePermitArchived                                = Archivado del permiso de fuego
+FirePermitSignatureAddAttendant                   = Adición de participante al permiso de fuego
+FirePermitSentByMail                              = Envío por correo del permiso de fuego
+FirePermitLine                                    = riesgo(s)
+FirePermitDet                                     = Riesgo del permiso de fuego
+Firepermitdet                                     = Riesgo del permiso de fuego
+FirePermitLineCreated                             = Creación de riesgo en el permiso de fuego
+FirePermitLineModified                            = Modificación de riesgo en el permiso de fuego
+FirePermitLineDeleted                             = Eliminación de riesgo en el permiso de fuego
+FirePermitRiskList                                = Lista de los riesgos del permiso de fuego
+AddFirePermitLine                                 = Adición del riesgo
+UpdateFirePermitLine                              = Actualización del riesgo
+DeleteFirePermitLine                              = Eliminación del riesgo
+FirePermitMessage                                 = al permiso de fuego
+UsedMaterialTooltip                               = Material a utilizar para limitar el riesgo
+ActionsFirePermitRisk                             = Acciones
+ConfirmValidateFirePermit                         = ¿Está seguro de que desea validar el permiso de fuego? <br> La validación permite a los participantes firmar el documento pero <b> impide añadir nuevos participantes o modificar el permiso de fuego </b>.
+ConfirmReOpenFirePermit                           = ¿Está seguro de que desea reabrir el permiso de fuego? La reapertura permite modificar el permiso de fuego y añadir nuevos participantes pero <b>se perderán todas las firmas del documento</b>.
+ConfirmLockFirePermit                             = ¿Está seguro de que desea bloquear el permiso de fuego?<br>Este bloqueo permite congelar los datos y la generación del documento.
+FirePermitMustBeInProgress                        = El permiso de fuego debe estar en curso para acceder a esta funcionalidad
+NewLabelForCloneFirePermit                        = Etiqueta del nuevo permiso de fuego
+CloneFirePermitRisk                               = Clonar los riesgos del permiso de fuego
+CloneAttendantsFirePermit                         = Clonar los participantes del permiso de fuego
+CloneScheduleFirePermit                           = Clonar los horarios del permiso de fuego
+ConfirmCloneFirePermit                            = ¿Está seguro de que desea clonar el permiso de fuego <b> %s </b>?
+FirePermitDescription                             = Proyecto de los permisos de fuego
+FirePermitData                                    = Datos del permiso de fuego
+FirePermitManagement                              = Gestión de los permisos de fuego
+FPRProject                                        = Proyecto vinculado a los permisos de fuego
+firepermitdocument.odt                            = Permiso de fuego
+firepermitdocument_custom.odt                     = Permiso de fuego personalizado
+UsedEquipment                                     = Material utilizado
+ErrorThirdPartyHasAtLeastOneChildOfTypeFirePermit = El tercero está vinculado al menos a un hijo de tipo permiso de fuego:
+ErrorContactHasAtLeastOneChildOfTypeFirePermit    = El contacto está vinculado al menos a un hijo de tipo permiso de fuego:
+ConfirmDeleteFirePermit                           = ¿Está seguro de que desea eliminar este permiso de fuego?
+FirePermitRole                                    = Los roles del permiso de fuego
+FirepermitSchedules                               = Horario del permiso de fuego
+
+# Email
+FirePermitLabel   = Resumen del permiso de fuego
+FirePermitSubject = Correo del permiso de fuego
+FirePermitContent = Adjunto encontrará el documento ODT del permiso de fuego.
+
+
+#
+# Accident - Accidente
+#
+
+# Permiso
+AccidentsMin = accidentes
+
+# Disparador
+AccidentCreateTrigger         = Accidente %s creado
+ActionsOnAccident             = Eventos vinculados al accidente
+AccidentGeneratedWithDolibarr = Accidente generado con Dolibarr
+AccidentWorkStopCreateTrigger = Baja laboral %s añadida al accidente
+AccidentWorkStopModifyTrigger = Baja laboral %s modificada en el accidente
+AccidentWorkStopDeleteTrigger = Baja laboral %s eliminada del accidente
+AccidentModifyTrigger         = Accidente %s modificado
+AccidentDeleteTrigger         = Accidente %s eliminado
+AccidentMetaDataCreateTrigger = Registro de los datos complementarios del accidente
+AccidentLesionCreateTrigger   = Lesión %s añadida al accidente
+AccidentLesionModifyTrigger   = Lesión %s modificada en el accidente
+AccidentLesionDeleteTrigger   = Lesión %s eliminada del accidente
+ACC_USER_EMPLOYERSigned       = Firma del responsable de la empresa
+VictimAndCaregivers           = Víctima y persona que presta los cuidados
+Victim                        = Víctima
+Caregiver                     = Persona que presta los cuidados
+
+# Modelo de numeración
+DigiriskAccidentNumberingModule         = Modelo de numeración de los accidentes de Digirisk
+DigiriskAccidentStandardModel           = Devuelve el número con el formato ACCn, donde n es un contador secuencial sin interrupción y sin puesta a 0.
+DigiriskAccidentWorkStopNumberingModule = Modelo de numeración de las bajas laborales vinculadas al accidente
+DigiriskAccidentWorkStopStandardModel   = Devuelve el número con el formato ACCWn, donde n es un contador secuencial sin interrupción y sin puesta a 0.
+DigiriskAccidentLesionNumberingModule   = Modelo de numeración de las lesiones vinculadas al accidente
+DigiriskAccidentLesionStandardModel     = Devuelve el número con el formato ACCLn, donde n es un contador secuencial sin interrupción y sin puesta a 0.
+DigiriskAccidentDocumentNumberingModule = Modelo de numeración de las fichas de accidente de Digirisk
+DigiriskAccidentDocumentStandardModel   = Devuelve el número con el formato ACCDn, donde n es un contador secuencial sin interrupción y sin puesta a 0.
+
+# Plantilla ODT
+DigiriskTemplateDocumentAccident       = Modelos de documento de los accidentes de Digirisk
+AccidentDocumentCustomDigiriskTemplate = ODT personalizado de los accidentes
+AccidentDocumentDigiriskTemplate       = ODT por defecto de los accidentes
+AccidentDocument                       = Ficha de accidente
+AccidentDocumentGeneratedWithDolibarr  = Accidente generado con Dolibarr
+
+# Datos
+NewAccident                              = Nuevo accidente
+ModifyAccident                           = Modificar el accidente
+AccidentList                             = Lista de los accidentes
+Accident                                 = Accidente
+AccidentCreated                          = Creación de un accidente
+DeleteAccident                           = ¿Eliminar el accidente?
+AccidentModified                         = Modificación de un accidente
+AccidentDeleted                          = Eliminación de un accidente
+AccidentLine                             = riesgo(s)
+AccidentDate                             = Fecha del accidente
+AccidentSchedule                         = Horario del accidente
+AccidentRiskList                         = Lista de información complementaria sobre el accidente
+Accidentworkstop                         = Baja laboral
+AccidentWorkStopCreated                  = Creación de una baja laboral
+AccidentWorkStopModified                 = Modificación de una baja laboral
+AccidentWorkStopDeleted                  = Eliminación de una baja laboral
+AddAccidentWorkStop                      = Adición de una baja laboral al accidente
+UpdateAccidentWorkStop                   = Actualización de una baja laboral del accidente
+DeleteAccidentWorkStop                   = Eliminación de una baja laboral del accidente
+Accidentlesion                           = Lesión
+AccidentLesionCreated                    = Creación de una lesión
+AccidentLesionModified                   = Modificación de una lesión
+AccidentLesionDeleted                    = Eliminación de una lesión
+AddAccidentLesion                        = Adición de una lesión al accidente
+UpdateAccidentLesion                     = Actualización de una lesión del accidente
+DeleteAccidentLesion                     = Eliminación de una lesión del accidente
+AccidentDescription                      = Proyecto de los accidentes
+AccidentManagement                       = Gestión de los accidentes
+AccidentWorkstopManagement               = Gestión de las bajas laborales
+AccidentLesionManagement                 = Gestión de las lesiones
+AccidentInvestigationManagement          = Gestión de las investigaciones de accidente
+ACCProject                               = Proyecto vinculado a los accidentes
+UserVictim                               = Víctima del accidente
+AccidentType                             = Tipo de accidente
+WorkAccidentStatement                    = Accidente de trabajo
+CommutingAccident                        = Accidente in itinere
+AccidentMetaData                         = Datos complementarios
+RelativeLocation                         = Precisiones complementarias sobre el lugar del accidente
+VictimActivity                           = Actividad de la víctima en el momento del accidente
+AccidentNature                           = Naturaleza del accidente
+AccidentObject                           = Objeto cuyo contacto ha herido a la víctima
+AccidentNatureDoubt                      = Posibles reservas motivadas (adjunte, si es necesario, una carta de acompañamiento)
+AccidentNatureDoubtLink                  = Enlace a la carta de acompañamiento
+VictimTransportedTo                      = La víctima ha sido trasladada a
+VictimWorkHours                          = Horario de trabajo de la víctima el día del accidente
+WorkHoursMorningDateStart                = Inicio del horario de trabajo de la víctima (mañana)
+WorkHoursMorningDateEnd                  = Fin del horario de trabajo de la víctima (mañana)
+WorkHoursAfternoonDateStart              = Inicio del horario de trabajo de la víctima (tarde)
+WorkHoursAfternoonDateEnd                = Fin del horario de trabajo de la víctima (tarde)
+AccidentNoticed                          = Información del accidente
+Found                                    = Constatado
+Known                                    = Conocido
+AccidentNoticeDate                       = Fecha en que se tuvo conocimiento del accidente
+AccidentNoticeBy                         = Persona que ha informado del accidente
+ByEmployer                               = Por el empresario
+ByEmployees                              = Por sus empleados
+AccidentDescribedByVictim                = El accidente ha sido descrito por la víctima
+RegisteredInAccidentRegister             = El accidente está inscrito en el registro de accidentes de trabajo leves
+RegisterDate                             = Fecha de inscripción en el registro de accidentes de trabajo leves
+RegisterNumber                           = Número de inscripción en el registro de accidentes de trabajo leves
+Consequence                              = Consecuencias
+WithoutWorkStop                          = Sin baja laboral
+LessThanFourDays                         = Menos de 4 días
+LessThanTwentyOneDays                    = Menos de 21 días
+LessThanThreeMonth                       = Menos de 3 meses
+LessThanSixMonths                        = Menos de 6 meses
+LongTimeWorkStop                         = Más de 6 meses
+WithWorkStop                             = Con baja laboral
+Fatal                                    = Fallecimiento
+PoliceReport                             = Atestado policial
+PoliceReportBy                           = Persona que ha redactado el atestado policial
+FirstPersonNoticedIsWitness              = Persona avisada
+Witness                                  = Testigo
+FirstPersonNoticed                       = Primera persona avisada
+ThirdPartyResponsability                 = ¿El accidente ha sido causado por un tercero?
+FkSocResponsible                         = Empresa del tercero responsable
+FkSocResponsibleInsuranceSociety         = Compañía de seguros del tercero
+LesionLocalization                       = Localización de las lesiones
+LesionNature                             = Naturaleza de las lesiones
+AccidentInvestigation                    = Investigación de accidente
+Accidentinvestigation                    = Investigación de accidente
+AccidentInvestigationLink                = Enlace a la investigación de accidente
+AccidentLocation                         = Lugar del accidente
+DigiriskDolibarrActionTrigger            = Disparador de los eventos Digirisk
+CollateralVictim                         = Víctima colateral
+FromDigirisk                             = De
+At                                       = A
+AndFrom                                  = Y de
+ExternalAccident                         = ¿El accidente ha tenido lugar en un centro distinto al de adscripción de la víctima?
+AccidentAttendants                       = Accidente - Participantes
+UserEmployer                             = Responsable de la empresa
+SignatureUserEmployer                    = Firma del responsable de la empresa
+CerfaLink                                = Enlace al formulario Cerfa
+WorkStopDays                             = Número de días de baja laboral
+AccidentLesionList                       = Lista de las lesiones vinculadas al accidente
+DocumentsMetaData                        = Archivos adjuntos complementarios
+WorkStopDocument                         = Declaración de baja laboral
+AccidentMetaDataSave                     = Los datos complementarios del accidente se han registrado correctamente
+ErrorFieldNotEmpty                       = Error: el campo <b>'%s'</b> no puede estar vacío
+ErrorFieldMustBeGreaterOrEqualZero       = Error: el campo <b>'%s'</b> debe ser mayor o igual que 0
+ConfirmDeleteAccidentWorkStop            = ¿Está seguro de que desea eliminar la baja laboral <b>%s</b> del accidente?
+AccidentMetaDataLesion                   = Datos complementarios de las lesiones
+TotalWorkStopDays                        = Número total de días de baja laboral
+RegisterAccident                         = Accidente leve
+AccidentsLinked                          = Accidente(s) vinculado(s)
+GaugeCounter                             = Este campo se utiliza en el contador del indicador
+DateStartWorkStop                        = Fecha de inicio de la baja laboral
+DateEndWorkStop                          = Fecha de fin de la baja laboral
+ReturnWorkDate                           = Fecha de reincorporación
+DayWithoutAccident                       = Días sin accidente(s)
+AccidentRepartition                      = Distribución de los accidentes por tipo
+AccidentByYear                           = Distribución de los accidentes por año
+NbAccidentsByEmployees                   = Número de accidentes por trabajador
+AccidentRegister                         = Accidente por registro
+AccidentWithoutRegister                  = Accidentes sin registro
+AccidentWithRegister                     = Accidentes con registro
+WorkStopDurationDistribution             = Distribución del tiempo por baja laboral
+WorkStopDurationDistributionDigiriskElem = Distribución del tiempo de baja laboral por GP/UT
+WorkStopDuration                         = Duración de la baja laboral
+NoAbsence                                = Ninguna baja
+UpTo4Days                                = Hasta 4 días
+UpTo21Days                               = Hasta 21 días
+UpTo3Months                              = Hasta 3 meses
+UpTo6Months                              = Hasta 6 meses
+MoreThan6Months                          = Más de 6 meses
+FrequencyIndex                           = Índice de frecuencia
+FrequencyRate                            = Tasa de frecuencia
+GravityIndex                             = Índice de gravedad
+GravityRate                              = Tasa de gravedad
+AccidentRateIndicator                    = Tasas e índices de los indicadores de rendimiento de los accidentes
+NbPresquAccidents                        = Número de casi accidentes
+NbAccidentInvestigations                 = Número de investigaciones de accidente
+AccidentInvestigationsMin                = investigaciones de accidente
+NbWorkedHours                            = Número de horas trabajadas
+ConfirmDeleteAccident                    = ¿Está seguro de que desea eliminar el accidente?
+TheAccident                              = el accidente
+AccidentInvestigation                    = Investigación de accidente
+Accident_investigation                   = Investigación de accidente
+AccidentInvestigationDocument            = Documento de investigación de accidente
+Accidentinvestigationdocument            = Documento de investigación de accidente
+accidentinvestigationdocument.odt        = Investigación de accidente
+NewAccidentInvestigation                 = Nueva investigación de accidente
+UpdateAccidentInvestigation              = Modificar una investigación de accidente
+AccidentInvestigationList                = Lista de las investigaciones de accidente
+TheAccidentinvestigation                 = la investigación de accidente
+SeniorityInPosition                      = Antigüedad en el puesto
+VictimSkills                             = Competencias del accidentado
+CollectiveEquipment                      = Equipo de Protección Colectiva (EPC)
+IndividualEquipment                      = Equipo de Protección Individual (EPI)
+Circumstances                            = Circunstancias
+CurativeAction                           = Acciones curativas
+CorrectiveAction                         = Acciones correctivas
+PreventiveAction                         = Acciones preventivas
+DigiriskActionType                       = Tipo de acción Digirisk
+Actions                                  = Acciones
+ActionsTab                               = Acciones
+CurativeActions                          = Acciones curativas
+PreventiveActions                        = Acciones preventivas
+TotalPlannedBudget                       = Presupuesto previsto
+AccidentInvestigationDocumentPDF         = EA-A4-VERTICAL
+PreventionPlanDocumentPDF                = PP-A4-VERTICAL
+PreventionPlanDocumentPDFDescription     = Generar el plan de prevención en PDF
+AccidentInvestigationDocumentPDFDescription = Generar la investigación de accidente en PDF
+AccidentInvestigationDocumentGeneratedAt = Generado el
+CorrectiveActions                        = Acciones correctivas
+AddCurativeAction                        = Añadir una acción curativa
+AddCorrectiveAction                      = Añadir una acción correctiva
+InvestigationNotValidatedYet             = Valide primero la investigación de accidente para poder crear acciones
+ActionLabel                              = Etiqueta de la acción
+ActionDeadline                           = Vencimiento
+ActionAssignedTo                         = Asignada a
+ActionProgress                           = Avance
+MarkAsDone                               = Marcar como terminada
+XActionsOfY                              = %s / %s terminada(s)
+NoActionsYet                             = Ninguna acción por el momento
+ActionAdded                              = La acción ha sido creada
+ActionClosed                             = La acción ha sido cerrada
+ActionsAreProjectTasks                   = Las acciones son subtareas del proyecto Dolibarr
+SeeProjectTasksView                      = Ver la tarea padre
+OpenTask                                 = Abrir la tarea
+AccidentInvestigationValidated           = La investigación de accidente ha sido validada
+AccidentInvestigationReOpened            = La investigación de accidente ha sido reabierta
+AccidentInvestigationTaskCreated         = Las tareas de la investigación de accidente han sido creadas
+AccidentInvestigationTaskDeleted         = Las tareas de la investigación de accidente han sido eliminadas
+CausalityTree                            = Árbol de causas
+TaskWillBeCreatedAfterValidation         = Las tareas se crearán tras la validación de la investigación de accidente
+AccidentInvestigationCreated             = Creación de una investigación de accidente
+AccidentInvestigationModified            = Modificación de una investigación de accidente
+AccidentInvestigationDeleted             = Eliminación de una investigación de accidente
+AccidentInvestigationValidate            = Validación de una investigación de accidente
+AccidentInvestigationUnValidate          = Reapertura de una investigación de accidente
+AccidentInvestigationLock                = Bloqueo de la investigación de accidente
+AccidentInvestigationSigned              = Firma de una investigación de accidente
+CloneWorkStop                            = ¿Clonar las bajas laborales?
+CloneMetadata                            = ¿Clonar los datos complementarios?
+CloneLesion                              = ¿Clonar los datos complementarios de las lesiones?
+CloneFrom                                = Clon de
+AccidentInvestigationRole                = Los roles de la investigación de accidente
+LesionsOrWorkStop                        = lesiones o bajas laborales
+AccidentsCategoriesArea                  = Espacio de las etiquetas/categorías de los accidentes
+AddAccidentIntoCategory                  = Asignar esta categoría al accidente
+PreventionplansCategoriesArea            = Espacio de las etiquetas/categorías de los planes de prevención
+AddPreventionplanIntoCategory            = Asignar esta categoría al plan de prevención
+FirepermitsCategoriesArea                = Espacio de las etiquetas/categorías de los permisos de fuego
+AddFirepermitIntoCategory                = Asignar esta categoría al permiso de fuego
+RisksCategoriesArea                      = Espacio de las etiquetas/categorías de los riesgos
+AddRiskIntoCategory                      = Asignar esta categoría al riesgo
+AddTicketIntoCategory                    = Asignar esta categoría al ticket
+StartDateInvestigate                     = Fecha de inicio de la investigación
+EndDateInvestigate                       = Fecha de fin de la investigación
+YearType                                 = Tipo de año
+AllYears                                 = Todos los años
+FiscalYear                               = Año fiscal
+CalendarYear                             = Año natural
+
+# AccidentTooltip - Ayudas de los accidentes
+VictimActivityTooltip              = Precise la actividad o la tarea de la víctima en el momento del accidente, es decir, lo que estaba haciendo la víctima
+AccidentNatureTooltip              = Describa el evento que ha llevado al accidente, cómo se ha producido el accidente (problema eléctrico, fuga de gas, rotura de material, resbalón, caída, esfuerzo físico, agresión...), o cómo se ha herido la víctima (golpe, colisión, aplastamiento, pinchazo, ahogamiento, contacto con una sustancia...)
+AccidentObjectTooltip              = Es decir, con qué se ha herido la víctima: material, residuo, herramienta (destornillador, cúter, taladro...), máquina, vehículo, carretilla de manutención, sustancia química, elemento de construcción (puerta, pared...), suelo...
+AccidentNatureDoubtTooltip         = Indique, en su caso, las reservas motivadas, que solo podrán tenerse en cuenta si se refieren a las circunstancias de tiempo y lugar del accidente o a la existencia de una causa totalmente ajena al trabajo (art. R. 441-11 del Código de la Seguridad Social francés)
+VictimWorkHoursTooltip             = Indique las horas de trabajo realizadas por su empleado/a, o las horas previstas, el día del accidente
+ConsequenceTooltip                 = Si la víctima ha interrumpido su trabajo por prescripción médica, debe OBLIGATORIAMENTE cumplimentar y enviar el formulario «attestation de salaire accident du travail ou maladie professionnelle» - referencia S6202, a la Caja Primaria del Seguro de Enfermedad del lugar de residencia habitual de la víctima. <br> Posteriormente, en caso de nueva baja tras un periodo de cuidados o una reincorporación al trabajo, en un mes distinto, deberá cumplir igualmente este mismo trámite
+FirstPersonNoticedIsWitnessTooltip = Indique el apellido, el nombre y la dirección del testigo. <br> A falta de testigo, indique la primera persona de la empresa que fue avisada del accidente
+ThirdPartyResponsabilityTooltip    = Cuando tenga conocimiento de la implicación de un tercero, sea cual sea su parte de responsabilidad, en un accidente de trabajo o in itinere, esta mención debe indicarse obligatoriamente en este apartado
+FrequencyIndexTooltip              = Número de accidentes por trabajador x 1 000
+FrequencyRateTooltip               = Número de accidentes por horas trabajadas x 1 000 000
+GravityRateTooltip                 = Número de días de baja laboral por horas trabajadas x 1 000
+NbWorkedHoursTooltip               = El número de horas trabajadas se ha introducido manualmente
+DocumentGeneratedWithVersioning    = Documento generado durante el versionado
+
+# Diccionario
+UsualWorkplace                  = Lugar de trabajo habitual
+OccasionalWorkplace             = Lugar de trabajo ocasional
+LocationOfTheMeal               = Lugar de la comida
+OnTheWayBetweenHomeAndWorkplace = Durante el trayecto entre el domicilio y el lugar de trabajo
+OnTheWayBetweenMealAndWorkplace = Durante el trayecto entre el trabajo y el lugar de la comida
+DuringATripForTheEmployer       = Durante un desplazamiento por cuenta del empresario
+
+Trunk             = Tronco
+Hand              = Mano
+LowerLimbs        = Miembros inferiores
+UpperLimbs        = Miembros superiores
+MultipleLocations = Localizaciones múltiples
+Foot              = Pie
+Head              = Cabeza
+Eyes              = Ojos
+InternalSeating   = Localizaciones internas
+Neck              = Cuello
+Back              = Espalda
+WholeBody         = Todo el cuerpo
+NotSpecified      = Sin precisar
+
+PainEffortLumbago           = Dolor por esfuerzo, lumbago
+Contusion                   = Contusión
+Wounds                      = Heridas
+Sprain                      = Esguince
+FracturePitting             = Fractura o fisura
+MultipleInjuries            = Lesiones de naturaleza múltiple
+MuscleOrTendonTear          = Desgarro muscular o tendinoso
+PresenceOfForeignBody       = Presencia de cuerpo extraño
+Burns                       = Quemadura
+UnspecifiedAndMiscellaneous = Sin precisar y varios
+Other                       = Otros
+CutOff                      = Corte
+
+Investigator = Investigador
+Rescuer      = Socorrista
+
+#
+# ListingRisksDocument - Listado de riesgos con documentos
+#
+
+# Permiso
+ListingRisksDocumentMin = listados de riesgos con documentos
+
+# Datos
+ListingRisksDocument            = Listado de riesgos
+Listingrisksdocument            = Listado de riesgos
+ListingRisksHeader              = Riesgos - %s
+ListingRisksDocumentGenerated   = Generación del listado de riesgos con documentos
+listingrisksdocument.odt        = Listado de riesgos con documentos
+listingrisksdocument_custom.odt = Listado de riesgos con documentos personalizado
+
+#
+# ListingRisksPhoto - Listado de riesgos con fotos
+#
+
+# Permiso
+ListingRisksPhotosMin = listados de riesgos con fotos
+
+# Datos
+ListingRisksPhoto            = Listado de riesgos con fotos
+Listingrisksphoto            = Listado de riesgos con fotos
+ListingRisksPhotoGenerated   = Generación del listado de riesgos con fotos
+listingrisksphoto.odt        = Listado de riesgos con fotos
+listingrisksphoto_custom.odt = Listado de riesgos con fotos personalizado
+
+
+#
+# ListingRisksAction - Listado de riesgos con acciones correctivas
+#
+
+# Permiso
+ListingRisksActionsMin = listados de riesgos con acciones correctivas
+
+# Datos
+ListingRisksAction                        = Listado de riesgos con acciones correctivas
+Listingrisksaction                        = Listado de riesgos con acciones correctivas
+ListingRisksActionGenerated               = Generación del listado de riesgos con acciones correctivas
+listingrisksaction.odt                    = Listado de riesgos con acciones correctivas
+listingrisksaction_custom.odt             = Listado de riesgos con acciones correctivas personalizado
+DigiriskListingRisksActionData            = Datos configurables de los listados de riesgos con acciones correctivas
+ShowTaskDoneListingRisksActionDescription = Permite mostrar u ocultar las tareas finalizadas en el listado de riesgos con acciones correctivas
+
+
+#
+# RiskAssessmentDocument - Documento de evaluación de riesgos
+#
+
+# Permiso
+
+RiskAssessmentDocumentsMin = Documentos de evaluación de riesgos
+
+# Datos
+RiskAssessmentDocument                                    = Documento de evaluación de riesgos
+Riskassessmentdocument                                    = Documento de evaluación de riesgos
+RiskAssessmentDocumentGenerated                           = Generación del documento de evaluación de riesgos
+AuditStartDate                                            = Fecha de inicio de la auditoría
+AuditEndDate                                              = Fecha de fin de la auditoría
+Recipient                                                 = Destinatario
+ImportantNote                                             = Observación importante
+SitePlans                                                 = Ubicación de los planos
+SetStartEndDateBeforeSendEmail                            = Defina la fecha de inicio y la fecha de fin de la auditoría en esta página para poder enviar un correo
+NoSitePlans                                               = Ningún plano de la empresa informado
+riskassessmentdocument.odt                                = Documento de evaluación de riesgos
+riskassessmentdocument_custom.odt                         = Documento de evaluación de riesgos personalizado
+DigiriskRiskAssessmentDocumentData                        = Datos configurables del documento de evaluación de riesgos
+ActionPreventionCompletedTaskDone                         = Las acciones finalizadas no se muestran
+AppliedOn                                                 = Activo en:
+RiskAssessmentDocumentMethod                              = * Etapa 1: Recopilación de la información<br />- Visita de las instalaciones<br />- Recopilación de los datos del personal<br /><br />* Etapa 2: Definición de la metodología y del documento<br />- Validación de las fichas de unidad de trabajo estándar<br />- Validación del árbol de unidades<br /><br />* Etapa 3: Realización del estudio de riesgos<br />- Sensibilización del personal ante los riesgos y los peligros<br />- Creación de las unidades de trabajo con el personal y el o los responsables<br />- Evaluación de los riesgos por unidad de trabajo con el personal<br /><br />* Etapa 4<br />- Tratamiento y redacción del documento de evaluación de riesgos
+RiskAssessmentDocumentSources                             = La sensibilización ante los riesgos está definida en el ED840 editado por el INRS.<br />En este documento encontrará:<br />- La definición de un riesgo y de un peligro, con un esquema explicativo<br />- Las explicaciones sobre los distintos métodos de evaluación
+RiskAssessmentDocumentImportantNote                       = Notas importantes:<br />Puede consultar la documentación de DigiRisk aquí<br /><a href="https://wiki.dolibarr.org/index.php?title=Module_Digirisk" target="_blank">https://wiki.dolibarr.org/index.php?title=Module_Digirisk</a><br />Puede seguir el proyecto aquí:<br /><a href="https://github.com/Evarisk/Digirisk/projects?type=classic" target="_blank">https://github.com/Evarisk/Digirisk/projects?type=classic</a><br />Informe de un error aquí<br /><a href="https://github.com/Evarisk/Digirisk/issues" target="_blank">https://github.com/Evarisk/Digirisk/issues</a>
+GenerateZipArchiveWithDigiriskElementDocuments            = Generación de un archivo ZIP con el documento de evaluación de riesgos
+GenerateZipArchiveWithDigiriskElementDocumentsDescription = Generación automática de un archivo ZIP que contiene el documento de evaluación de riesgos y todas las fichas de puesto al generar el documento de evaluación de riesgos
+RiskAssessmentDocumentDescription                         = Plan de acción del documento de evaluación de riesgos
+ErrorFailToFetchDigiriskElements                          = Error: no se han podido recuperar las agrupaciones y unidades de trabajo que deben incluirse en el archivo ZIP
+ErrorNoDocumentModelFound                                 = Error: no hay ningún modelo de documento disponible para <b>%s</b>
+ErrorFailToGenerateDigiriskElementDocument                = Error: la generación del documento de <b>%s</b> ha fallado, no está en el archivo ZIP
+
+# Boxes - Widget
+NextGenerateDate  = Próxima generación
+LastGenerateDate  = Última generación
+DelayGenerateDate = Días restantes
+NoDelay           = Sin retraso
+
+# Email
+RiskAssessmentDocumentLabel   = Resumen del documento de evaluación de riesgos
+RiskAssessmentDocumentSubject = Correo del documento de evaluación de riesgos
+RiskAssessmentDocumentContent = Adjunto encontrará el ZIP y el documento ODT del documento de evaluación de riesgos.
+
+
+
+#
+# AuditReportDocument - Informe de auditoría
+#
+
+# Datos
+AuditReportDocument     = Informe de auditoría
+Auditreportdocument     = Informe de auditoría
+AuditReportDocumentsMin = informes de auditoría
+auditreportdocument.odt = Informe de auditoría
+
+
+
+#
+# GroupmentDocument - Ficha de agrupación
+#
+
+# Permiso
+
+# Datos
+GroupmentDocument                        = Ficha de agrupación
+Groupmentdocument                        = Ficha de agrupación
+DocumentModelStandardPDF                 = Modelo PDF estándar
+GroupmentDocumentGenerated               = Generación de la ficha de agrupación
+groupmentdocument.odt                    = Ficha de agrupación
+groupmentdocument_custom.odt             = Ficha de agrupación personalizada
+groupmentdocumentinherited.odt           = Ficha de agrupación - Riesgos heredados
+groupmentdocumentinherited_custom.odt    = Ficha de agrupación - Riesgos heredados personalizada
+groupmentdocumentshared.odt              = Ficha de agrupación - Riesgos compartidos
+groupmentdocumentshared_custom.odt       = Ficha de agrupación - Riesgos compartidos personalizada
+DigiriskGroupmentDocumentData            = Datos configurables de las fichas de agrupación
+ShowTaskDoneGroupmentDocumentDescription = Permite mostrar u ocultar las tareas finalizadas en la ficha de agrupación
+
+#
+# WorkUnitDocumment - Ficha de unidad de trabajo
+#
+
+# Permiso
+
+# Datos
+WorkUnitDocument                        = Ficha de unidad de trabajo
+Workunitdocument                        = Ficha de unidad de trabajo
+WorkUnitDocumentGenerated               = Generación de la ficha de unidad de trabajo
+workunitdocument.odt                    = Ficha de unidad de trabajo
+workunitdocument_custom.odt             = Ficha de unidad de trabajo personalizada
+workunitdocumentinherited.odt           = Ficha de unidad de trabajo - Riesgos heredados
+workunitdocumentinherited_custom.odt    = Ficha de unidad de trabajo - Riesgos heredados personalizada
+workunitdocumentshared.odt              = Ficha de unidad de trabajo - Riesgos compartidos
+workunitdocumentshared_custom.odt       = Ficha de unidad de trabajo - Riesgos compartidos personalizada
+workunitdocumentcomplete.odt            = Ficha de unidad de trabajo - Todos los riesgos (propios, heredados, compartidos)
+workunitdocumentcomplete_custom.odt     = Ficha de unidad de trabajo - Todos los riesgos personalizada
+DigiriskWorkUnitDocumentData            = Datos configurables de las fichas de unidad de trabajo
+ShowTaskDoneWorkUnitDocumentDescription = Permite mostrar u ocultar las tareas finalizadas en la ficha de unidad de trabajo
+
+
+#
+# DigiriskElement - Elemento Digirisk
+#
+
+# Permisos
+DigiriskElementsMin = elementos Digirisk (agrupación y unidad de trabajo)
+
+# Datos
+NewDigiriskElement                  = Nuevo elemento Digirisk
+Digiriskelement                     = Agrupación / Unidad de trabajo
+GPUTOrganization                    = Organización de los GP/UT
+DigiriskElement                     = Elemento Digirisk
+HiddenElements                      = Papelera
+DigiriskElementCreated              = Creación de elemento Digirisk
+DigiriskElementModified             = Modificación de elemento Digirisk
+DigiriskElementDeleted              = Eliminación de elemento Digirisk
+ElementType                         = Tipo de elemento
+ParentElement                       = Elemento padre
+OrganizationSaved                   = La organización de las agrupaciones y de las unidades de trabajo se ha guardado
+OrganizationNotSaved                = No se ha podido guardar la organización de las agrupaciones y de las unidades de trabajo
+UnsavedChanges                      = Modificaciones sin guardar
+SavingInProgress                    = Guardando...
+Saved                               = Guardado
+ErrorSaving                         = Error al guardar
+DigiriskElementOrganization         = Organización del árbol
+ShareDigiriskelement                = Activar el uso compartido de las agrupaciones y unidades de trabajo
+DIGIRISKELEMENTSharing              = Uso compartido de las agrupaciones y unidades de trabajo
+DIGIRISKELEMENTSharingDescription   = Selección de las entidades que compartirán sus agrupaciones y unidades de trabajo con esta entidad.
+DigiriskElementSharedTooltip        = Esta opción permite compartir las agrupaciones y unidades de trabajo. <br> INFO: si desea poder mostrar las tareas, debe activar la opción de uso compartido de los proyectos.
+PleaseSelectADigiriskElement        = Seleccionar una agrupación o una unidad de trabajo...
+Registers                           = Registros
+ShowInSelectOnPublicTicketInterface = Debe aparecer en la lista de elementos de la interfaz pública de tickets
+Organization                        = Organización GP/UT
+YouDontHaveOrganization             = No ha creado ninguna agrupación ni unidad de trabajo, acceda a "Documento de evaluación de riesgos" o haga clic <b> aquí </b> para crear una.
+
+
+#
+# Groupment - Agrupación
+#
+
+# Datos
+Groupment                  = Agrupación
+GroupmentManagement        = Gestión de los datos de las agrupaciones
+NewGroupment               = Nueva agrupación
+ModifyGroupment            = Modificar agrupación
+TrashGroupment             = Agrupación papelera
+DeletedElements            = Papelera
+DeletedDigiriskElement     = Agrupaciones / Unidades de trabajo colocadas en la papelera
+ShowDeletedDigiriskElement = Mostrar las agrupaciones / unidades de trabajo que se encuentran en la papelera
+
+#
+# WorkUnit - Unidad de trabajo
+#
+
+# Datos
+WorkUnit           = Unidad de trabajo
+Workunit           = Unidad de trabajo
+WorkUnitManagement = Gestión de los datos de las unidades de trabajo
+NewWorkUnit        = Nueva unidad de trabajo
+ModifyWorkUnit     = Modificar unidad de trabajo
+
+
+#
+# Evaluator - Evaluador
+#
+
+# Permisos
+EvaluatorsMin = evaluadores
+
+# Datos
+Evaluator                    = Evaluador
+Evaluators                   = Evaluadores
+EvaluatorCreated             = Creación de un evaluador
+EvaluatorModified            = Modificación de un evaluador
+EvaluatorDeleted             = Eliminación de un evaluador
+TheEvaluator                 = El evaluador
+EvaluatorWellCreated         = Evaluador creado
+EvaluatorNotCreated          = Error al crear el evaluador
+EvaluatorList                = Lista de los evaluadores
+AssignmentDate               = Fecha de asignación
+EvaluationDuration           = Duración
+UserAssigned                 = Usuario asignado
+AddEvaluatorTitle            = Adición de un evaluador
+AddEvaluatorButton           = Añadir el evaluador
+EvaluatorConfig              = Configuración de los datos de los evaluadores
+DeleteEvaluatorMessage       = Eliminación del evaluador
+DigiriskEvaluatorData        = Datos configurables de los evaluadores
+EvaluatorDuration            = Duración de la evaluación por el evaluador
+EvaluatorDurationDescription = El tiempo que necesita el evaluador para realizar su evaluación de riesgos
+NbEmployeesInvolved          = Trabajadores implicados
+NbEmployees                  = Trabajadores
+NbEmployeesInvolvedTooltip   = Trabajadores (evaluadores) únicos
+NbEmployeesTooltip           = Si la gestión centralizada de los usuarios y de los grupos en la entidad principal está activada.<br>El número de trabajadores corresponde al número de usuarios compartidos/asignados a un grupo y también al número de administradores de la entidad principal
+NbEmployeesConfTooltip       = El número de trabajadores se ha introducido manualmente
+
+
+#
+# DigiriskStandard - Estándar de Digirisk
+#
+
+# Datos
+DigiriskStandardInformation = Información
+Digiriskstandard            = Estándar Digirisk
+DigiriskStandardMin         = estándares Digirisk
+TheDigiriskstandard         = el estándar Digirisk
+
+
+#
+# RisksAnalysis - Análisis de riesgos
+#
+
+# Datos
+RiskAnalysis = Análisis de riesgos
+UpdateData   = Actualizar
+
+#
+# Risks - Riesgos
+#
+
+# Permisos
+RisksMin = riesgos
+
+# Datos
+Risks                                    = Riesgos
+Risk                                     = Riesgo
+Riskprofessionals                        = Riesgos laborales
+RiskCreated                              = Creación de un riesgo
+RiskModified                             = Modificación de un riesgo
+RiskDeleted                              = Eliminación de un riesgo
+RiskConfig                               = Configuración de los datos de los riesgos
+TheRisk                                  = El riesgo
+RiskWellCreated                          = Riesgo creado
+RiskNotCreated                           = Error al crear el riesgo
+RiskWellEdited                           = Riesgo editado
+RiskNotEdited                            = Error al editar el riesgo
+RiskList                                 = Listado de riesgos
+AddRiskTitle                             = Adición del riesgo
+AddRiskButton                            = Añadir el riesgo
+EditRisk                                 = Edición del riesgo
+LinkedRisk                               = Riesgo vinculado
+RiskCategory                             = Cat.
+RiskCategoryEdit                         = Categoría de riesgo
+RiskCategoryEditDescription              = Activar la modificación de la categoría de un riesgo existente
+HowToEditRiskCategory                    = Para modificar la categoría del riesgo, haga clic en el pictograma de la categoría
+DigiriskElementRisksList                 = Lista de los riesgos
+DigiriskElementRisk                      = Riesgos
+RiskDescriptionNotEnabled                = El campo descripción del riesgo no está activado
+HowToEnableRiskDescription               = Para activar el campo descripción del riesgo, vaya a "Configuración del módulo -> Documento de evaluación de riesgos"
+HowToEnableRiskCategoryEdit              = Para activar la modificación de la categoría de riesgo, vaya a "Configuración del módulo -> Documento de evaluación de riesgos"
+SortRisksListingsByEvaluation            = Ordenar los riesgos por evaluación
+SortRisksListingsByEvaluationDescription = Activar la ordenación automática de los riesgos por evaluación en los listados
+ListingHeaderEvaluation                  = Lista de las evaluaciones
+RiskDescription                          = Descripción del riesgo
+RiskDescriptionDescription               = Activar el campo descripción del riesgo
+RiskDescriptionNotActivated              = Active el campo descripción del riesgo en Configuración del módulo / Análisis de riesgos / Riesgos
+AddRisk                                  = Añadir un riesgo
+MoveRisk                                 = Mover el riesgo
+MoveRisks                                = Mover los riesgos
+MoveRisksDescription                     = Permite mover los riesgos de una agrupación o de una unidad de trabajo a otra
+SetConfToMoveRisk                        = Primero debe autorizar el desplazamiento de los riesgos en "Configuración del módulo -> Documento de evaluación de riesgos"
+RiskDescriptionPrefill                   = Rellenar previamente la descripción
+RiskDescriptionPrefillDescription        = Rellenar previamente la descripción del riesgo con el nombre de la categoría
+DigiriskElementSharedRisksList           = Lista de los riesgos compartidos
+ImportSharedRisks                        = Importar riesgos compartidos
+SelectAllSharedRisksOfElement            = Seleccionar todos los riesgos de este elemento
+AlreadyImported                          = Ya importado
+ShowSharedRisks                          = Riesgos compartidos
+ShareRisk                                = Activar el uso compartido de los riesgos
+RISKSharing                              = Uso compartido de los riesgos
+RISKSharingDescription                   = Selección de las entidades que compartirán sus riesgos con esta entidad.
+ShowSharedRisksDescription               = Mostrar los riesgos compartidos en los documentos y los listados
+UnlinkSharedRisk                         = Desvincular el riesgo compartido
+RiskWellUnlinkShared                     = Riesgo desvinculado
+RiskNotUnlinkShared                      = Error al desvincular el riesgo
+HasBeenUnlinkSharedM                     = ha sido desvinculado
+HasNotBeenUnlinkSharedM                  = no ha sido desvinculado
+RiskSharedTooltip                        = Esta opción permite compartir los riesgos. <br> INFO: si desea poder mostrar las tareas, debe activar la opción de uso compartido de los proyectos.
+ShowInheritedRisksInListings             = Riesgos heredados - Listados <br> (procedentes de los niveles superiores)
+ShowInheritedRisksInListingsDescription  = Los riesgos heredados son los definidos en un nivel superior (p. ej. centro o GP) y aplicados automáticamente al GP/UT. <br> Active esta opción para mostrarlos en los listados
+ShowInheritedRisksInDocuments            = Riesgos heredados - Documentos <br> (procedentes de los niveles superiores)
+ShowInheritedRisksInDocumentsDescription = Los riesgos heredados son los definidos en un nivel superior (p. ej. centro o GP) y aplicados automáticamente al GP/UT. <br> Active esta opción para mostrarlos en los documentos
+DigiriskElementInheritedRisksList        = Lista de los riesgos heredados
+ConfirmImportSharedRisks                 = Elija los riesgos compartidos que desea importar
+RisksRepartition                         = Distribución de los riesgos por evaluación
+ShowRiskOrigin                           = Mostrar la procedencia del riesgo
+ShowRiskOriginDescription                = Mostrar la procedencia de los riesgos en los documentos (Documento de evaluación de riesgos, Agrupación, Unidades de trabajo, Listado de riesgos con acciones y con fotos, etc.).
+SharedRiskImportWithSuccess              = Riesgo importado correctamente
+RiskImport                               = Importación de riesgos
+RiskUnlink                               = Eliminación del riesgo compartido
+RiskDeleted                              = El riesgo %s ha sido eliminado
+RiskSharedWithEntityRefLabel             = Uso compartido del riesgo %s con
+RiskUnlinkedFromEntityRefLabel           = Desvinculación del riesgo %s de
+TheDigiriskelement                       = el elemento Digirisk
+DefaultProjectContactType                = Rol asignado por defecto al proyecto del documento de evaluación de riesgos
+DefaultTaskContactType                   = Rol asignado por defecto a las tareas del proyecto del documento de evaluación de riesgos
+RiskListParentView                       = Mostrar todos los elementos padre
+RiskListParentViewDescription            = Mostrar todos los elementos padre de un riesgo en la lista de riesgos y en los documentos
+CategoryOnRisk                           = Mostrar las etiquetas/categorías en los riesgos
+CategoryOnRiskDescription                = Permite asignar etiquetas/categorías a los riesgos y mostrarlas - manipular con precaución
+AddPsychosocialRisk                      = Añadir un riesgo psicosocial
+AddPsychosocialRiskTitle                 = Adición de un riesgo psicosocial
+AddPsychosocialRiskButton                = Añadir el riesgo psicosocial
+AddSelectedPsychosocialRisks             = Añadir los riesgos psicosociales seleccionados
+SocialRelationsAtWork                    = Relaciones sociales en el trabajo
+WorkIntensityAndTime                     = Intensidad y tiempo de trabajo
+EmotionalRequirements                    = Exigencias emocionales
+Autonomy                                 = Autonomía
+MeaningOfWork                            = Sentido del trabajo
+WorkSituationInsecurity                  = Inseguridad de la situación laboral
+PreventionContextInCompany               = Contexto de prevención en la empresa
+RPSImpactOnCompanyAndEmployees           = Impacto de los riesgos psicosociales en la empresa y los trabajadores
+PsychosocialRisksFactors                 = Factores de riesgo psicosocial
+CompanyPreventionInformations            = Información sobre la prevención en la empresa
+Weak                                     = Bajo
+Moderate                                 = Moderado
+High                                     = Elevado
+Extreme                                  = Extremo
+HereIsTheWorkStationDescription          = Esta es la descripción del puesto de trabajo
+ImageAnalysis                            = Análisis de la imagen
+TextAnalysis                             = Análisis de texto
+AnalyzeText                              = Analizar el texto
+EnterTextForAnalysis                     = Introduzca el texto a analizar
+AIRiskAnalysis                           = Análisis de riesgos por IA
+AnalysisInProgress                       = Análisis en curso...
+
+# Estadísticas
+GreyRisk                                         = Riesgo bajo
+OrangeRisk                                       = Riesgo a planificar
+RedRisk                                          = Riesgo a tratar
+BlackRisk                                        = Riesgo inaceptable
+RisksNotAssessed                                 = Riesgos no evaluados
+RisksRepartitionByDangerCategories               = Distribución de los riesgos por categoría de peligro
+RiskListsByDangerCategories                      = Lista de los riesgos por categoría de peligro
+DigiriskElementsRepartitionByDepth               = Distribución del árbol de las agrupaciones de nivel %s
+RisksRepartitionByDangerCategoriesAndCriticality = Distribución de los riesgos por categoría de peligro y criticidad
+NumberOfRisks                                    = Número de riesgos
+DangerCategories                                 = Categorías de peligro
+RisksRepartitionByDigiriskElement                = Distribución de los riesgos por agrupación / unidad de trabajo %s
+
+
+
+#
+# RiskEnvironmentals - Riesgos medioambientales
+#
+
+# Datos
+Environment                                    = Medio ambiente
+Riskenvironmental                              = Riesgo medioambiental
+RiskEnvironmentals                             = Riesgos medioambientales
+Riskenvironmentals                             = Riesgos medioambientales
+RiskEnvironmentalsMin                          = riesgos medioambientales
+AddRiskenvironmentalTitle                      = Adición del riesgo medioambiental
+DigiriskElementRiskenvironmentalsList          = Lista de los riesgos medioambientales
+DigiriskElementInheritedRiskenvironmentalsList = Lista de los riesgos medioambientales heredados
+DigiriskElementSharedRiskenvironmentalsList    = Lista de los riesgos medioambientales compartidos
+ImportSharedRiskenvironmentals                 = Importar riesgos medioambientales compartidos
+SelectAllSharedRiskenvironmentalsOfElement     = Seleccionar todos los riesgos medioambientales de este elemento
+ConfirmImportSharedRiskenvironmentals          = Elija los riesgos medioambientales compartidos que desea importar
+EnvironmentDescription                         = Planificación - Acciones a implantar frente a los riesgos y oportunidades
+
+#
+# ListingRisksEnvironmentalAction - Listado de riesgos medioambientales con acciones correctivas
+#
+
+# Permiso
+ListingRisksEnvironmentalActionMin = Listado de riesgos medioambientales con acciones correctivas
+
+# Datos
+ListingRisksEnvironmentalAction            = Listado de riesgos medioambientales con acciones correctivas
+Listingrisksenvironmentalaction            = Listado de riesgos medioambientales con acciones correctivas
+ListingRisksEnvironmentalActionGenerated   = Generación del listado de riesgos medioambientales con acciones correctivas
+listingrisksenvironmentalaction.odt        = Listado de riesgos medioambientales con acciones correctivas
+listingrisksenvironmentalaction_custom.odt = Listado de riesgos medioambientales con acciones correctivas personalizado
+
+#
+# ListingRisksEnvironmentalDocument - Listado de riesgos medioambientales con documentos
+#
+
+# Datos
+ListingRisksEnvironmentalDocument = Listado de riesgos medioambientales
+
+
+
+#
+# RiskAssessment - Evaluación
+#
+
+# Datos
+RiskAssessment                              = Evaluación
+Riskassessment                              = Evaluación
+RiskAssessments                             = Evaluaciones
+RiskAssessmentCreated                       = Creación de una evaluación
+RiskAssessmentModified                      = Modificación de una evaluación
+RiskAssessmentDeleted                       = Eliminación de una evaluación
+RiskAssessmentConfig                        = Configuración de los datos de las evaluaciones
+TheRiskAssessment                           = La evaluación
+LastRiskAssessment                          = Última evaluación del riesgo
+RiskAssessmentWellCreated                   = Evaluación creada
+RiskAssessmentNotCreated                    = Error al crear la evaluación
+RiskAssessmentWellEdited                    = Evaluación editada
+RiskAssessmentNotEdited                     = Error al editar la evaluación
+RiskAssessmentWellDeleted                   = Evaluación eliminada
+RiskAssessmentNotDeleted                    = Error al eliminar la evaluación
+EvaluationCreate                            = Adición de la evaluación
+EvaluationEdit                              = Edición de la evaluación
+EvaluationMethod                            = Método de evaluación
+lastEvaluationOn                            = Última evaluación el
+DeleteEvaluation                            = ¿Está seguro de que desea eliminar la evaluación?
+DigiriskRiskAssessmentData                  = Datos configurables de las evaluaciones
+MultipleRiskAssessmentMethodName            = Métodos de evaluación
+MultipleRiskAssessmentMethodDescription     = Activar el cambio de método de evaluación
+AdvancedRiskAssessmentMethod                = Método de evaluación avanzado
+AdvancedRiskAssessmentMethodDescription     = Activar el método de evaluación avanzado
+RiskAssessmentList                          = Lista de las evaluaciones del riesgo
+EditRiskAssessment                          = Editar la evaluación
+ShowAllRiskAssessments                      = Ver todas las evaluaciones
+ShowAllRiskAssessmentsDescription           = Mostrar la lista completa de las evaluaciones de riesgo en la lista de riesgos
+ParentRisk                                  = Riesgo padre
+RiskAssessmentDate                          = Fecha de la evaluación
+SimpleEvaluation                            = Evaluación simple
+AdvancedEvaluation                          = Evaluación avanzada
+CalculatedEvaluation                        = Evaluación calculada
+SelectEvaluation                            = Marque las casillas para calcular su evaluación
+EvaluationList                              = Lista de las evaluaciones del riesgo
+HowToSetMultipleRiskAssessmentMethod        = Para configurar el uso múltiple de los métodos de evaluación, vaya a Configuración del módulo - Análisis de riesgos - Evaluación
+NoFileLinked                                = Ninguna foto vinculada
+AddRiskAssessment                           = Añadir una evaluación del riesgo
+AddRiskAssessmentTask                       = Añadir una tarea al riesgo
+ListRiskAssessmentTask                      = Lista de las tareas del riesgo
+ShowRiskAssessmentDate                      = Fecha de las evaluaciones
+ShowRiskAssessmentDateDescription           = Sustituye la fecha de creación por la fecha de inicio de las evaluaciones en la ficha y los documentos
+RiskAssessmentHideDateInDocument            = Ocultar la fecha de la evaluación en los documentos
+RiskAssessmentHideDateInDocumentDescription = Ocultar la fecha de la evaluación de la columna "Información sobre la evaluación" en los documentos
+RiskTaskComplete                            = Tarea %s completada
+
+# Estadísticas
+TasksRepartition = Distribución de las tareas por avance real declarado
+TaskAt0Percent   = Tarea al 0
+TaskInProgress   = Tarea en curso
+TaskAt100Percent = Tarea al 100
+
+
+#
+# RiskSign - Señalización
+#
+
+# Permisos
+RiskSignsMin = señalizaciones
+
+# Datos
+RiskSign                           = Señalización
+RiskSignCreated                    = Creación de una señalización
+RiskSignModified                   = Modificación de una señalización
+RiskSignDeleted                    = Eliminación de una señalización
+TheRiskSign                        = La señalización
+RiskSignConfig                     = Configuración de los datos de las señalizaciones
+RiskSignWellCreated                = Señalización creada
+RiskSignNotCreated                 = Error al crear la señalización
+RiskSignWellEdited                 = Señalización editada
+RiskSignNotEdited                  = Error al editar la señalización
+RiskSignWellDeleted                = Señalización eliminada
+RiskSignNotDeleted                 = Error al eliminar la señalización
+RiskSignCategory                   = Categoría
+RiskSignImport                     = Importación de señalizaciones
+RiskSignUnlink                     = Eliminación de la señalización compartida
+AddRiskSignTitle                   = Adición de una señalización
+AddRiskSignButton                  = Añadir la señalización
+EditRiskSign                       = Edición de una señalización
+DeleteRiskSignMessage              = Eliminación de la señalización
+DigiriskElementRiskSignList        = Lista de las señalizaciones
+RiskSigns                          = Señalizaciones
+DigiriskElementSharedRiskSignsList = Lista de las señalizaciones compartidas
+ImportSharedRiskSigns              = Importar señalizaciones compartidas
+SelectAllSharedRiskSignsOfElement  = Seleccionar todas las señalizaciones de este elemento
+AlreadyImportedF                   = Ya importada
+ShowSharedRiskSigns                = Señalizaciones compartidas
+ShowSharedRiskSignsDescription     = Mostrar las señalizaciones compartidas en los documentos y los listados
+DigiriskElementSharedRiskSign      = Señalizaciones compartidas
+SharedRiskSigns                    = Señalizaciones compartidas
+ShareRisksign                      = Activar el uso compartido de las señalizaciones
+RISKSIGNSharing                    = Uso compartido de las señalizaciones
+RISKSIGNSharingDescription         = Selección de las entidades que compartirán sus señalizaciones con esta entidad.
+UnlinkSharedRiskSign               = Desvincular la señalización compartida
+RiskSignWellUnlinkShared           = Señalización desvinculada
+RiskSignNotUnlinkShared            = Error al desvincular la señalización
+HasBeenUnlinkSharedF               = ha sido desvinculada
+HasNotBeenUnlinkSharedF            = no ha sido desvinculada
+RiskSignSharedTooltip              = Esta opción permite compartir las señalizaciones. <br> INFO: si desea poder mostrar las tareas, debe activar la opción de uso compartido de los proyectos.
+ShowInheritedRiskSigns             = Señalizaciones heredadas
+ShowInheritedRiskSignsDescription  = Mostrar las señalizaciones heredadas en los documentos y los listados
+DigiriskElementInheritedRiskSignsList = Lista de las señalizaciones heredadas
+ConfirmImportSharedRiskSigns       = Elija las señalizaciones compartidas que desea importar
+RiskSignSharedWithEntityRefLabel   = Uso compartido de la señalización %s con
+RiskSignUnlinkedFromEntityRefLabel = Desvinculación de la señalización %s de
+
+#
+# Tasks - Tarea
+#
+
+# Datos
+ActionPlan                               = Plan de acción
+Task                                     = Tarea
+TaskCreatedEvent                         = Creación de una tarea
+TaskModifiedEvent                        = Modificación de una tarea
+TaskDeletedEvent                         = Eliminación de una tarea
+TheTask                                  = La tarea
+TaskConfig                               = Configuración de los datos de las tareas
+TaskWellCreated                          = Tarea creada
+TaskNotCreated                           = Error al crear la tarea
+TaskWellEdited                           = Tarea editada
+TaskNotEdited                            = Error al editar la tarea
+TaskWellDeleted                          = Tarea eliminada
+TaskNotDeleted                           = Error al eliminar la tarea
+TasksManagement                          = Gestión de las tareas
+SelectProject                            = Elección del proyecto
+DUProject                                = Proyecto vinculado a las tareas de los riesgos
+EnvironmentProject                       = Proyecto vinculado a las tareas de los riesgos medioambientales
+NoTaskLinked                             = Ninguna tarea en curso
+TaskList                                 = Lista de las tareas del riesgo
+TaskCreate                               = Adición de la tarea
+TaskEdit                                 = Edición de la tarea
+HowToSetDUProject                        = Para configurar la elección del proyecto, vaya a Configuración del módulo - Análisis de riesgos - Tarea
+DeleteTask                               = ¿Está seguro de que desea eliminar la tarea?
+ListingHeaderTask                        = Lista de las tareas
+ListingHeaderTaskTooltip                 = Active el uso compartido de los proyectos para mostrar las tareas
+TasksManagementDescription               = Activar la gestión de las tareas
+TaskManagementNotActivated               = Active la gestión de las tareas en Configuración del módulo / Análisis de riesgos / Tarea
+DigiriskProgress                         = Avance
+ShowTaskStartDate                        = Fecha de inicio de las tareas
+ShowTaskStartDateDescription             = Sustituye la fecha de creación por la fecha de inicio de las tareas en la ficha y los documentos
+ShowTaskEndDate                          = Fecha de fin de las tareas
+ShowTaskEndDateDescription               = Mostrar la fecha de fin de las tareas
+ShowTasksDone                            = Tareas completadas
+ShowTasksDoneDescription                 = Mostrar las tareas completadas al 100
+ShowTasksDoneDescriptionExtend           = en las listas de riesgos
+ShowTaskCalculatedProgress               = Avance de la tarea
+ShowTaskCalculatedProgressDescription    = Mostrar el avance calculado de la tarea en lugar del avance declarado
+ShowAllTasks                             = Todas las tareas de un riesgo en los listados
+ShowAllTasksDescription                  = Mostrar todas las tareas en la lista de tareas de un riesgo en los listados
+DeleteTaskTimeSpent                      = ¿Está seguro de que desea eliminar %s min de tiempo dedicado a la tarea?
+TaskTimeSpentEdit                        = Edición del tiempo dedicado a la tarea
+TheTaskTimeSpent                         = El tiempo dedicado
+TaskTimeSpentCreated                     = Creación de tiempo dedicado
+TaskTimeSpentModified                    = Modificación de tiempo dedicado
+TaskTimeSpentDeleted                     = Eliminación de tiempo dedicado
+TaskTimeSpentWellCreated                 = Tiempo dedicado creado
+TaskTimeSpentNotCreated                  = Error al crear el tiempo dedicado
+TaskTimeSpentWellEdited                  = Tiempo dedicado editado
+TaskTimeSpentNotEdited                   = Error al editar el tiempo dedicado
+TaskTimeSpentWellDeleted                 = Tiempo dedicado eliminado
+TaskTimeSpentNotDeleted                  = Error al eliminar el tiempo dedicado
+OnTheTask                                = a la tarea
+TaskTimeSpentDuration                    = Duración del tiempo dedicado
+TaskTimeSpentDurationDescription         = El tiempo dedicado añadido por defecto a cada tarea
+NoTaskShared                             = Ninguna tarea compartida
+WarningTaskLabel                         = Atención, ha superado el número máximo de caracteres permitido (255)
+ErrorRecordHasSubTasks                   = La tarea tiene hijos
+TotalConsumedTime                        = Total del tiempo dedicado al proyecto
+TotalConsumedTimeAmount                  = Coste del tiempo dedicado
+NbTasks                                  = Número de tareas
+TotalProgress                            = Avance real global de las tareas
+TotalBudget                              = Suma del presupuesto de las tareas
+TaskTimeSpentDate                        = Fecha del tiempo dedicado
+StartDateCannotBeAfterEndDate            = La fecha de fin no puede ser anterior a la fecha de inicio
+TasksFromProject                         = Las tareas mostradas proceden del proyecto definido como "Proyecto del documento de evaluación de riesgos"
+TaskHideRefInDocument                    = Ocultar la referencia
+TaskHideRefInDocumentDescription         = Ocultar la referencia de la tarea en los documentos
+TaskHideResponsibleInDocument            = Ocultar el responsable
+TaskHideResponsibleInDocumentDescription = Ocultar el responsable de la tarea en los documentos
+TaskHideDateInDocument                   = Ocultar la fecha
+TaskHideDateInDocumentDescription        = Ocultar la fecha de inicio y de fin de la tarea en los documentos
+TaskHideBudgetInDocument                 = Ocultar el presupuesto
+TaskHideBudgetInDocumentDescription      = Ocultar el presupuesto de la tarea en los documentos
+
+#
+# DigiAI - DigiAI
+#
+
+# Datos
+WelcomeToDigiAI = Bienvenido a DigiAI
+UploadAnImage = Subir una imagen
+OpenAIApiKey = Clave API de OpenAI
+OpenAIApiKeyDescription = Para utilizar DigiAI, debe disponer de una clave API de OpenAI. Puede obtener una creando una cuenta en <a href="https://platform.openai.com/signup" target="_blank">https://platform.openai.com/signup</a>. Una vez registrado, podrá generar una clave API en la sección "API Keys" de su panel de control.
+
+#
+# Ticket - Interfaz pública de tickets
+#
+
+# Permisos
+TicketTagsConfig                         = Modificación de los registros de seguridad y salud laboral
+
+# Datos
+Register                                 = Registro
+Send                                     = Enviar
+TicketSent                               = Ticket enviado
+FilesLinked                              = Fotos / Archivos adjuntos
+AddDocument                              = Añadir documento
+LastnamePlaceholder                      = Ejemplo: García
+FirstnamePlaceholder                     = Ejemplo: Juan
+PhonePlaceholder                         = 00.00.00.00.00
+LocationPlaceholder                      = Ejemplo: Oficina A
+ServicePlaceholder                       = Ejemplo: Peón de recogida
+Location                                 = Lugar
+CategoriesCreated                        = Creación de las categorías de ticket
+ExtrafieldsCreated                       = Creación de los campos adicionales de ticket
+AnticipatedLeave                         = Salida anticipada
+DGI                                      = Peligro grave e inminente
+SST                                      = Seguridad y salud en el trabajo
+PresquAccident                           = Casi accidente
+Accident                                 = Accidente
+EnhancementSuggestion                    = Sugerencia de mejora
+MaterialProblem                          = Problema material
+HumanProblem                             = Problema humano
+Others                                   = Otro
+AccidentWithoutDIAT                      = Accidente leve
+AccidentWithDIAT                         = Accidente de trabajo
+Environment                              = Medio ambiente
+Quality                                  = Calidad
+NonCompliance                            = No conformidad
+FirstName                                = Nombre
+LastName                                 = Apellidos
+Phone                                    = Teléfono
+DeclarationDate                          = Declaración
+DigiriskTicketPublicAccess               = Hay disponible una interfaz pública que no requiere identificación en la siguiente URL
+TicketActivatePublicInterface            = Activar la interfaz pública
+GenerateExtrafields                      = Generación de los campos adicionales de ticket por defecto
+GenerateTicketCategories                 = Generación de las categorías de ticket por defecto
+AlreadyGenerated                         = Ya generados
+NotGenerated                             = Aún no generado
+NotCreated                               = Aún no creados
+ExtrafieldsGeneration                    = Esta opción permite generar los campos adicionales por defecto de los tickets. Los campos creados serán: <br> Apellidos, Nombre, Teléfono, GP/UT, Lugar y Fecha
+CategoriesGeneration                     = Esta opción permite generar las categorías por defecto de los tickets. Las categorías creadas serán: <br> - Registro <br> - - Accidente <br> - - - Casi accidente, Accidente leve, Accidente de trabajo <br> - - Seguridad y salud en el trabajo <br> - - - Salida anticipada, Otros, Problema humano, Problema material <br> - - Peligro grave e inminente <br> - - Calidad <br> - - - No conformidad, Sugerencia de mejora <br> - - Medio ambiente <br> - - - No conformidad, Otros
+TicketSuccess                            = Su registro ha sido transmitido al servicio de prevención con el número:
+TicketPublicAccess                       = Enlace de vuelta a la interfaz pública de tickets:
+TicketShowCompanyLogo                    = Mostrar el logotipo de la empresa en la interfaz pública
+TicketShowCompanyLogoHelp                = Active esta opción para ocultar el logotipo de la empresa en las páginas de la interfaz pública
+YouMustNotifyYourHierarchy               = Tiene la <b>obligación</b> de avisar a su jerarquía
+GoBackToTicketCreation                   = Ir a la página de seguimiento de los tickets
+SendEmailOnTicketSubmit                  = Enviar correos al crear
+CatTicketsList                           = Lista de las etiquetas/categorías de los tickets
+SendEmailTo                              = Dirección de correo a notificar
+SendEmailOnTicketSubmitHelp              = Activar el envío automático de un correo al crear un ticket
+MultipleEmailsSeparator                  = Para asignar varias direcciones de correo a notificar, sepárelas con un ";". Por ejemplo: "aaaa@bbb.cc;dddd@eee.ff"
+TicketCategories                         = Categorías de los tickets
+TicketDocumentsConfig                    = Documentos de los tickets
+TicketExtrafields                        = Campos adicionales de los tickets
+MainCategorySetting                      = Esta opción permite definir la categoría cuyas subcategorías aparecerán en la interfaz pública
+TicketCategoriesInDocumentsSetting       = Esta opción permite elegir las categorías de tickets mostradas en la lista de tickets de los documentos (Documento de evaluación de riesgos, ficha de agrupación, etc.). Si no se selecciona ninguna categoría, se muestran todas las categorías
+ParentCategorySetting                    = Esta opción permite definir el título de la categoría padre para la interfaz pública de tickets
+ChildCategorySetting                     = Esta opción permite definir el título de la categoría hija para la interfaz pública de tickets
+TicketManagement                         = Gestión de los tickets
+MainCategory                             = Elección de la categoría principal
+TicketCategoriesInDocuments              = Categorías mostradas en los documentos
+ParentCategoryLabel                      = Título de la categoría padre
+ChildCategoryLabel                       = Título de la categoría hija
+TicketPublicInterfaceEnabled             = La interfaz pública de tickets ha sido activada
+TicketPublicInterfaceDisabled            = La interfaz pública de tickets ha sido desactivada
+TicketPublicInterface                    = Interfaz pública
+EmailsToNotifySet                        = Las direcciones de correo a notificar se han registrado correctamente
+MainCategorySet                          = La categoría principal ha sido definida
+TicketCategoriesInDocumentsSet           = Las categorías mostradas en los documentos han sido definidas
+ParentCategoryLabelSet                   = El título de la categoría padre ha sido definido
+ChildCategoryLabelSet                    = El título de la categoría hija ha sido definido
+TicketPublicInterfaceConfigDocumentation = Para configurar la interfaz pública de tickets, consulte la documentación
+ParentCategory                           = Categoría padre
+TSProject                                = Proyecto vinculado a los tickets
+TicketDescription                        = Proyecto de los tickets
+TicketProjectUpdated                     = El proyecto por defecto de los tickets ha sido actualizado
+QRCodeAlreadyGenerated                   = Código QR generado
+GenerateQRCode                           = Generar el código QR
+CompanyQRCodeGeneration                  = Generación del código QR de la entidad
+QRCodeGeneration                         = Generación del código QR
+MultiCompanyQRCodeGeneration             = Generación del código QR multientidad
+TicketCreationMailWellSent               = Correo de confirmación de creación del ticket enviado
+TicketCreationMailSent                   = El correo de creación del ticket ha sido enviado a %s
+HowToSetupTicketCategories               = Para configurar las categorías de ticket, haga clic en este enlace:
+ConfigTicketCategories                   = Configuración de las categorías de ticket
+NewTicketSubmitted                       = Se ha enviado un ticket a través de la interfaz pública
+ANewTicketHasBeenSubmitted               = Nuevo registro de seguridad creado para %s
+TicketCreationSubject                    = Creación de ticket a través de la interfaz pública de Digirisk
+TicketDocumentCustomDigiriskTemplate     = ODT personalizado de las fichas de ticket
+HowToSetupDigiriskElement                = Para configurar los elementos de Digirisk (agrupaciones/unidades de trabajo), haga clic en este enlace:
+ConfigDigiriskElement                    = Configuración de los elementos de Digirisk
+ErrorFieldEmail                          = Error: el correo debe corresponder al siguiente formato: <b>'aaa@aaa.fr'</b>
+ErrorFieldPhone                          = Error: el teléfono debe corresponder al siguiente formato: <b>'0XXXXXXXXXXX'</b> o <b>'+33XXXXXXXXX'</b>
+TicketEmailRequired                      = Correo obligatorio para crear un ticket
+TicketEmailRequiredHelp                  = Active esta opción para hacer obligatoria la introducción de un correo al crear un ticket en la interfaz pública
+WelcomeToPublicTicketInterface           = Bienvenido a la interfaz pública de tickets
+PleaseSelectAnEntity                     = Seleccione una entidad:
+ShowSelectorOnTicketPublicInterface      = Mostrar el selector multientidad en la interfaz pública de tickets en lugar de la lista de entidades
+ShowSelectorOnTicketPublicInterfaceHelp  = Mostrar el selector multientidad en la interfaz pública de tickets en lugar de la lista de entidades con su logotipo
+MultiEntityPublicInterface               = Interfaz pública de tickets multiempresa
+TicketCategoriesNotCreated               = No ha creado ninguna categoría de tickets
+TicketPublicInterfaceQRCode              = Código QR de la interfaz pública de tickets
+MultiEntityTicketPublicInterfaceQRCode   = Código QR de la interfaz pública de tickets multiempresa
+PublicInterfaceConfiguration             = Campos visibles / obligatorios de la interfaz pública
+TicketNumber                             = N.º de ticket
+FromAndDate                              = Procedencia y fecha
+AuthorRequest                            = Solicitante
+DateCloture                              = Fecha de cierre
+
+PublicInterfaceUseSignatory              = Firma obligatoria para declarar este registro
+ValidateText                             = Condiciones a aceptar para la firma
+TicketPublicInterfaceShowCategory        = Mostrar la descripción de la categoría
+EmailTemplate                            = Plantilla de correo
+EmailTemplateDescription                 = Plantilla de correo
+
+OpenInNewTab                             = Abrir en una pestaña nueva
+TicketDigiriskElementRequired            = GP/UT obligatorio para crear un ticket
+TicketDigiriskElementRequiredHelp        = Active esta opción para hacer obligatoria la selección de un GP/UT al crear un ticket en la interfaz pública
+TicketDigiriskElementHideRef             = Ocultar la referencia de los GP/UT en el selector de servicio de la interfaz pública
+TicketDigiriskElementHideRefHelp         = Active esta opción para ocultar la referencia de un GP/UT en la interfaz pública
+TicketDigiriskelementVisible             = Mostrar el campo GP/UT para crear un ticket
+TicketServiceVisible                     = Mostrar el campo GP/UT para crear un ticket
+TicketDigiriskelementVisibleHelp         = Active esta opción para mostrar el campo GP/UT en la interfaz pública y hacerlo obligatorio si es necesario
+TicketServiceVisibleHelp                 = Active esta opción para mostrar el campo GP/UT en la interfaz pública y hacerlo obligatorio si es necesario
+TicketPhotoVisible                       = Mostrar el campo Foto para crear un ticket
+TicketPhotoVisibleHelp                   = Active esta opción para mostrar el campo Foto en la interfaz pública
+TicketEmailVisible                       = Mostrar el campo Correo para crear un ticket
+TicketEmailVisibleHelp                   = Active esta opción para mostrar el campo Correo en la interfaz pública y hacerlo obligatorio si es necesario
+TicketLastnameVisible                    = Mostrar el campo Apellidos para crear un ticket
+TicketLastnameVisibleHelp                = Active esta opción para mostrar el campo Apellidos en la interfaz pública y hacerlo obligatorio si es necesario
+TicketFirstnameVisible                   = Mostrar el campo Nombre para crear un ticket
+TicketFirstnameVisibleHelp               = Active esta opción para mostrar el campo Nombre en la interfaz pública y hacerlo obligatorio si es necesario
+TicketPhoneVisible                       = Mostrar el campo Teléfono para crear un ticket
+TicketPhoneVisibleHelp                   = Active esta opción para mostrar el campo Teléfono en la interfaz pública y hacerlo obligatorio si es necesario
+TicketLocationVisible                    = Mostrar el campo Lugar para crear un ticket
+TicketLocationVisibleHelp                = Active esta opción para mostrar el campo Lugar en la interfaz pública y hacerlo obligatorio si es necesario
+TicketDateVisible                        = Mostrar el campo Fecha para crear un ticket
+TicketDateVisibleHelp                    = Active esta opción para mostrar el campo Fecha en la interfaz pública y hacerlo obligatorio si es necesario
+QRCodeGenerated                          = Código QR generado
+FkTicket                                 = Ticket vinculado
+PublicTicket                             = Interfaz pública de tickets
+TicketPublicInterfaceForbidden           = Acceso prohibido a la interfaz pública de tickets
+DefaultUserGroup                         = Grupo por defecto
+DefaultUserGroupDescription              = Grupo por defecto en los selectores de grupos
+ConfigureDefaultUserGroup                = Configurar el grupo por defecto
+RegisterSigned                           = Registro firmado
+
+#Interfaz pública
+TicketPublicInterfaceShowCategoryDescription     = Mostrar la descripción de las categorías de ticket en la interfaz pública
+TicketPublicInterfaceShowCategoryDescriptionHelp = Active esta opción para mostrar la descripción de las categorías de ticket en la interfaz pública
+
+
+# Estadísticas
+TicketStatistics    = Estadísticas de los tickets
+ExportCSV           = Exportación CSV
+GenerateCSV         = Generar el archivo CSV
+SuccessGenerateCSV  = Archivo CSV %s generado correctamente
+ErrorMissingData    = Error: no se ha podido generar el archivo CSV, los datos enviados al archivo son incorrectos. <br> Compruebe que tiene GP/UT asignados a tickets.
+CSVFileExport       = Exportación de los registros en formato CSV asociados a GP/UT
+ThirdPartyHelp      = Si el filtro "Tercero" está vacío, no se utiliza ningún tercero para la búsqueda
+GP/UTHelp           = Por defecto, el filtro toma todos los GP/UT
+CategoryTicketHelp  = Por defecto, el filtro toma todas las categorías
+CreatedByHelp       = Si el filtro "Creado por" está vacío, no se utiliza ningún usuario para la búsqueda
+AssignedToHelp      = Si el filtro "Asignado a" está vacío, no se utiliza ningún usuario para la búsqueda
+StatusHelp          = Por defecto, el filtro toma todos los estados<br>
+ConcernedTimePeriod = Periodo considerado
+LessThan            = Menos de
+MoreThan            = Más de
+Comparator          = Comparador
+RangeNumber         = Cantidad
+TimeRange           = Unidad de tiempo
+RangeLabel          = Nombre de la restricción
+Inferior            = Inferior a
+Superior            = Superior a
+TimeRangeAdded      = Restricción añadida
+TimeRangeDeleted    = Restricción eliminada
+
+NumberOfTicketsByMainCategorieAndDigiriskElement    = Número de registros por categoría y por GP
+NumberOfTicketsByMainSubCategorieAndDigiriskElement = Número de registros por subcategoría y por GP
+NumberOfTicketsByYear                           = Número de tickets por año
+
+# Ticket Management Dashboard - Panel de gestión de tickets
+TicketManagementDashboard                 = Panel de gestión de tickets
+RunningTicket                             = Tickets en curso
+NbOfOpenedTicket                          = Número de tickets abiertos
+OldestTicket                              = Ticket más antiguo
+OldestTicketDescription                   = Ticket más antiguo con el tiempo transcurrido desde su creación
+OldestMessageTicket                       = Ticket más antiguo con un mensaje
+OldestMessageTicketDescription            = Ticket más antiguo con un mensaje y el tiempo transcurrido desde la creación del mensaje
+MeanAnswerTime                            = Tiempo medio de respuesta
+MeanAnswerTimeDescription                 = Plazo medio entre la apertura y el cierre, calculado únicamente sobre los tickets cerrados
+MeanFirstResponseTime                     = Plazo medio de primera respuesta
+MeanFirstResponseTimeDescription          = Plazo medio entre la apertura del ticket y el primer mensaje visible para el declarante. Las notas internas no cuentan, y los tickets sin mensaje público quedan excluidos del cálculo
+NbTicketPerUser                           = Número medio de tickets asignados por persona
+NbExchangePerTicket                       = Número de intercambios por ticket
+TicketRepartitionPerUserAndMeanAnswerTime = Distribución de los tickets por usuario y tiempo medio de respuesta
+TopSocietyWithMostTickets                 = Top %s de las empresas con más tickets
+TicketsCreatedVersusClosedByMonth         = Tickets creados y cerrados en los últimos %s meses
+TicketsCreated                            = Creados
+TicketsClosed                             = Cerrados
+OpenTicketsByStatus                       = Distribución de los tickets abiertos por estado
+OpenTicketBacklogAge                      = Antigüedad de los tickets abiertos (desde la creación)
+BacklogAgeUnderDays                       = Menos de %s días
+BacklogAgeBetweenDays                     = De %s a %s días
+BacklogAgeOverDays                        = Más de %s días
+ShowSelectedDateTypes                     = Seleccione el tipo de fecha a mostrar
+
+# Email
+The                            = El
+TicketMessage                  = Mensaje del registro
+SeeTicketUrl                   = Ver el ticket
+AutoNotificationTicket         = Notificación por correo enviada automáticamente por
+TicketPublicInterfaceOtherName = Interfaz de gestión de los registros de seguridad y salud laboral y de peligro grave e inminente
+
+
+
+# Documento de ticket
+
+# Datos
+TicketDocument                 = Ficha del ticket
+Ticketdocument                 = Ficha del ticket
+ticketdocument.odt             = Ficha del ticket
+ticketdocument_custom.odt      = Ficha personalizada del ticket
+ticketdocument_events.odt      = Ficha del ticket con eventos
+ticketdocument_sign.odt        = Ficha del ticket con firma
+ticketdocument_event_sign.odt  = Ficha del ticket con evento y firma
+TicketSuccessMessage           = Mensaje de éxito del ticket
+TicketSuccessMessageSet        = El mensaje ha sido modificado correctamente
+TicketDocumentPDF              = FT-A4-HORIZONTAL
+TicketDocumentPDFDescription   = Mostrar la ficha del ticket
+GeneratedTicketDocumentDate    = Fecha de exportación de este ticket
+
+
+# Documento de proyecto
+
+# Plantilla ODT
+DigiriskTemplateDocumentProject = Modelos de documento de las fichas de proyecto de Digirisk
+DocumentModelPapripactA3Paysage = Modelos de documento de informe previsional sobre las tareas de los proyectos
+PapripactFullName               = Programa Anual de Prevención de Riesgos Laborales y de Mejora de las Condiciones de Trabajo
+
+# Documento de registro
+
+RegisterDocument     = Registro de accidentes de trabajo leves
+Registerdocument     = Registro de accidentes de trabajo leves
+RegisterDocumentsMin = registros de accidentes de trabajo leves
+registerdocument.odt = Registro de accidentes de trabajo leves
+
+#
+# Tools - Herramientas
+#
+
+# Datos
+Tools                                        = Herramientas
+DigiriskDataMigration                        = Gestión de los datos de migración
+DataMigrationImport                          = Importación de los datos del árbol de Digirisk
+DataMigrationImportDescription               = Importación de los datos del árbol de Digirisk WordPress en formato ZIP
+DataMigrationImportRisks                     = Importación de los datos de los riesgos de Digirisk
+DataMigrationImportRisksDescription          = Importación de los datos de los riesgos de Digirisk WordPress en formato ZIP
+ErrorFileNotWellFormatted                    = El archivo no tiene el formato correcto o está vacío. Debe adjuntar un archivo de importación procedente de Digirisk WordPress denominado DATE_OBJET_export.json
+ErrorFileNotWellFormattedZIP                 = El archivo no tiene el formato correcto o está vacío. Debe adjuntar un archivo de importación procedente de Digirisk WordPress denominado DATE_OBJET_export.zip
+ErrorJsonBadFormatted                        = El archivo JSON no tiene el formato correcto
+SuccessImport                                = Importación de los datos realizada correctamente
+DataMigrationImportRiskSigns                 = Importación de los datos de las señalizaciones de Digirisk
+DataMigrationImportRiskSignsDescription      = Importación de los datos de las señalizaciones de Digirisk WordPress en formato ZIP
+DataMigrationImportGlobal                    = Importación de los datos globales de Digirisk <br> (Árbol, riesgos y señalizaciones)
+DataMigrationImportGlobalDescription         = Importación de los datos globales de Digirisk WordPress en formato ZIP <br> (Árbol, riesgos y señalizaciones)
+DataMigrationExportGlobal                    = Exportación de los datos globales de Digirisk <br> (Árbol, riesgos y señalizaciones)
+DataMigrationExportGlobalDescription         = Exportación de los datos globales de Digirisk Dolibarr en formato ZIP <br> (Árbol, riesgos y señalizaciones)
+DataMigrationExportTree                      = Exportación del árbol de Digirisk <br> (Solo el árbol)
+DataMigrationExportTreeDescription           = Exportación del árbol de Digirisk Dolibarr en formato ZIP <br> (GP/UT visibles de la entidad actual, sin los riesgos ni las señalizaciones)
+DataMigrationImportGlobalDolibarrDescription = Importación de los datos globales de Digirisk Dolibarr en formato ZIP <br> (Árbol, riesgos y señalizaciones)
+DataMigrationTreeAlreadyImported             = Importación de los datos del árbol ya realizada
+DataMigrationRisksAlreadyImported            = Importación de los datos de los riesgos ya realizada
+DataMigrationRiskSignsAlreadyImported        = Importación de los datos de las señalizaciones ya realizada
+DataMigrationGlobalAlreadyImported           = Importación de los datos globales (Árbol, riesgos y señalizaciones) ya realizada
+AdvancedImport                               = Importación avanzada
+AdvancedImportDescription                    = Permite importar cada elemento de forma independiente (Árbol, riesgos y señalizaciones)
+DataMigrationWordPressToDolibarr             = Migración de los datos de WordPress a Dolibarr
+DataMigrationDolibarrToDolibarr              = Migración de los datos de Dolibarr a Dolibarr
+RepairRisks                                  = Reparar los riesgos
+NumberOfRisksCorrupted                       = Tiene %s riesgo(s) cuya categoría está dañada, vaya a la página "Herramientas" para repararlo(s)
+NoRiskToRepair                               = Ningún riesgo que reparar
+DigiriskElementSuccessfullyRepaired          = Elementos Digirisk (GP/UT) reparados correctamente
+RiskSuccessfullyRepaired                     = Riesgos reparados correctamente
+RiskAssessmentSuccessfullyRepaired           = Evaluaciones reparadas correctamente
+CorruptedCategoryOnRiskList                  = Lista de los riesgos cuya categoría está dañada
+
+# Clean - Limpiar
+Clean                                          = Limpiar
+CleanObject                                    = Limpiar los datos
+CleanDigiriskElementExistParentDigiriskElement = %d elementos Digirisk (GP/UT) tienen un padre no válido
+CleanDigiriskElement                           = Limpiar los elementos Digirisk (GP/UT)
+CleanRiskFkElement                             = %d riesgos tienen un GP/UT no válido
+CleanRiskStatus                                = %d riesgos tienen un estado no válido
+CleanRiskExistFkElement                        = %d riesgos son huérfanos
+CleanRiskExistRiskAssessment                   = %d riesgos no tienen ninguna evaluación
+CleanRisk                                      = Limpiar los riesgos
+CleanRiskAssessmentStatus                      = %d evaluaciones tienen un estado no válido
+CleanRiskAssessmentCotation                    = %d evaluaciones tienen una valoración vacía
+CleanRiskAssessmentExistFkRisk                 = %d evaluaciones son huérfanas
+CleanRiskAssessment                            = Limpiar las evaluaciones
+NoDigiriskElementToClean                       = Ningún elemento Digirisk (GP/UT) que limpiar
+NoRiskToClean                                  = Ningún riesgo que limpiar
+NoRiskAssessmentToClean                        = Ninguna evaluación que limpiar
+
+
+#
+# Otros
+#
+
+# Datos
+AT = al
+
+LabourInspectorName                 = DREETS
+UrlLabourInspector                  = https://travail-emploi.gouv.fr/ministere/organisation/article/dreets-directions-regionales-de-l-economie-de-l-emploi-du-travail-et-des
+IDCCTooltip                         = Este campo procede del módulo Digirisk para Dolibarr <br> La nomenclatura de los convenios colectivos procede de travail-emploi.gouv.fr
+NoEmailContact                      = Sin correo en este contacto
+AddMedia                            = Añadir un archivo multimedia
+NoMediaLinked                       = Ningún archivo multimedia vinculado
+UserGroup                           = Grupo de usuarios
+ReaderGroup                         = Grupo de lectores
+UserCreated                         = El usuario ha sido creado correctamente
+GetAPI                              = Uso de las rutas API de Digirisk con el método GET
+PostAPI                             = Uso de las rutas API de Digirisk con el método POST
+MinimizeMenu                        = Reducir el menú
+ActionsLine                         = Acciones
+PhotoWellSent                       = La foto ha sido añadida a la biblioteca multimedia
+PhotoNotSent                        = La foto no se ha enviado correctamente
+PhotoWellSaved                      = El o los archivos multimedia han sido añadidos correctamente
+PhotoNotSaved                       = El o los archivos multimedia no han sido añadidos
+UseCaptcha                          = Código gráfico (CAPTCHA)
+UseCaptchaDescription               = Uso del código gráfico (CAPTCHA) en las páginas de la interfaz pública
+GP/UTParticipation                  = Participación GP/UT
+LabourDoctorName                    = AMETRA
+LabourDoctorFirstName               = Médico del
+LabourDoctorLastName                = trabajo
+DashBoard                           = Panel de control
+Close                               = Cerrar
+DateRange                           = Intervalo de fechas
+UseDateRange                        = Utilizar el intervalo de fechas
+SiretNumber                         = N.º de identificación fiscal
+Society                             = Empresa
+MulticompanyTransverseModeEnabled   = La gestión centralizada de los usuarios y de los grupos en la entidad principal está activada.<br>Por lo tanto, no puede crear un usuario ni un grupo en esta entidad.<br>Acceda a la entidad principal para realizar esta adición.
+ManuelInputNBEmployees              = Introducir manualmente el número de trabajadores
+ManuelInputNBEmployeesDescription   = Si la opción está activada, puede introducir manualmente el número de trabajadores en la configuración de la empresa.<br>De lo contrario, el número de trabajadores se calcula.<br>Consulte la documentación para más información.
+ManuelInputNBWorkedHours            = Introducir manualmente el número de horas trabajadas
+ManuelInputNBWorkedHoursDescription = Si la opción está activada, puede introducir manualmente el número de horas trabajadas en la configuración de la empresa.<br>De lo contrario, el número de horas trabajadas se calcula.<br>Consulte la documentación para más información.
+ShowPatchNoteAgain                  = Mostrar la nota de actualización
+ShowPatchNoteAgainDescription       = Si la opción está activada, la nota de actualización de la versión actual vuelve a aparecer en la página de inicio de Digirisk.<br>(Requiere que la opción «Mostrar las notas de actualización desde GitHub» esté activada para ser visible.)
+HowToConfigureSetupConf             = Para configurar los datos de la empresa vinculados a Digirisk,<br>acceda a Digirisk - Configuración - Ajustes
+LabourDoctorNameFull                = Asociación de Médicos
+PermissionInheritedFromConfig       = Los permisos se heredan de la configuración general o de la configuración padre
+CategorieManagement                 = Gestión de las categorías
+ShowSelectedRiskTypes               = Seleccione los tipos de riesgo a mostrar
+CharRemaining                       = Caracteres restantes
+NumberOfLinkedFiles                 = Número de archivos adjuntos
+ChooseAnImage                       = Elegir una imagen
+
+# Action Plan - Gantt / Kanban
+ActionPlanGantt                     = Diagrama de Gantt
+ActionPlanKanban                    = Kanban
+ActionPlanView                      = Plan de acción
+ColumnDraft                         = Borrador
+ColumnInProgress                    = En curso
+ColumnInControl                     = Por controlar
+ColumnDone                          = Terminado
+NoTasks                             = Ninguna acción correctiva
+ActionPlanGlobalProgress            = Avance global del PAPRIPACT
+ActionPlanGlobalProgressInfo        = Media del avance de %s acción(es) correctiva(s)
+KanbanLoadMore                      = Ver más (%s)
+KanbanDisplay                       = Visualización del Kanban
+KanbanPageSize                      = Número de tarjetas por columna
+KanbanPageSizeDesc                  = Número de acciones correctivas mostradas de entrada en cada columna; las siguientes se cargan mediante el botón «Ver más» (mejora el rendimiento con volúmenes grandes)
+KanbanDraftMax                      = Umbral de la columna «Borrador»
+KanbanDraftMaxDesc                  = Avance máximo (%) para que una acción permanezca en la columna «Borrador»
+KanbanProgressMax                   = Umbral de la columna «En curso»
+KanbanProgressMaxDesc               = Avance máximo (%) para la columna «En curso»
+KanbanControlMax                    = Umbral de la columna «Por controlar»
+KanbanControlMaxDesc                = Avance máximo (%) para la columna «Por controlar»; por encima, la acción pasa a «Terminado»
+PlannedWorkload                     = Carga prevista
+TimeSpent                           = Tiempo dedicado
+LinkedRisk                          = Riesgo asociado
+TaskMovedTo                         = Tarea movida a %s
+
+AddCategory                        = Añadir una categoría
+SelectCategory                     = Elegir una categoría
+DateEndBeforeStart                 = Fecha de fin anterior a la de inicio
+InternalUsers                      = Usuarios internos
+ExternalContacts                   = Contactos externos
+AddContributor                     = Añadir un colaborador
+RemoveContact                      = Retirar el contacto
+ColumnWidth                        = Anchura
+ColumnGap                          = Espaciado
+ActionPlanExportCsv                = Descargar el PAPRIPACT en formato CSV
+ActionPlanExportA3                 = Descargar el PAPRIPACT en PDF A3 horizontal
+ActionPlanExportGantt              = Descargar el diagrama de Gantt como imagen PNG
+ActionPlanDisplayedProject         = Proyecto mostrado
+ActionPlanChangeProject            = Cambiar de proyecto
+ActionPlanDefaultProject           = Documento de evaluación de riesgos (por defecto)
+ActionPlanNoProjectConfigured      = Ningún proyecto configurado
+
+# ActionPlan — Registro de eventos
+ActionPlanLogging                  = Plan de acción — Historial de las modificaciones
+ActionPlanLoggingDescription       = Activar la creación de eventos al realizar modificaciones en el Kanban
+ActionPlanLogLabel                 = Modificación de la etiqueta
+ActionPlanLogLabelDesc             = Crear un evento cuando se modifica la etiqueta de una tarea
+ActionPlanLogWorkload              = Modificación de la carga
+ActionPlanLogWorkloadDesc          = Crear un evento cuando se modifica la carga prevista
+ActionPlanLogBudget                = Modificación del presupuesto
+ActionPlanLogBudgetDesc            = Crear un evento cuando se modifica el presupuesto
+ActionPlanLogContributorAdd        = Adición de un colaborador
+ActionPlanLogContributorAddDesc    = Crear un evento cuando se añade un colaborador
+ActionPlanLogContributorRemove     = Retirada de un colaborador
+ActionPlanLogContributorRemoveDesc = Crear un evento cuando se retira un colaborador
+ActionPlanLogProgress              = Modificación del avance
+ActionPlanLogProgressDesc          = Crear un evento cuando se modifica el avance
+ActionPlanLogTag                   = Modificación de las etiquetas
+ActionPlanLogTagDesc               = Crear un evento cuando se añade o se retira una etiqueta
+ActionPlanLogDateStart             = Modificación de la fecha de inicio
+ActionPlanLogDateStartDesc         = Crear un evento cuando se modifica la fecha de inicio
+ActionPlanLogDateEnd               = Modificación de la fecha de fin
+ActionPlanLogDateEndDesc           = Crear un evento cuando se modifica la fecha de fin
+ActionPlanTaskLabelChanged         = Etiqueta modificada: "%s" → "%s"
+ActionPlanTaskWorkloadChanged      = Carga modificada: %s → %s
+ActionPlanTaskBudgetChanged        = Presupuesto modificado: %s → %s
+ActionPlanTaskContributorAdded     = Colaborador añadido: %s
+ActionPlanTaskContributorRemoved   = Colaborador retirado: ID %s
+ActionPlanTaskProgressChanged      = Avance modificado: %s%% → %s%%
+ActionPlanTaskTagAdded             = Etiqueta añadida: %s
+ActionPlanTaskTagRemoved           = Etiqueta retirada: ID %s
+ActionPlanTaskDateStartChanged     = Fecha de inicio modificada: %s → %s
+ActionPlanTaskDateEndChanged       = Fecha de fin modificada: %s → %s
+
+# ===========================================================================
+# Filtros del plan de acción — issue #4907 (GP/UT, nivel de riesgo, etiquetas)
+# ===========================================================================
+ActionPlanElement                    = GP/UT
+ActionPlanFilterElementChildren      = Con los subelementos
+ActionPlanFilterElementChildrenHelp  = Incluir las acciones correctivas de los GP/UT hijos del GP/UT seleccionado
+ActionPlanFilterScale                = Nivel de riesgo
+ActionPlanFilterAllScales            = Todos los niveles
+ActionPlanFilterTags                 = Etiquetas
+ActionPlanFilterCount                = %s acción(es) correctiva(s) mostrada(s) de %s
+ActionPlanDictionaries               = Listas del Kanban
+ActionPlanDictionariesDesc           = Gestionar los valores propuestos en las listas del plan de acción y de los Kanban
+ActionPlanTagDictionary              = Etiquetas de las acciones correctivas
+ActionPlanTagDictionaryDesc          = Etiquetas (categorías de tareas) propuestas en las tarjetas y en el filtro del Kanban del plan de acción
+ActionPlanTicketDictionaries         = Diccionarios de los Kanban de tickets
+ActionPlanTicketDictionariesDesc     = Tipos, grupos y severidades que componen las columnas de los Kanban de tickets
+ActionPlanManageDictionary           = Gestionar
+
+# ===========================================================================
+# Tarjeta de acción de ticket — issue #4443 (interfaz de 1 clic)
+# ===========================================================================
+TicketActionCard                     = Acción de ticket
+TicketActionCardPickerIntro          = Seleccione un ticket para realizar una acción rápida en 1 clic.
+TicketActionCardStatusSection        = Estado
+TicketActionCardAssignSection        = Asignación
+TicketActionCardContentSection       = Contenido
+TicketActionCardDangerSection        = Zona sensible
+TicketActionMarkRead                 = Marcar como leído
+TicketActionInProgress               = Poner en curso
+TicketActionWaiting                  = Poner en espera
+TicketActionClose                    = Cerrar
+TicketActionCancel                   = Anular ticket
+TicketActionAssignSelf               = Asignármelo
+TicketActionAssignOther              = Asignar a...
+TicketActionAddMessage               = Añadir un mensaje
+TicketActionLinkAccident             = Vincular un accidente
+TicketActionOpenFull                 = Detalles completos
+TicketActionMarkedRead               = Ticket marcado como leído
+TicketActionInProgressDone           = Ticket puesto en curso
+TicketActionWaitingDone              = Ticket puesto en espera
+TicketActionClosedDone               = Ticket cerrado
+TicketActionCancelledDone            = Ticket anulado
+TicketActionAssignedSelfDone         = Ticket asignado a usted
+TicketActionAssignedOtherDone        = Ticket asignado
+TicketActionCloseConfirm             = Confirmar el cierre
+TicketActionCancelConfirm            = Confirmar la anulación
+TicketActionCardRegistresSection      = Información de los registros
+TicketMessageTitle                    = Título del mensaje
+TicketResponsibleAndProgress          = Responsable y avance
+TicketActionCardClassificationSection = Clasificación
+TicketActionCardDatesSection          = Fechas clave
+TicketActionCardIdentificationSection = Identificación
+TicketActionCardOtherFieldsSection    = Otra información
+TicketActionCardEventsSection         = Eventos recientes
+TicketActionCardRelatedSection        = Objetos vinculados
+UnknownFieldToUpdate                  = Campo desconocido: %s
+Saved                                 = Guardado
+SeeAll                                = Ver todo
+LayoutCustomize                       = Personalizar
+LayoutDone                            = Terminado
+LayoutControls                        = Controles de diseño
+LayoutWidthHalf                       = Media columna
+LayoutWidthFull                       = Columna entera
+LayoutWidthSpan                       = Ancho completo
+LayoutSaved                           = Diseño guardado
+LayoutReset                           = Restablecer
+LayoutResetTitle                      = Restablecer el diseño (volver a los valores por defecto)
+LayoutDensity                         = Densidad de visualización
+LayoutDensityCompact                  = Compacto
+LayoutDensityCozy                     = Cómodo
+LayoutDensitySpacious                 = Espacioso
+AddTag                                = Añadir una etiqueta
+TagAdded                              = Etiqueta añadida
+TagRemoved                            = Etiqueta retirada
+Preview                               = Vista previa
+OpenInNewTab                          = Abrir en una pestaña nueva
+FileDeleted                           = Archivo eliminado
+OtherTicket                           = otro ticket
+OtherTickets                          = otros tickets
+SeeOtherTicketsForThisCompany         = Ver el historial de tickets de este cliente
+StatusTimeline                        = Cronología del estado
+WatchTicket                           = Seguir este ticket
+UnwatchTicket                         = Dejar de seguir este ticket
+TicketWatched                         = Ticket seguido
+TicketUnwatched                       = Ticket retirado del seguimiento
+WatchedTicket                         = Ticket seguido
+WatchedOnly                           = Solo los seguidos
+AllTickets                            = Todos
+NoWatchedTicket                       = Ningún ticket seguido
+FileUploaded                          = Archivo enviado
+UploadFile                            = Elegir un archivo
+OrDropAnywhere                        = o arrastre y suelte sobre la tarjeta
+Messages                              = Mensajes
+TypeYourReply                         = Escriba su respuesta…
+PrivateMessage                        = Mensaje privado
+Send                                  = Enviar
+NoMessageYet                          = Ningún mensaje por el momento
+BeFirstToReply                        = Sea el primero en responder
+MessagePosted                         = Mensaje enviado
+MessageEdited                         = Mensaje modificado
+MessageDeleted                        = Mensaje eliminado
+ConfirmDeleteMessage                  = ¿Eliminar este mensaje?
+ReplyByEmail                          = Enviar por correo
+SentByMail                            = Enviado por correo
+MailSentToNRecipients                 = correo enviado a %d destinatario(s)
+MailNotSent                           = error al enviar el correo
+NoRecipientFound                      = ningún destinatario encontrado
+OriginalMessage                       = Mensaje original
+JustNow                               = ahora mismo
+NMinAgo                               = hace %d min
+NHAgo                                 = hace %d h
+NDAgo                                 = hace %d d
+NAttachedFiles                        = %d archivo(s) adjunto(s)
+Quote                                 = Citar
+NotAllowed                            = Acción no autorizada
+Private                               = Privado
+Unknown                               = Desconocido
+LayoutTagsMode                        = Visualización de las etiquetas
+LayoutTagsModeChips                   = Lista completa (chips)
+LayoutTagsModeSelector                = Selector desplegable
+LayoutActionsMode                     = Visualización de las acciones
+LayoutActionsModeBar                  = Barra de acciones
+LayoutActionsModeMenu                 = Menú (⋮)
+Move                                  = Mover
+Hide                                  = Ocultar
+Show                                  = Mostrar
+
+# ===========================================================================
+# Kanban de tickets — configuración del registro de eventos — issue #4753
+# ===========================================================================
+TicketKanban                           = Kanban de tickets
+TicketKanbanLogging                    = Kanban de tickets — Historial de las modificaciones
+TicketKanbanLoggingDescription         = Activar la creación de eventos al realizar modificaciones en el kanban
+TicketKanbanLogStatus                  = Modificación del estado
+TicketKanbanLogStatusDesc              = Crear un evento cuando se modifica el estado de un ticket desde el kanban
+TicketKanbanLogAssignee                = Modificación del asignado
+TicketKanbanLogAssigneeDesc            = Crear un evento cuando se modifica el asignado de un ticket desde el kanban
+TicketKanbanLogCategoryAdd             = Adición de una etiqueta
+TicketKanbanLogCategoryAddDesc         = Crear un evento cuando se añade una etiqueta a un ticket desde el kanban
+TicketKanbanLogCategoryRemove          = Retirada de una etiqueta
+TicketKanbanLogCategoryRemoveDesc      = Crear un evento cuando se retira una etiqueta de un ticket desde el kanban
+TicketKanbanLogType                    = Modificación del tipo
+TicketKanbanLogTypeDesc                = Crear un evento cuando se modifica el tipo de un ticket desde el kanban
+TicketKanbanLogGroup                   = Modificación del grupo
+TicketKanbanLogGroupDesc               = Crear un evento cuando se modifica el grupo de un ticket desde el kanban
+TicketKanbanLogSeverity                = Modificación de la severidad
+TicketKanbanLogSeverityDesc            = Crear un evento cuando se modifica la severidad de un ticket desde el kanban
+TicketKanbanLogSubject                 = Modificación del asunto
+TicketKanbanLogSubjectDesc             = Crear un evento cuando se modifica el asunto de un ticket desde el kanban
+TicketKanbanLogDeadline                = Modificación de la fecha límite
+TicketKanbanLogDeadlineDesc            = Crear un evento cuando se modifica la fecha límite de un ticket desde el kanban
+TicketKanbanClosedLimit                = Límite de tickets cerrados
+TicketKanbanClosedLimitDesc            = Número máximo de tickets cerrados/anulados mostrados en el kanban (0 = ilimitado)
+
+# ===========================================================================
+# Ticket — trazabilidad de las modificaciones — issue #4885
+# ===========================================================================
+TicketLogModifications                 = Trazabilidad de las modificaciones
+TicketLogModificationsDesc             = Crear un evento por cada edición realizada desde la ficha del ticket (asunto, mensaje, registros, asignado, tercero, proyecto, avance, estado, tareas, documentos)
+TicketMessageEdited                    = Mensaje modificado
+TicketMessageDeleted                   = Mensaje eliminado
+TicketTaskCreated                      = Tarea creada: %s
+TicketDocumentGenerated                = Documento generado
+TicketFileDeleted                      = Archivo eliminado
+
+# Panel de creación rápida de ticket
+SelectNothing                          = — Seleccionar —
+QuickCreateTicket                      = Crear rápidamente un ticket
+TicketSubjectPlaceholder               = Título del ticket...
+TicketInitialMessage                   = Mensaje inicial
+OptionalDescription                    = Descripción (opcional)...
+Unassigned                             = Sin asignar
+QuickCreateAttachments                 = Archivos adjuntos
+QuickCreateDropzone                    = Arrastre y suelte o haga clic para seleccionar
+QuickCreateDropzoneActive              = Suelte aquí…
+QuickCreateAttachmentHint              = Formatos aceptados: imágenes, PDF, documentos. Máx. 10 MB por archivo.
+QuickCreateTicketSuccess               = Ticket %s creado correctamente.
+
+# MeteoVigilance - Alerta meteorológica Météo-France
+MeteoVigilance = Alerta meteorológica Météo-France
+MeteoVigilancePanelTitle = Alerta %s
+MeteoVigilanceAdvice2 = Esté atento
+MeteoVigilanceAdvice3 = Esté muy vigilante
+MeteoVigilanceAdvice4 = Vigilancia absoluta
+MeteoVigilanceUpdatedAt = Actualizado %s
+MeteoVigilanceEnabled = Activar la alerta meteorológica
+MeteoVigilanceEnabledDescription = Muestra el widget de alerta meteorológica Météo-France en el panel de control (y la banda de alerta en caso de alerta naranja/roja).
+MeteoVigilanceLevel = Nivel de alerta
+MeteoVigilanceActivePhenomena = Fenómenos activos
+MeteoVigilanceNoAlert = Ninguna alerta particular
+MeteoVigilanceSource = Fuente
+MeteoVigilanceSeeOnMeteoFrance = Ver en vigilance.meteofrance.fr
+MeteoVigilanceNotConfigured = Clave API de Météo-France no configurada — haga clic para configurarla
+MeteoVigilanceUnknownDepartment = Departamento de la empresa no determinado
+MeteoVigilanceUnavailable = Datos de alerta momentáneamente no disponibles
+MeteoVigilanceBannerTitle = Alerta %s en curso en el departamento %s
+MeteoVigilanceLevel1 = Verde
+MeteoVigilanceLevel2 = Amarillo
+MeteoVigilanceLevel3 = Naranja
+MeteoVigilanceLevel4 = Rojo
+MeteoVigilancePhenomenon1 = Viento fuerte
+MeteoVigilancePhenomenon2 = Lluvia e inundación
+MeteoVigilancePhenomenon3 = Tormentas
+MeteoVigilancePhenomenon4 = Crecidas
+MeteoVigilancePhenomenon5 = Nieve y hielo
+MeteoVigilancePhenomenon6 = Ola de calor
+MeteoVigilancePhenomenon7 = Frío extremo
+MeteoVigilancePhenomenon8 = Avalanchas
+MeteoVigilancePhenomenon9 = Oleaje e inundación costera
+MeteoVigilanceSetup = Configuración de la alerta meteorológica
+MeteoVigilanceApiKey = Clave API de Météo-France
+MeteoVigilanceApiKeyDescription = Clave API del portal Météo-France (cree una cuenta y una aplicación «Bulletin Vigilance» en <a href="https://portail-api.meteofrance.fr" target="_blank">portail-api.meteofrance.fr</a> para generar la clave).
+MeteoVigilanceDepartment = Código de departamento (anulación)
+MeteoVigilanceDepartmentDescription = Déjelo vacío para deducir automáticamente el departamento de la dirección de la empresa. Si no, introduzca un código (p. ej. 35, 2A).
+MeteoVigilanceCacheTTL = Duración de la caché (segundos)
+MeteoVigilanceCacheTTLDescription = Tiempo durante el cual los datos de la API se guardan en caché antes de una nueva llamada (por defecto 3600).
+MeteoVigilanceSettings = Configuración de la alerta meteorológica
+MeteoVigilanceRefreshNow = Actualizar ahora
+MeteoVigilanceRefreshed = Datos actualizados: alerta %s en el departamento %s
+
+# Sistema de conversación de tickets
+Conversation = Conversación
+PublicMessage = Mensaje público
+ConvTo = Para
+ConvCc = Cc
+
+SaveNote = Guardar la nota
+
+AddRecipient = Añadir un destinatario
+NoRecipientFound = Ningún destinatario
+
+AddFile = Añadir un archivo
+
+MentionAgents = Mencionar a agentes
+YouWereMentionedOnTicket = Ha sido mencionado en el ticket %s
+YouWereMentionedOnTicketBody = %s le ha mencionado en el ticket %s:
+
+Mentioned = Mencionado
+
+# Creación rápida móvil del plan de prevención
+MobileQuickCreation = Creación rápida móvil
+MobilePPInteriorCompany = Empresa usuaria (interior)
+MobilePPResponsibleAutoSign = Responsable (firma automáticamente)
+MobilePPSignatureSaved = Firma registrada
+MobilePPEditSignature = Modificar la firma
+MobilePPDrawSignatureHint = Dibuje su firma a continuación y guárdela. Se reutilizará en sus próximos planes.
+MobilePPClearSignature = Borrar
+MobilePPSaveSignature = Guardar mi firma
+MobilePPExteriorCompany = Empresa externa
+MobileSirenOrSiret = SIREN / SIRET
+MobileSirenOrSiretPlaceholder = 9 o 14 cifras
+MobilePPResponsibleToSign = Responsable que debe firmar
+MobilePPChooseExistingContact = Elegir un contacto existente
+MobilePPNewContact = Nuevo contacto
+MobilePPEmailForSignatureHelp = Este correo recibirá la solicitud de firma.
+MobilePPPeriod = Periodo de intervención
+MobilePPMaxOneYearHint = 1 año como máximo entre la fecha de inicio y la fecha de fin.
+MobilePPSubmit = Crear el plan de prevención
+MobilePPErrorNoSignature = Debe guardar su firma antes de crear el plan.
+MobilePPErrorEmptySignature = La firma está vacía.
+MobilePPErrorInvalidSiren = SIREN o SIRET no válido (se esperan 9 o 14 cifras).
+MobilePPErrorEndBeforeStart = La fecha de fin debe ser posterior a la fecha de inicio.
+MobilePPErrorMaxOneYear = La duración no puede superar 1 año.
+MobilePPErrorDatesRequired = Indique la fecha de inicio y la fecha de fin.
+MobilePPErrorStartRequired = Falta la fecha de inicio.
+MobilePPErrorEndRequired = Falta la fecha de fin.
+MobilePPErrorNoProject = No hay configurado ningún proyecto de plan de prevención por defecto.
+MobilePPCompanyFound = Empresa encontrada:
+MobilePPCompanyNotFound = No se ha encontrado ninguna empresa en la base de datos: se creará una nueva.
+MobilePPWarningEmailNotSent = El plan ha sido creado pero no se ha podido enviar el correo de firma.
+MobilePPWarningEmailNotConfigured = El plan ha sido creado pero el correo no está configurado: solicitud de firma no enviada.
+MobilePPCreated = Plan de prevención %s creado.
+MobilePPUpdated = Plan de prevención %s actualizado.
+MobilePPSignatureEmailSubject = Solicitud de firma del plan de prevención %s
+MobilePPSignatureEmailContent = Hola:<br><br>Le invitamos a firmar el plan de prevención relativo a %s.<br><br><a href="%s">Haga clic aquí para firmar</a><br><br>Atentamente.
+MobilePPSuccessTitle = Plan de prevención creado
+MobilePPSuccessText = El responsable interior ha firmado automáticamente. Se ha enviado una solicitud de firma a la empresa externa.
+MobilePPViewPlan = Ver el plan
+MobilePPCreateAnother = Crear otro plan
+MobileSuccessInteriorSigned = Responsable interior: firmado
+MobileSuccessExteriorNotified = Empresa externa: solicitud de firma enviada
+MobileSuccessExteriorNotSigned = Empresa externa: firma pendiente de recoger
+MobileSuccessExteriorNotNotified = Empresa externa: solicitud de firma no enviada
+MobileSuccessExteriorSigned = Empresa externa: firmado
+MobileSuccessDocumentGenerated = Documento del plan generado
+MobilePPWarningEmailNotSentDetail = No se ha podido enviar el correo de firma: %s
+MobilePPWarningNoRecipientEmail = ninguna dirección de correo válida para el responsable exterior
+MobilePPSignatureEmailSentTo = Solicitud de firma enviada a %s
+MobilePPExtSignatureTitle = Firma de la empresa externa
+MobilePPExtEmailSentOn = Solicitud enviada a %s el %s
+MobilePPExtEmailNotSent = Solicitud de firma no enviada: transmita el enlace o hágalo firmar ahora
+MobilePPSpreadDefaultsTitle = Visualización pública de la difusión
+MobilePPSpreadShowCount = Mostrar el número de firmantes
+MobilePPSpreadShowName = Mostrar el nombre y los apellidos
+MobilePPSpreadShowContact = Mostrar el teléfono y el correo
+MobilePPSpreadHidePublicNote = No mostrar la nota pública
+MobilePPExtAlreadySigned = Firmado el %s
+MobilePPExtSignNow = Hacer firmar ahora
+MobilePPExtResendEmail = Reenviar el correo
+MobilePPNoTagAvailable = No hay disponible ninguna etiqueta de plan de prevención.
+MobilePPCreateTag = Crear una etiqueta
+MobileSpreadShareTitle = Compartir la difusión
+MobileSpreadShareText = Haga escanear este código a las personas afectadas. Sin cuenta ni conexión, indican sus datos, depositan sus documentos y firman.
+MobileSpreadOpen = Abrir la difusión
+MobilePPRisks = Riesgos
+MobilePPAddRisk = Añadir un riesgo
+MobilePPRiskModalTitle = Elegir un riesgo
+MobilePPRiskComment = Comentario
+MobilePPRiskDescriptionPlaceholder = Describir el riesgo en el centro
+MobilePPNoRiskYet = Ningún riesgo añadido por el momento.
+MobilePPDeleteRiskTitle = Eliminar el riesgo
+MobilePPDeleteRiskConfirm = «%s» se va a retirar del plan, con su descripción, sus fotos y sus protecciones.
+MobilePPUserCompany = Empresa usuaria
+MobilePPUserCompanyShort = EU
+MobilePPConcernedCompanies = Afecta a
+MobilePPExteriorCompanyShort = EE
+MobilePPPriorFormalities = Trámites previos
+MobilePPPriorVisitDone = Inspección conjunta previa realizada
+MobilePPPriorVisitTextPlaceholder = Lo que se ha constatado durante la inspección
+MobileRiskCompanies = Empresas afectadas por los riesgos (móvil)
+CertificationDictionary = Certificaciones y habilitaciones
+MobilePPChooseExistingCompany = Elegir un tercero existente
+MobilePPOrFillManually = o introducir la información
+MobilePPProtections = Protecciones
+MobilePPAddProtection = Añadir una protección
+MobilePPProtectionModalTitle = Elegir una protección
+MobilePPMandatory = Obligatorio
+MobileProtections = Protecciones (móvil)
+MobilePPCertifications = Certificaciones obligatorias
+MobilePPAddCertification = Añadir una certificación
+MobileCertifications = Certificaciones (móvil)
+MobilePPUploadCertPhoto = Enviar una foto
+MobilePPErrorCreatingThirdparty = Error al crear el tercero.
+MobilePPErrorCreatingContact = Error al crear el contacto.
+MobilePPErrorUpdatingPlan = Error al actualizar el plan de prevención.
+MobilePPErrorCreatingPlan = Error al crear el plan de prevención.
+MobileSuccessViewDocument = Ver el documento
+MobileSuccessPlanSentByEmailOn = Plan de prevención enviado por correo el %s
+MobileSuccessExteriorSignedOn = Responsable de la Empresa Externa (EE): Firmado el %s
+MobileSuccessExteriorPendingSignature = Responsable de la Empresa Externa (EE): Pendiente de firma
+MobilePPDefaultsTitle = Valores por defecto (creación móvil)
+MobilePPDefaultDateStartToday = Fecha de inicio = fecha de hoy
+MobilePPDefaultDuration = Duración por defecto del periodo (días)
+MobilePPEmailAutoSend = Enviar automáticamente el correo de firma al crear
+
+# Creación rápida móvil del permiso de fuego
+MobileFPPreventionPlanHelp = La empresa externa y el periodo del plan seleccionado se retoman automáticamente.
+MobileFPPeriod = Lugar y periodo de los trabajos
+MobileFPMaxOneMonthHint = Un mes como máximo entre el inicio y el fin de los trabajos.
+MobileFPErrorMaxOneMonth = La duración no puede superar un mes.
+MobileFPErrorNoProject = No hay configurado ningún proyecto de permiso de fuego por defecto.
+MobileFPWorkTypes = Tipos de trabajos
+MobileFPAddWorkType = Añadir un tipo de trabajos
+MobileFPWorkTypeModalTitle = Elegir un tipo de trabajos
+MobileFPSubmit = Crear el permiso de fuego
+MobileFPCreated = Permiso de fuego %s creado.
+MobileFPUpdated = Permiso de fuego %s actualizado.
+MobileFPSignatureEmailSubject = Solicitud de firma del permiso de fuego %s
+MobileFPSignatureEmailContent = Hola:<br><br>Le invitamos a firmar el permiso de fuego para %s.<br><br><a href="%s">Haga clic aquí para firmar</a><br><br>Atentamente.
+MobileFPSuccessTitle = Permiso de fuego creado
+MobileFPViewPermit = Ver el permiso
+MobileFPCreateAnother = Crear otro permiso
+
+# PWA de Digirisk
+PwaApplication = App móvil
+PwaNavHome = Inicio
+PwaNavPreventionPlans = Planes
+PwaNavFirePermits = Permisos
+PwaNavMenu = Menú
+PwaNavFavoritesHint = Favoritos mostrados abajo (máx. %s)
+PwaNavAddFavorite = Añadir a favoritos
+PwaNavRemoveFavorite = Quitar de favoritos
+PwaHello = Hola %s
+PwaResultCount = %s resultado(s)
+AllStatus = Todos los estados
+PwaTilePreventionPlanInProgress = Planes en curso
+PwaTilePreventionPlanToSign = Planes por firmar
+PwaTileFirePermitInProgress = Permisos en curso
+PwaTileFirePermitToSign = Permisos por firmar
+
+# Acciones masivas sobre las tareas
+MassValidateTasks = Validar las tareas
+MassChangeTasksProject = Cambiar de proyecto
+ConfirmMassValidateTasksQuestion = ¿Está seguro de que desea validar las %s tarea(s) seleccionada(s)? Solo se validarán las tareas con estado borrador.
+ConfirmMassChangeTasksProjectQuestion = ¿Está seguro de que desea vincular las %s tarea(s) seleccionada(s) al proyecto elegido?
+MassValidateTasksSuccess = %s tarea(s) validada(s) de %s seleccionada(s)
+MassChangeTasksProjectSuccess = %s tarea(s) vinculada(s) al proyecto %s
+
+# PDF del plan de prevención
+PreventionPlanLegalNotice = El plan de prevención es un documento obligatorio destinado a prevenir los riesgos derivados de la interferencia entre las actividades de varias empresas en un mismo centro, conforme al artículo R4512-7 del Código de Trabajo francés.
+PreventionPlanUserCompany = Empresa Usuaria - EU
+PreventionPlanExteriorCompany = Empresa Externa - EE
+PreventionPlanUserCompanyResponsible = Responsable de la Empresa Usuaria (EU)
+PreventionPlanExteriorCompanyResponsible = Responsable de la Empresa Externa (EE)
+EmergencyNumbers = Números de emergencia
+Firefighters = Bomberos
+AnyEmergency = Cualquier emergencia
+PriorVisitIntro = La empresa usuaria ha procedido, previamente a la ejecución de la operación, a una inspección conjunta previa con fecha de %s. Durante esta visita, la empresa usuaria ha presentado los siguientes puntos (art. R. 4512-2 y R. 4512-3 del Código de Trabajo francés):
+PriorVisitCheckList = Lugares de trabajo|Instalaciones que allí se encuentran|Materiales eventualmente puestos a disposición de las empresas externas|Delimitar el sector de intervención de las empresas externas|Señalizar las zonas de este sector que pueden presentar peligros para los trabajadores|Indicar las vías de circulación que podrán utilizar los trabajadores, así como los vehículos y máquinas de todo tipo pertenecientes a las empresas externas|Definir las vías de acceso de los trabajadores a los locales e instalaciones destinados al uso de las EE (en particular las instalaciones sanitarias, vestuarios colectivos y locales de restauración)
+PriorVisitComments = Se han recogido los siguientes comentarios:
+InterventionPeriodSentence = Este plan comienza el %s y finaliza el %s. Las intervenciones se desarrollarán en los siguientes horarios:
+RiskAnalysisIntro = Ha previsto %s intervención(es) para este plan de prevención: a continuación, el detalle de las acciones previstas, los riesgos generados y los medios de prevención implantados.
+PreventionPlanAttendants = Intervinientes: Empresa Externa (EE) y subcontratistas
+Morning = Mañana
+Afternoon = Tarde
+Signatures = Firmas
+SignaturePending = Pendiente
+PreventionPlanRiskPhotos = Fotos del riesgo
+InterventionPeriodOnly = Este plan comienza el %s y finaliza el %s.
+
+DigiRisk=DigiRisk
+DigiriskIdentification=DESCRIPCIÓN Y CARACTERÍSTICAS
+DigiriskSecurity=SEGURIDAD
+DigiriskUserManual=MODO DE EMPLEO SIMPLIFICADO
+DigiriskQualification=CUALIFICACIÓN Y HABILITACIÓN
+DigiriskHygiene=HIGIENE Y LIMPIEZA
+DigiriskMaintenance=MANTENIMIENTO Y CONTROLES
+DangerCategory=Familia de riesgo
+SelectDangerCategory=Elegir una familia de riesgo
+DescribeRiskOnProduct=Describir el riesgo en este producto...
+ConfirmDeleteProductRisk=¿Eliminar este riesgo?
+AddProductRisk=Añadir un riesgo de producto
+ClickToAddContent=Haga clic para añadir contenido...
+AddProtection=Añadir una protección
+
+SelectProtection=Elegir una protección EPI
+TechnicalSheet=Ficha técnica
+DigiriskRisks=RIESGOS Y PROTECCIONES
+MobileSuccessInteriorSignedOn=Responsable de la Empresa Usuaria (EU): Firmado el %s
+
+MobileSuccessPlanSentByEmailOn = Plan de prevención enviado por correo el %s
+MobileSuccessExteriorSignedOn = Responsable de la Empresa Externa (EE): Firmado el %s
+MobileSuccessExteriorPendingSignature = Responsable de la Empresa Externa (EE): Pendiente de firma
+
+MobilePPErrorInvalidEmail = Respete el formato del correo electrónico.
+MobilePPErrorInvalidPhone = Respete el formato del teléfono.
+MobilePPExtSendEmail = Enviar el correo
+MobilePPErrorMailServerNotConfigured = Su servidor de correo no está configurado, contacte con el administrador.
+MobilePPDoliletterNotInstalled = El módulo Doliletter no está instalado. La difusión de los planes de prevención y permisos de fuego no estará disponible (contacte con su administrador)
+
+# Estados y tipos para las ayudas contextuales
+preventionplan = Plan de prevención
+Locked = Bloqueado
+InProgress = En curso
+ValidatePendingSignature = Pendiente de firma
+Archived = Archivado
+
+ProductFIChaptersManagement=Personalización de los capítulos de la ficha de instrucción
+ProductFIChaptersManagementSub=Personalización de la pestaña "Ficha de instrucción" y de la pestaña "Riesgos" en la ficha del producto
+DefaultContent=Contenido por defecto
+CustomSvgUploaded=SVG personalizado
+DeleteCustomSvg=Eliminar
+DefaultSvgUsed=SVG por defecto
+
+PwaTilePreventionPlanLocked = Planes validados
+PwaTileFirePermitLocked = Permisos validados
+
+# ===========================================================================
+# Diccionario de columnas del Kanban del plan de acción — issue #5017
+# ===========================================================================
+ActionPlanColumnDictionary           = Columnas del Kanban del plan de acción
+ActionPlanColumnDictionaryDesc       = Columnas mostradas en el Kanban del PAPRIPACT cuando el modo diccionario está activado: etiqueta, rango de avance, color e icono
+KanbanColumnSource                   = Origen de las columnas
+KanbanColumnSourceDesc               = Dividir el Kanban con los umbrales de porcentaje indicados a continuación (funcionamiento histórico) o con el diccionario de columnas
+KanbanColumnSourceThresholds         = Umbrales de porcentaje (por defecto)
+KanbanColumnSourceDictionary         = Diccionario de columnas
+ActionPlanColumnProgressHelp         = Límites de avance cubiertos por la columna, de 0 a 100
+ActionPlanColumnColorHelp            = Color hexadecimal de la columna, por ejemplo #3085d6
+ActionPlanColumnPictoHelp            = Nombre de icono Font Awesome, por ejemplo fa-check
+Progress_min                         = Avance mín.
+Progress_max                         = Avance máx.
+Picto                                = Icono
+
+# Seguimiento del tiempo dedicado
+GenerateTimeSpentReport = Generar el seguimiento de tiempo (PDF)
+TimeSpentReport = Seguimiento del tiempo dedicado
+TimeSpentReportUsersHelp = Déjelo vacío para incluir a todas las personas que hayan registrado tiempo en este proyecto.
+TimeSpentReportSummary = Resumen por usuario
+TimeSpentReportGrandTotal = Total general
+TimeSpentReportGeneratedAt = Generado el
+TimeSpentReportWholePeriod = Desde el inicio del proyecto
+TimeSpentReportNoData = Ningún tiempo dedicado corresponde a los usuarios y al periodo seleccionados.
+TimeSpentDocumentPDFDescription = Tiempo dedicado a un proyecto, agrupado por usuario
+
+# Paridad del permiso de fuego móvil con el plan de prevención - issue #5042
+MobileProgress = Avance
+MobileStepDone = HECHO
+MobileStepInProgress = EN CURSO
+MobileStepTodo = POR HACER
+MobileStepSignedOn = FIRMADO EL
+MobilePPStepCreated = PP creado
+MobileFPStepCreated = PF creado
+MobileStepUserCompanyResponsible = Resp. EU
+MobileStepExteriorCompanyResponsible = Resp. EE
+MobileStepLock = Bloquear
+MobileStepArchive = Archivar
+MobileLock = Bloquear
+MobileResponsibleShort = Resp.
+MobileMailSentTo = Correo enviado a
+MobilePPMotif = Motivo de la intervención
+MobilePPSchedules = Horarios de intervención
+MobilePPConfigHours = Configure aquí sus horarios
+MobilePPCopyCompanyHours = Copiar los horarios de la empresa
+FirePermitUserCompany = Empresa Usuaria - EU
+FirePermitExteriorCompany = Empresa Externa - EE
+MobileFPMotif = Motivo de los trabajos
+MobileFPMotifPlaceholder = Ej.: soldadura en estructura
+MobileFPNoMotif = Ningún motivo indicado
+MobileFPSchedules = Horarios de los trabajos
+MobileFPWorkTypeDescriptionPlaceholder = Describir los trabajos en el centro
+MobileFPNoWorkTypeYet = Ningún tipo de trabajos añadido por el momento.
+MobileFPDeleteWorkTypeTitle = Eliminar el tipo de trabajos
+MobileFPDeleteWorkTypeConfirm = «%s» se va a retirar del permiso, con su descripción, su material, sus fotos y sus protecciones.
+MobileFPNoTagAvailable = No hay disponible ninguna etiqueta de permiso de fuego.
+MobileFPErrorUpdatingPermit = Error al actualizar el permiso de fuego.
+MobileFPErrorCreatingPermit = Error al crear el permiso de fuego.
+MobileFPLockNeedsSignature = El permiso debe estar firmado antes de poder bloquearlo.
+MobileFPSpreadAvailableOnceSignedAndLocked = La difusión estará disponible en cuanto el permiso esté firmado por los responsables y bloqueado.
+MobileFPDefaultDateStartToday = Fecha de inicio = fecha de hoy
+MobileFPDefaultDuration = Duración por defecto del periodo (días)
+firepermit = Permiso de fuego
+ErrorRecordIsLocked = Este registro está bloqueado, ya no se puede modificar.
+MobilePPEmailTemplateExt = Plantilla de correo para el responsable de la empresa externa
+MobilePPEmailTemplateInt = Plantilla de correo para los intervinientes de la empresa externa
+
+#
+# ListingRisksDocument PDF - Listado de riesgos en formato PDF
+#
+
+ListingRisksDocumentPDF            = Listado de riesgos PDF
+ListingRisksDocumentPDFDescription = Listado de riesgos en PDF nativo, abierto sobre el mini documento de evaluación de riesgos del elemento
+ListingRisksDocumentPDFTitle       = EVALUACIÓN DE RIESGOS
+ListingRisksEstablishment          = Centro de trabajo
+ListingRisksCoverContent           = Contenido
+ListingRisksCoverHierarchy         = Jerarquía
+ListingRisksCoverDuerpFollowUp     = Seguimiento del documento de evaluación de riesgos
+ListingRisksCoverEmergencyNumbers  = Números de emergencia
+ListingRisksCoverReportIncident    = Notificar un accidente o un problema
+ListingRisksCoverRegisters         = Registros de seguridad y salud laboral y de peligro grave e inminente
+ListingRisksCoverIllustration      = Imagen de ilustración
+NoPreventionOfficerAssigned        = Ningún responsable de prevención designado
+NoEmergencyNumberConfigured        = Ningún número de emergencia configurado
+NoResponsibleAssigned              = Ningún responsable designado
+ListingRisksLegalTitle             = Marco reglamentario
+RiskDefinitionTitle                = Definición de un riesgo
+RiskDefinitionText                 = Riesgo: n. masc. Peligro o inconveniente al que uno se expone. Hacer algo por su cuenta y riesgo, asumiendo toda la responsabilidad de las consecuencias. Un riesgo calculado. Correr riesgos: exponerse a un peligro.
+DangerDefinitionTitle              = Definición de un peligro
+DangerDefinitionText               = Peligro: n. masc. (del latín popular dominiarium «poder», de dominus «amo»; originalmente el hecho de estar a merced de alguien). Lo que amenaza la seguridad o la vida de alguien; lo que puede comprometer una situación, una empresa, etc.
+SingleDocumentTitle                = El documento de evaluación de riesgos
+SingleDocumentText                 = El documento de evaluación de riesgos se rige por los artículos R4121-1 a 4 del Código de Trabajo francés. Los principios generales de prevención imponen el orden de tratamiento del riesgo.
+PreventionPrinciplesTitle          = Los principios generales de prevención - Artículo L4121-2
+PreventionPrinciplesIntro          = El empresario aplica las medidas previstas en el artículo L. 4121-1 sobre la base de los siguientes principios generales de prevención:
+PreventionPrinciple1               = Evitar los riesgos.
+PreventionPrinciple2               = Evaluar los riesgos que no se pueden evitar.
+PreventionPrinciple3               = Combatir los riesgos en su origen.
+PreventionPrinciple4               = Adaptar el trabajo a la persona, en particular en lo que respecta a la concepción de los puestos de trabajo, así como a la elección de los equipos de trabajo y de los métodos de trabajo y de producción, con vistas en especial a limitar el trabajo monótono y el trabajo a ritmo impuesto y a reducir sus efectos sobre la salud.
+PreventionPrinciple5               = Tener en cuenta la evolución de la técnica.
+PreventionPrinciple6               = Sustituir lo peligroso por lo que no lo es o por lo que entraña menos peligro.
+PreventionPrinciple7               = Planificar la prevención integrando, en un conjunto coherente, la técnica, la organización del trabajo, las condiciones de trabajo, las relaciones sociales y la influencia de los factores ambientales, en particular los riesgos vinculados al acoso moral y al acoso sexual, así como los vinculados a las conductas sexistas.
+PreventionPrinciple8               = Adoptar medidas de protección colectiva dándoles prioridad sobre las medidas de protección individual.
+PreventionPrinciple9               = Dar las instrucciones adecuadas a los trabajadores.
+ListingRisksCotationMethodTitle    = Método de cálculo de las valoraciones
+ListingRisksCotationMethodText     = La valoración de un riesgo es una puntuación de 0 a 100 asignada durante su evaluación. El nivel de riesgo que figura en el listado se deriva directamente de ella, según la tabla siguiente.
+ListingRisksCotationLevel          = Nivel
+ListingRisksCotationRange          = Valoración
+ListingRisksCotationMeaning        = Significado
+ListingRisksCotationAction         = Actuación a seguir
+ListingRisksCotationAction1        = Mantener los medios de prevención existentes.
+ListingRisksCotationAction2        = Incluir una acción en el programa anual de prevención.
+ListingRisksCotationAction3        = Emprender una acción de prevención a corto plazo.
+ListingRisksCotationAction4        = Actuar de inmediato, la exposición debe cesar.
+ListingRisksListTitle              = Lista de riesgos
+ListingRisksActionPlan             = Acciones del programa anual de prevención
+ListingRisksCotationColumn         = Val.
+ListingRisksRiskColumn             = Riesgo
+ListingRisksAssessmentColumn       = Información sobre la evaluación
+NoRiskAssessed                     = Ningún riesgo evaluado en este ámbito

--- a/langs/es_ES/index.php
+++ b/langs/es_ES/index.php
@@ -1,0 +1,2 @@
+<?php
+//Silence is golden

--- a/langs/fr_FR/digiriskdolibarr.lang
+++ b/langs/fr_FR/digiriskdolibarr.lang
@@ -1273,7 +1273,7 @@ HasNotBeenUnlinkSharedF            = n'a pas été déliée
 RiskSignSharedTooltip              = Cette option permet de partager les signalisations. <br> INFO : Si vous souhaitez pouvoir afficher les tâches, il faut activer l'option de partage des projets.
 ShowInheritedRiskSigns             = Signalisations héritées
 ShowInheritedRiskSignsDescription  = Afficher les signalisations héritées dans les documents et les listings
-DigiriskElementInheritedRiskSignsList Liste des signalisations héritées
+DigiriskElementInheritedRiskSignsList = Liste des signalisations héritées
 ConfirmImportSharedRiskSigns       = Veuillez choisir les signalisations partagées à importer
 RiskSignSharedWithEntityRefLabel   = Partage de la signalisation %s avec
 RiskSignUnlinkedFromEntityRefLabel = Dissociation de la signalisation %s avec
@@ -2229,6 +2229,8 @@ DangerCategory=Famille de risque
 SelectDangerCategory=Choisir une famille de risque
 DescribeRiskOnProduct=Decrire le risque sur ce produit...
 ConfirmDeleteProductRisk=Supprimer ce risque ?
+AddProductRisk=Ajouter un risque produit
+ClickToAddContent=Cliquer pour ajouter du contenu...
 AddProtection=Ajouter une protection
 
 SelectProtection=Choisir une protection EPI

--- a/langs/it_IT/digiriskdolibarr.lang
+++ b/langs/it_IT/digiriskdolibarr.lang
@@ -1,0 +1,2387 @@
+# Copyright (C) 2021-2023 EVARISK <technique@evarisk.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#
+# Generale
+#
+
+# Module label 'ModuleDigiriskdolibarrName'
+ModuleDigiriskdolibarrName = Digirisk
+
+# Module description 'ModuleDigiriskdolibarrDesc'
+ModuleDigiriskdolibarrDesc = Digirisk per Dolibarr
+
+# Modulo Saturne mancante
+SaturneModuleMissing = Il modulo Saturne è richiesto da Digirisk. Scaricalo gratuitamente da Dolistore (https://dolistore.com/en/modules/1906-Saturne.html) e installalo prima di attivare Digirisk.
+
+# Colonna delle immagini tutorial delle pagine di configurazione
+TutoImage = Immagine
+
+#
+# Pagina di amministrazione
+#
+
+# Dati
+DigiriskdolibarrSetup       = Configurazione del modulo Digirisk
+DigiriskdolibarrSetupPage        = Pagina di configurazione del modulo Digirisk
+AgendaModuleRequired        = Per garantire la tracciabilità delle azioni in Digirisk, assicurati che il modulo Agenda sia attivo
+DigiriskDolibarrDescription = Digirisk per Dolibarr
+HowToSetupOtherModules      = Per ulteriori funzionalità in Digirisk, puoi attivare numerosi moduli (gestione fornitori, fatture, ecc.) a questo link:
+ConfigMyModules             = Configurazione dei moduli
+AvoidLogoProblems              = Per evitare problemi con i loghi nei documenti generati, consulta questi consigli di configurazione:
+LogoHelpLink                = https://wiki.dolibarr.org/index.php?title=Premiers_paramétrages
+SecurityConfiguration       = Configurazione dei dati di sicurezza
+SocialConfiguration          = Configurazione dei dati sociali
+Uncompleted                     = Non compilato
+DigiriskData                 = Dati configurabili di Digirisk
+DigiriskManagement          = Reindirizzamento dopo l'accesso al sito
+DigiriskDescription          = Reindirizzamento predefinito alla pagina di benvenuto di Digirisk anziché a quella di Dolibarr.
+HowToSetupIHM                   = Per ulteriori possibilità di visualizzazione di Dolibarr (configurazione dell'immagine di sfondo, ecc.), puoi accedere a questo link:
+ConfigIHM                    = Configurazione della visualizzazione
+ConfigDico                     = Accedi alla pagina di configurazione dei dizionari
+LinkedProject               = Progetto collegato
+DigiriskUpdate                  = Aggiornamento di Digirisk:
+Security                       = Sicurezza
+HowToSharedElement          = Per maggiori informazioni sulla configurazione degli elementi condivisi, accedi a questo link:
+
+HowToSharedElementLink        = https://wiki.dolibarr.org/index.php?title=Module_Digirisk#Configuration
+ConfigSharedElement         = Configurazione degli elementi condivisi (rischi/segnaletica)
+DisabledSharedElement       = Opzione disattivata perché Multi-company non è attivo o la configurazione degli elementi condivisi (rischi/segnaletica) non è stata effettuata
+DigiriskEventAutoDesc       = Definisci qui gli eventi per i quali Digirisk creerà automaticamente una voce nell'agenda. Ogni evento contiene le informazioni relative all'azione effettuata.
+DigiriskActionsEvents       = Eventi per i quali Digirisk deve inserire automaticamente un evento nell'agenda.
+DigiriskDolibarr            = Digirisk
+Create                      = Crea
+
+# Ticket
+MultiCompanyTicketPublicInterfaceConfig = Configurazione dell'interfaccia pubblica dei ticket multi-azienda
+Subtitle                                = Sottotitolo
+
+# DigiriskElement
+DigiriskElementDepthGraph            = Livello di profondità nei grafici degli elementi Digirisk
+DigiriskElementDepthGraphDescription = Questa opzione consente di scegliere il livello di profondità nei grafici degli elementi Digirisk <br> Predefinito: livello 1
+
+# WHSRegister = Registro di sicurezza e salute sul lavoro
+TicketsPublicInterfaceConfig         = Configurazione dell'interfaccia pubblica dei ticket
+WHSRegister                          = Registro di sicurezza e salute sul lavoro
+CurrentTicketPublicInterfaceURL      = URL dell'interfaccia pubblica dei ticket
+MulticompanyTicketPublicInterfaceURL = URL dell'interfaccia pubblica dei ticket multi-azienda
+OriginURL                            = URL di origine
+ShortURL                             = URL abbreviato
+ExternalURL                          = URL esterno
+AddExtraField                        = Crea un campo aggiuntivo
+IfEmptyVisibleAllCategories          = Se vuoto, visibile in tutte le categorie
+
+# DigiQuali Sheet - Modelli
+LinkDigiriskdolibarr_digiriskstandard                 = Attiva il collegamento con le entità principali Digirisk Standard
+LinkDigiriskdolibarr_digiriskstandardDescription      = Consente il collegamento tra le entità standard Digirisk e i modelli
+LinkDigiriskdolibarr_digiriskelement                  = Attiva il collegamento con i raggruppamenti e le unità di lavoro
+LinkDigiriskdolibarr_digiriskelementDescription       = Consente il collegamento tra i raggruppamenti e le unità di lavoro e i modelli
+LinkDigiriskdolibarr_risk                             = Attiva il collegamento con i rischi
+LinkDigiriskdolibarr_riskDescription                  = Consente il collegamento tra i rischi e i modelli
+LinkDigiriskdolibarr_riskassessment                   = Attiva il collegamento con le valutazioni
+LinkDigiriskdolibarr_riskassessmentDescription        = Consente il collegamento tra le valutazioni e i modelli
+LinkDigiriskdolibarr_evaluator                        = Attiva il collegamento con i valutatori
+LinkDigiriskdolibarr_evaluatorDescription             = Consente il collegamento tra i valutatori e i modelli
+LinkDigiriskdolibarr_risksign                         = Attiva il collegamento con la segnaletica
+LinkDigiriskdolibarr_risksignDescription              = Consente il collegamento tra la segnaletica e i modelli
+LinkDigiriskdolibarr_preventionplan                   = Attiva il collegamento con i piani di prevenzione
+LinkDigiriskdolibarr_preventionplanDescription        = Consente il collegamento tra i piani di prevenzione e i modelli
+LinkDigiriskdolibarr_firepermit                       = Attiva il collegamento con i permessi di lavoro a caldo
+LinkDigiriskdolibarr_firepermitDescription            = Consente il collegamento tra i permessi di lavoro a caldo e i modelli
+LinkDigiriskdolibarr_accident                         = Attiva il collegamento con gli infortuni
+LinkDigiriskdolibarr_accidentDescription              = Consente il collegamento tra gli infortuni e i modelli
+LinkDigiriskdolibarr_accidentinvestigation            = Attiva il collegamento con le indagini sugli infortuni
+LinkDigiriskdolibarr_accidentinvestigationDescription = Consente il collegamento tra le indagini e i modelli
+
+#
+# DigiriskDolibarr
+#
+
+# Permesso
+LireDigirisk                 = Consultare il cruscotto Digirisk
+ReadDigirisk                 = Consultare il cruscotto Digirisk (lettura)
+YouDontHaveTheRightToSeeThis = Non hai il diritto di visualizzare i raggruppamenti e le unità di lavoro
+CanNotDoThis                 = Non hai il diritto di fare questo
+EnableDigiriskdolibarr       = Attiva il modulo DigiriskDolibarr per accedere a questa pagina
+
+# Dati
+DigiriskMenu          = Aggiungi informazioni sulla tua azienda/organizzazione. Fai clic sul pulsante "Salva" in fondo alla pagina per conservarle
+DigiriskConfigSociety = Configurazione dell'azienda
+PermissionDenied      = Permesso negato
+AddUser               = Crea un utente
+StartDate             = Data di inizio
+EndDate               = Data di fine
+NoPhoneNumber         = Nessun numero di telefono
+HasBeenCreatedF       = è stata creata
+HasBeenCreatedM       = è stato creato
+HasNotBeenCreatedF    = non è stata creata
+HasNotBeenCreatedM    = non è stato creato
+YourDocuments         = Documenti
+NoData                = N/D
+HasBeenEditedF        = è stata modificata
+HasBeenEditedM        = è stato modificato
+HasNotBeenEditedF     = non è stata modificata
+HasNotBeenEditedM     = non è stato modificato
+
+HasBeenDeletedF    = è stata eliminata
+HasBeenDeletedM    = è stato eliminato
+HasNotBeenDeletedF = non è stata eliminata
+HasNotBeenDeletedM = non è stato eliminato
+
+DigiriskUserGroup                 = Digirisk - Utenti
+DigiriskUserGroupDescription      = Il gruppo utenti DigiRisk ha i permessi per consultare e modificare gli oggetti relativi a DigiRisk
+DigiriskAdminUserGroup            = DigiRisk - Amministratori
+DigiriskAdminUserGroupDescription = Il gruppo amministratori ha tutti i permessi su DigiRisk e sui moduli necessari
+DigiriskReaderGroup               = DigiRisk - Lettori
+DigiriskReaderGroupDescription    = Il gruppo lettori ha tutti i permessi di sola lettura su DigiRisk e sui moduli necessari
+
+ContractType              = Tipo di contratto
+Apprentice/Student        = Apprendista/Studente
+Interim                   = Lavoratore interinale
+ProfessionalQualification = Qualifica professionale
+DigiriskDocumentation     = Documentazione di Digirisk
+
+SelectUser               = Seleziona un utente
+LabourInspectorFirstName = Ispettorato del
+LabourInspectorLastName  = lavoro
+LabourInspector          = Ispettorato del lavoro
+LabourInspectorSociety   = Terzo Ispettorato del lavoro
+LabourInspectorAssigned  = Ispettorato del lavoro
+
+SocieteSchedules = Orari dell'azienda
+weekDayDefault   = Vedi sito web
+weekEndDefault   = Chiuso Chiuso
+
+#
+# DigriskDocuments - Documenti Digirisk
+#
+
+# Dati
+DigiriskDocuments              = Documento Digirisk
+Responsible                    = Responsabile
+ContactsAction                 = Contatti dell'azione
+PERCOTooltip                   = Se la tua azienda dispone di un piano di risparmio pensionistico collettivo (PERCO), spunta questa casella
+PEETooltip                     = Se la tua azienda dispone di un piano di risparmio aziendale (PEE), spunta questa casella
+ShowPictoName                  = Mostra il nome del pittogramma di pericolo
+ShowPictoNameDescription       = Mostra il nome del pittogramma di pericolo del rischio nei documenti <br> Utile se desideri trasferire la tabella in un foglio di calcolo
+RiskAssessmentColor            = Colore delle valutazioni
+RiskAssessmentColorDescription = Mostra il colore delle valutazioni nel documento Papripact-A3-Orizzontale
+
+#
+# LegalDisplay - Affissione obbligatoria
+#
+
+# Permesso
+LegalDisplaysMin = Affissioni obbligatorie
+
+# Dati
+LegalDisplay             = Affissione obbligatoria
+Legaldisplay             = Affissione obbligatoria
+HowToSetDataLegalDisplay = Per configurare i dati dell'affissione obbligatoria, vai su Home - Configurazione - Azienda/Organizzazione - Sicurezza
+
+LegalDisplayDocumentGenerated       = Generazione dell'affissione obbligatoria
+LabourDoctor                        = Medico competente
+LabourInspector                     = Ispettorato del lavoro
+FireBrigade                         = Vigili del fuoco
+AllEmergencies                      = Qualsiasi emergenza
+RightsDefender                      = Difensore civico
+PoisonControlCenter                 = Centro Antiveleni
+Police                              = Polizia di emergenza
+SafetyInstructions                  = Istruzioni di sicurezza
+ResponsibleToNotify                 = Responsabile da avvisare
+PreventionOfficers                  = Responsabili della prevenzione
+PreventionOfficer                   = Responsabile della prevenzione
+LocationOfDetailedInstructions      = Ubicazione dell'istruzione dettagliata
+LocationOfDetailedInstructionsValue = Nessuna istruzione dettagliata in questo sito
+FirstAid                            = Primo soccorso
+FirstAidValue                       = <h2>Elenco degli addetti al primo soccorso presenti in sito (Nome, Azienda, Telefono)</h2><br><br>Ogni squadra deve essere costituita in modo da poter prestare, in qualsiasi circostanza, il primo soccorso a qualunque membro della squadra.<br />Gli addetti al primo soccorso devono essere chiaramente identificati e noti a tutti.<h2>Come comportarsi in caso di infortunio</h2><br><br><h3>Infortunio lieve</h3><br><ul><li> - Cure prestate dagli addetti al primo soccorso</li><br><li> - Presenza di una cassetta di primo soccorso</li></ul><br><br>Ogni macchina è dotata di almeno una cassetta di primo soccorso che consente di prestare cure per ferite lievi.<br><br><h3>Infortunio grave</h3><br><ul><li> - Avvisare l'addetto al primo soccorso presente in sito</li><br><li> - Attivare la procedura di emergenza</li><br><li> - Informare il responsabile dell'impresa utilizzatrice, reperibilità esercizio 24 h</li><br><li> - Contattare in caso di infortunio</li></ul><br><br>L'impresa utilizzatrice richiama in allegato i numeri di emergenza. <br />
+AddPhoneNumber                      = Aggiungi un numero di telefono all'utente
+ConfigureLabourInspector            = Configura un ispettorato del lavoro
+SocietyAdditionalDetails            = Informazioni complementari dell'azienda
+GeneralMeansAtDisposal              = Mezzi generali messi a disposizione
+GeneralMeansAtDisposalValue         = <h2>Mezzi di soccorso messi a disposizione</h2><br><ul><li> - Infermeria</li><br><li> - Il nostro personale addetto al primo soccorso è identificato sui caschi e sull'abbigliamento da lavoro con il badge di addetto al primo soccorso</li><br><li> - Cassette di primo soccorso per infortuni lievi disponibili in ogni sito</li></ul><br><br><h2>Istruzioni in caso di infortunio lieve</h2><br><ul><li> - Contattare l'addetto al primo soccorso più vicino</li><br><li> - Cure con la cassetta di primo soccorso messa a disposizione</li><br><li> - Dichiarazione nel sito:</li></ul><br><br><h2>Istruzioni in caso di infortunio</h2><br><ul><li> - Chiamata Vigili del fuoco: 18</li><br><li> - Emergenza sanitaria: 15</li><br><li> - Polizia e Gendarmeria: 17</li><br><li> - N&deg; di emergenza europeo: 112</li></ul><br><br><h2>Istruzioni in caso di incendio</h2><br>In caso di incendio, procedere in questo ordine:<br><ol><li> - Attivare il segnale di allarme.</li><br><li> - Attaccare il fuoco (se non è troppo esteso) con un estintore.</li><br><li> - Se il fuoco non è spento dopo l'uso di un solo estintore, o se il fuoco è già troppo esteso, avvisare i vigili del fuoco.</li><br><li> - Chiudere le porte e le finestre prima di lasciare i locali.</li><br><li> - Chiedere aiuto alle squadre formate.</li><br></ol>
+GeneralInstructions                 = Istruzioni generali
+GeneralInstructionsValue            = <h2>Tutti gli impianti</h2><br><br><p>È formalmente vietato fumare, accendere fuochi o utilizzare fiamme libere all'interno e sopra gli impianti.<br />Se l'intervento richiede l'uso di una fiamma libera (lavori di saldatura, ecc.), è obbligatorio emettere un permesso di lavoro a caldo (vedi esempio nell'allegato 9.5).<br />In generale, l'accesso agli impianti è vietato alle persone non autorizzate.<br />Ogni operatore deve essere munito delle proprie abilitazioni e attestati di formazione. Deve poterli mostrare in sito su richiesta dell'impresa utilizzatrice.</p><br><br><h2>Abilitazioni</h2><br>Ogni persona che interviene deve disporre di una copia delle seguenti abilitazioni:<br><ul><li> - Abilitazione elettrica in funzione dei lavori da realizzare</li><br><li> - Attestato di formazione o abilitazione per lavori in quota e salvataggio in quota</li></ul><br>Ed essere in grado di presentarla su semplice richiesta dell'impresa utilizzatrice, del preposto ai lavori o di qualsiasi ispettore incaricato<br><br><h2>Protezioni individuali</h2><br>Ogni persona che interviene deve poter disporre dei seguenti dispositivi di protezione individuale, in funzione dei tipi di lavori effettuati e delle misure di protezione definite nella valutazione dei rischi.<br><br><h3>Lavori vari</h3><br><ul><li> - Casco concepito per lavori in quota (EN397) con sottogola e/o conforme all'isolamento elettrico (ambiente elettrico)</li><br><li> - Calzature di sicurezza</li><br><li> - Protezioni acustiche, se necessario</li><br><li> - Altri (da precisare): in funzione dei lavori realizzati e dei rischi associati.</li></ul><br><br><h3>Lavori elettrici</h3><br><ul><li> - Tappeto isolante o sgabello isolante</li><br><li> - Guanti adatti al livello di tensione</li><br><li> - Caschi per lavori elettrici con schermo facciale (EN166)</li><br><li> - DPI regolamentari per intervento in media tensione (UTE C 18-510)</li></ul><br><br><h3>Altro</h3><br>Nota: le imprese esterne devono fornire ai propri operatori i DPI sopra indicati. Uno sgabello e un'asta si trovano nelle cabine di consegna.<br><br><h3>Lavori in quota</h3><br><ul><li> - DPI regolamentari (imbracatura, casco, 2 cordini con assorbitore o cordino doppio a Y, moschettoni, anticaduta, ecc.) con verifica aggiornata</li><br><li> - Sistema di evacuazione automatica:</li><br><li> - Numero: 1 kit di evacuazione (previsto per 2 persone)</li><li>Ubicazione: nel cestello</li><br><li> - Ricordare di munirsi di un kit di evacuazione supplementare se ci sono più di due persone nel cestello</li><br><li> - Altro (da precisare): anticaduta utilizzato: HACA con riferimento 0529 7103 (attacco sternale sull'imbracatura)</li></ul><br><br>Gli anticaduta devono essere compatibili con il sistema di assicurazione rigido di cui sono dotate le macchine. Gli anticaduta devono essere conformi all'ultima norma e aver superato con successo le prove complementari (test aggiuntivi CNB/P/11.073 del 13/10/2010) rese obbligatorie dal Parere del Ministero del Lavoro francese del 28 settembre 2010, al fine di garantire la conformità ai requisiti della direttiva 89/686/CEE.
+RulesOfProcedure                    = Regolamento interno
+RulesOfProcedureValue               = Disponibile nell'affissione obbligatoria della sala pausa
+CollectiveAgreement                 = Contratti collettivi
+CollectiveAgreementValue            = Disponibile sul sito del governo:<br /><a href="https://www.service-public.fr/particuliers/vosdroits/F78" target="_blank">https://www.service-public.fr/particuliers/vosdroits/F78</a>
+legaldisplay.odt                    = Affissione obbligatoria
+legaldisplay_custom.odt             = Affissione obbligatoria personalizzata
+
+#
+# InformationsSharing - Diffusione delle informazioni
+#
+
+# Permesso
+InformationsSharingsMin = Diffusioni di informazioni
+
+# Dati
+InformationsSharing                  = Diffusione delle informazioni
+Informationssharing                  = Diffusione delle informazioni
+InformationsSharingDocumentGenerated = Generazione della diffusione delle informazioni
+HowToSetDataInformationsSharing      = Per configurare i dati sulla diffusione delle informazioni, vai su Home - Configurazione - Azienda/Organizzazione - Sociale
+ConfigureSecurityAndSocialData       = Configura i dati dell'azienda
+LastMainDoc                          = Ultimo documento generato
+
+ParticipationAgreement      = Accordi di partecipazione agli utili
+ParticipationAgreementValue = Sì, tutti i collaboratori con un contratto di lavoro a tempo indeterminato o determinato in corso con l'azienda, di qualsiasi natura, potranno beneficiare della partecipazione agli utili.<br />È tuttavia richiesta una condizione di anzianità: 6 mesi in azienda.<br />Per la determinazione dell'anzianità richiesta si tiene conto di tutti i contratti di lavoro eseguiti nel periodo di calcolo e nei 12 mesi precedenti.<br />L'anzianità è valutata alla data di chiusura dell'esercizio interessato o alla data di uscita in caso di cessazione del contratto nel corso dell'esercizio.
+TermsAndConditions          = Modalità
+
+ESC                  = Comitato Sociale ed Economico
+StaffRepresentatives = Rappresentanti del personale
+ElectionDate         = Data di elezione
+ElectionDateCSE      = Data di elezione del Comitato Sociale ed Economico
+ElectionDateDP       = Data di elezione dei rappresentanti del personale
+
+Titulars                       = Titolari
+Alternates                     = Supplenti
+informationssharing.odt        = Diffusione delle informazioni
+informationssharing_custom.odt = Diffusione delle informazioni personalizzata
+ActionOnUser                   = Utente interessato
+HarassmentOfficer              = Responsabile molestie
+HarassmentOfficerCSE           = Responsabile molestie del Comitato Sociale ed Economico
+ExceptionsToWorkingHours       = Deroghe agli orari di lavoro
+PermanentDerogation            = Deroga permanente
+PermanentDerogationValue       = No
+OccasionalDerogation           = Deroga occasionale
+OccasionalDerogationValue      = Sì
+
+
+#
+# PreventionPlan - Piano di prevenzione
+#
+
+# Permesso
+PreventionPlansMin = piani di prevenzione
+
+# Dati
+
+PreventionPlan                                        = Piano di prevenzione
+Preventionplan                                        = Piano di prevenzione
+ThePreventionplan                                     = il piano di prevenzione
+PreventionPlanDocument                                = Piano di prevenzione
+Preventionplandocument                                = Piano di prevenzione
+PreventionPlanDocumentGenerated                       = Generazione del piano di prevenzione
+PreventionPlanList                                    = Elenco dei piani di prevenzione
+PreventionPlanLine                                    = rischio/i
+PreventionPlanLineCreated                             = Creazione di un rischio nel piano di prevenzione
+PreventionPlanLineModified                            = Modifica di un rischio nel piano di prevenzione
+PreventionPlanLineDeleted                             = Eliminazione di un rischio dal piano di prevenzione
+NewPreventionPlan                                     = Nuovo piano di prevenzione
+PriorVisit                                            = Sopralluogo congiunto preliminare
+PriorVisitYesNo                                       = Visita preliminare effettuata
+PriorVisitText                                        = Nota del sopralluogo
+CSSCTIntervention                                     = Intervento del CSSCT
+CSSCTInterventionText                                 = Intervento del CSSCT?
+MasterWorker                                          = Responsabile dell'impresa utilizzatrice
+MasterWorker                                          = Responsabile dell'impresa utilizzatrice
+ExtSociety                                            = Impresa esterna
+ExtSocietyResponsible                                 = Responsabile dell'impresa esterna
+ExtSocietyResponsible                                 = Responsabile dell'impresa esterna
+ExtSocietyAttendant                                   = Operatore dell'impresa esterna
+ActionsDescription                                    = Descrizione delle attività
+INRSRisk                                              = Rischio (INRS)
+PreventionMethod                                      = Mezzi di prevenzione
+PreventionplanSchedules                               = Orari del piano di prevenzione
+Attendants                                            = Partecipanti
+ModifyPreventionPlan                                  = Modifica il piano di prevenzione
+ActionsDescriptionTooltip                             = Descrizione delle attività svolte dall'operatore
+INRSRiskTooltip                                       = Elenco delle categorie di rischio proposte nel riferimento INRS
+PreventionMethodTooltip                               = Mezzo di prevenzione da attuare per limitare il rischio
+LockPreventionPlan                                    = Blocca il piano di prevenzione
+ConfirmLockPreventionPlan                             = Sei sicuro di voler bloccare il piano di prevenzione?<br>Questo blocco consente di congelare i dati e la generazione del documento.
+AllSignatoriesMustHaveSigned                          = Tutti i partecipanti devono aver firmato per bloccare l'oggetto
+ValidatePreventionPlan                                = Convalida il piano di prevenzione
+ConfirmValidatePreventionPlan                         = Sei sicuro di voler convalidare il piano di prevenzione? <br> La convalida consente ai partecipanti di firmare il documento ma <b> impedisce l'aggiunta di nuovi partecipanti o la modifica del piano di prevenzione </b>.
+ReOpenPreventionPlan                                  = Riapri il piano di prevenzione
+ConfirmReOpenPreventionPlan                           = Sei sicuro di voler riaprire il piano di prevenzione? La riapertura consente la modifica del piano di prevenzione e l'aggiunta di nuovi partecipanti ma <b>tutte le firme del documento andranno perse</b>.
+PreventionPlanRiskList                                = Elenco dei rischi del piano di prevenzione
+ActionsPreventionPlanRisk                             = Azioni
+PreventionPlanDescription                             = Progetto dei piani di prevenzione
+PriorVisitDate                                        = Data del sopralluogo congiunto preliminare
+AddPreventionPlanLine                                 = Aggiunta del rischio
+UpdatePreventionPlanLine                              = Aggiornamento del rischio
+DeletePreventionPlanLine                              = Eliminazione del rischio
+PreventionPlanDet                                     = Rischio del piano di prevenzione
+Preventionplandet                                     = Rischio del piano di prevenzione
+PreventionPlanMessage                                 = al piano di prevenzione
+PreventionPlanMustBeValidated                         = Il piano di prevenzione deve essere convalidato per poterlo riaprire
+PreventionPlanMustBeInProgress                        = Il piano di prevenzione deve essere in corso per accedere a questa funzionalità
+PreventionPlanMustBeInProgressToValidate              = Il piano di prevenzione è già convalidato
+CSEMustBeAlerted3DaysBeforeVisit                      = Il CSE deve essere avvisato 3 giorni prima del sopralluogo congiunto preliminare (art. R. 4514-1 1°, R. 4514-3 e R. 4514-9 del Codice del lavoro francese)
+PreventionPlanData                                    = Dati del piano di prevenzione
+MasterWorkerDescription                               = L'utente utilizzato per impostazione predefinita come responsabile dell'impresa utilizzatrice
+NoPreventionPlanRisk                                  = Nessun rischio nel piano di prevenzione
+NoPreventionPlanLinked                                = Nessun piano di prevenzione collegato
+PreventionPlanLinked                                  = Piano di prevenzione collegato
+PreventionPlanManagement                              = Gestione dei piani di prevenzione
+PPRProject                                            = Progetto collegato ai piani di prevenzione
+NewLabelForClonePreventionPlan                        = Denominazione del nuovo piano di prevenzione
+ClonePreventionPlanRisk                               = Clona i rischi del piano di prevenzione
+CloneAttendantsPreventionPlan                         = Clona i partecipanti del piano di prevenzione
+CloneSchedulePreventionPlan                           = Clona gli orari del piano di prevenzione
+ConfirmClonePreventionPlan                            = Sei sicuro di voler clonare il piano di prevenzione <b> %s </b>?
+preventionplandocument.odt                            = Piano di prevenzione
+preventionplandocument_custom.odt                     = Piano di prevenzione personalizzato
+ErrorThirdPartyHasAtLeastOneChildOfTypePreventionPlan = Il terzo è collegato ad almeno un elemento figlio di tipo piano di prevenzione:
+ErrorContactHasAtLeastOneChildOfTypePreventionPlan    = Il contatto è collegato ad almeno un elemento figlio di tipo piano di prevenzione:
+ConfirmDeletePreventionPlan                           = Sei sicuro di voler eliminare questo piano di prevenzione?
+PreventionPlanRole                                    = I ruoli del piano di prevenzione
+
+# Email
+PreventionPlanLabel   = Riepilogo del piano di prevenzione
+PreventionPlanSubject = Email piano di prevenzione
+PreventionPlanContent = In allegato trovi il documento ODT del piano di prevenzione.
+
+# Trigger
+PreventionPlanCreated          = Creazione di un piano di prevenzione
+PreventionPlanModified         = Modifica di un piano di prevenzione
+PreventionPlanDeleted          = Eliminazione di un piano di prevenzione
+PreventionPlanInProgress       = Riapertura del piano di prevenzione
+PreventionPlanPendingSignature = Messa in attesa di firma del piano di prevenzione
+PreventionPlanLocked           = Blocco del piano di prevenzione
+PreventionPlanArchived         = Archiviazione del piano di prevenzione
+PreventionPlanSentByMail       = Invio del piano di prevenzione via email
+
+#
+# FirePermit - Permesso di lavoro a caldo
+#
+
+# Permesso
+FirePermitMin  = permesso di lavoro a caldo
+FirePermitsMin = permessi di lavoro a caldo
+
+# Dati
+NewFirePermit                                     = Nuovo permesso di lavoro a caldo
+ModifyFirePermit                                  = Modifica il permesso di lavoro a caldo
+FirePermitList                                    = Elenco dei permessi di lavoro a caldo
+FirePermit                                        = Permesso di lavoro a caldo
+Firepermit                                        = Permesso di lavoro a caldo
+TheFirepermit                                     = il permesso di lavoro a caldo
+FirePermitDocument                                = Permesso di lavoro a caldo
+Firepermitdocument                                = Permesso di lavoro a caldo
+FirePermitDocumentGenerated                       = Generazione del permesso di lavoro a caldo
+FirePermitCreated                                 = Creazione di un permesso di lavoro a caldo
+FirePermitModified                                = Modifica di un permesso di lavoro a caldo
+FirePermitDeleted                                 = Eliminazione di un permesso di lavoro a caldo
+FirePermitInProgress                              = Riapertura del permesso di lavoro a caldo
+FirePermitPendingSignature                        = Messa in attesa di firma del permesso di lavoro a caldo
+FirePermitLocked                                  = Blocco del permesso di lavoro a caldo
+FirePermitArchived                                = Archiviazione del permesso di lavoro a caldo
+FirePermitSignatureAddAttendant                   = Aggiunta di un partecipante al permesso di lavoro a caldo
+FirePermitSentByMail                              = Invio del permesso di lavoro a caldo via email
+FirePermitLine                                    = rischio/i
+FirePermitDet                                     = Rischio del permesso di lavoro a caldo
+Firepermitdet                                     = Rischio del permesso di lavoro a caldo
+FirePermitLineCreated                             = Creazione di un rischio nel permesso di lavoro a caldo
+FirePermitLineModified                            = Modifica di un rischio nel permesso di lavoro a caldo
+FirePermitLineDeleted                             = Eliminazione di un rischio dal permesso di lavoro a caldo
+FirePermitRiskList                                = Elenco dei rischi del permesso di lavoro a caldo
+AddFirePermitLine                                 = Aggiunta del rischio
+UpdateFirePermitLine                              = Aggiornamento del rischio
+DeleteFirePermitLine                              = Eliminazione del rischio
+FirePermitMessage                                 = al permesso di lavoro a caldo
+UsedMaterialTooltip                               = Materiale da utilizzare per limitare il rischio
+ActionsFirePermitRisk                             = Azioni
+ConfirmValidateFirePermit                         = Sei sicuro di voler convalidare il permesso di lavoro a caldo? <br> La convalida consente ai partecipanti di firmare il documento ma <b> impedisce l'aggiunta di nuovi partecipanti o la modifica del permesso di lavoro a caldo </b>.
+ConfirmReOpenFirePermit                           = Sei sicuro di voler riaprire il permesso di lavoro a caldo? La riapertura consente la modifica del permesso di lavoro a caldo e l'aggiunta di nuovi partecipanti ma <b>tutte le firme del documento andranno perse</b>.
+ConfirmLockFirePermit                             = Sei sicuro di voler bloccare il permesso di lavoro a caldo?<br>Questo blocco consente di congelare i dati e la generazione del documento.
+FirePermitMustBeInProgress                        = Il permesso di lavoro a caldo deve essere in corso per accedere a questa funzionalità
+NewLabelForCloneFirePermit                        = Denominazione del nuovo permesso di lavoro a caldo
+CloneFirePermitRisk                               = Clona i rischi del permesso di lavoro a caldo
+CloneAttendantsFirePermit                         = Clona i partecipanti del permesso di lavoro a caldo
+CloneScheduleFirePermit                           = Clona gli orari del permesso di lavoro a caldo
+ConfirmCloneFirePermit                            = Sei sicuro di voler clonare il permesso di lavoro a caldo <b> %s </b>?
+FirePermitDescription                             = Progetto dei permessi di lavoro a caldo
+FirePermitData                                    = Dati del permesso di lavoro a caldo
+FirePermitManagement                              = Gestione dei permessi di lavoro a caldo
+FPRProject                                        = Progetto collegato ai permessi di lavoro a caldo
+firepermitdocument.odt                            = Permesso di lavoro a caldo
+firepermitdocument_custom.odt                     = Permesso di lavoro a caldo personalizzato
+UsedEquipment                                     = Materiale utilizzato
+ErrorThirdPartyHasAtLeastOneChildOfTypeFirePermit = Il terzo è collegato ad almeno un elemento figlio di tipo permesso di lavoro a caldo:
+ErrorContactHasAtLeastOneChildOfTypeFirePermit    = Il contatto è collegato ad almeno un elemento figlio di tipo permesso di lavoro a caldo:
+ConfirmDeleteFirePermit                           = Sei sicuro di voler eliminare questo permesso di lavoro a caldo?
+FirePermitRole                                    = I ruoli del permesso di lavoro a caldo
+FirepermitSchedules                               = Orari del permesso di lavoro a caldo
+
+# Email
+FirePermitLabel   = Riepilogo del permesso di lavoro a caldo
+FirePermitSubject = Email permesso di lavoro a caldo
+FirePermitContent = In allegato trovi il documento ODT del permesso di lavoro a caldo.
+
+
+#
+# Accident - Infortunio
+#
+
+# Permesso
+AccidentsMin = infortuni
+
+# Trigger
+AccidentCreateTrigger         = Infortunio %s creato
+ActionsOnAccident             = Eventi collegati all'infortunio
+AccidentGeneratedWithDolibarr = Infortunio generato con Dolibarr
+AccidentWorkStopCreateTrigger = Assenza dal lavoro %s aggiunta all'infortunio
+AccidentWorkStopModifyTrigger = Assenza dal lavoro %s modificata sull'infortunio
+AccidentWorkStopDeleteTrigger = Assenza dal lavoro %s eliminata dall'infortunio
+AccidentModifyTrigger         = Infortunio %s modificato
+AccidentDeleteTrigger         = Infortunio %s eliminato
+AccidentMetaDataCreateTrigger = Registrazione dei dati complementari dell'infortunio
+AccidentLesionCreateTrigger   = Lesione %s aggiunta all'infortunio
+AccidentLesionModifyTrigger   = Lesione %s modificata sull'infortunio
+AccidentLesionDeleteTrigger   = Lesione %s eliminata dall'infortunio
+ACC_USER_EMPLOYERSigned       = Firma del responsabile dell'azienda
+VictimAndCaregivers           = Infortunato e soccorritore
+Victim                        = Infortunato
+Caregiver                     = Soccorritore
+
+# Modello di numerazione
+DigiriskAccidentNumberingModule         = Modello di numerazione degli infortuni di Digirisk
+DigiriskAccidentStandardModel           = Restituisce il numero nel formato ACCn, dove n è un contatore sequenziale senza interruzioni e senza azzeramento.
+DigiriskAccidentWorkStopNumberingModule = Modello di numerazione delle assenze dal lavoro collegate all'infortunio
+DigiriskAccidentWorkStopStandardModel   = Restituisce il numero nel formato ACCWn, dove n è un contatore sequenziale senza interruzioni e senza azzeramento.
+DigiriskAccidentLesionNumberingModule   = Modello di numerazione delle lesioni collegate all'infortunio
+DigiriskAccidentLesionStandardModel     = Restituisce il numero nel formato ACCLn, dove n è un contatore sequenziale senza interruzioni e senza azzeramento.
+DigiriskAccidentDocumentNumberingModule = Modello di numerazione delle schede di infortunio di Digirisk
+DigiriskAccidentDocumentStandardModel   = Restituisce il numero nel formato ACCDn, dove n è un contatore sequenziale senza interruzioni e senza azzeramento.
+
+# Modello ODT
+DigiriskTemplateDocumentAccident       = Modelli di documento degli infortuni di Digirisk
+AccidentDocumentCustomDigiriskTemplate = ODT personalizzato degli infortuni
+AccidentDocumentDigiriskTemplate       = ODT predefinito degli infortuni
+AccidentDocument                       = Scheda di infortunio
+AccidentDocumentGeneratedWithDolibarr  = Infortunio generato con Dolibarr
+
+# Dati
+NewAccident                              = Nuovo infortunio
+ModifyAccident                           = Modifica l'infortunio
+AccidentList                             = Elenco degli infortuni
+Accident                                 = Infortunio
+AccidentCreated                          = Creazione di un infortunio
+DeleteAccident                           = Eliminare l'infortunio?
+AccidentModified                         = Modifica di un infortunio
+AccidentDeleted                          = Eliminazione di un infortunio
+AccidentLine                             = rischio/i
+AccidentDate                             = Data dell'infortunio
+AccidentSchedule                         = Orari dell'infortunio
+AccidentRiskList                         = Elenco delle informazioni complementari sull'infortunio
+Accidentworkstop                         = Assenza dal lavoro
+AccidentWorkStopCreated                  = Creazione di un'assenza dal lavoro
+AccidentWorkStopModified                 = Modifica di un'assenza dal lavoro
+AccidentWorkStopDeleted                  = Eliminazione di un'assenza dal lavoro
+AddAccidentWorkStop                      = Aggiunta di un'assenza dal lavoro all'infortunio
+UpdateAccidentWorkStop                   = Aggiornamento di un'assenza dal lavoro sull'infortunio
+DeleteAccidentWorkStop                   = Eliminazione di un'assenza dal lavoro dall'infortunio
+Accidentlesion                           = Lesione
+AccidentLesionCreated                    = Creazione di una lesione
+AccidentLesionModified                   = Modifica di una lesione
+AccidentLesionDeleted                    = Eliminazione di una lesione
+AddAccidentLesion                        = Aggiunta di una lesione all'infortunio
+UpdateAccidentLesion                     = Aggiornamento di una lesione sull'infortunio
+DeleteAccidentLesion                     = Eliminazione di una lesione dall'infortunio
+AccidentDescription                      = Progetto degli infortuni
+AccidentManagement                       = Gestione degli infortuni
+AccidentWorkstopManagement               = Gestione delle assenze dal lavoro
+AccidentLesionManagement                 = Gestione delle lesioni
+AccidentInvestigationManagement          = Gestione delle indagini sugli infortuni
+ACCProject                               = Progetto collegato agli infortuni
+UserVictim                               = Infortunato
+AccidentType                             = Tipo di infortunio
+WorkAccidentStatement                    = Infortunio sul lavoro
+CommutingAccident                        = Infortunio in itinere
+AccidentMetaData                         = Dati complementari
+RelativeLocation                         = Precisazioni complementari sul luogo dell'infortunio
+VictimActivity                           = Attività dell'infortunato al momento dell'infortunio
+AccidentNature                           = Natura dell'infortunio
+AccidentObject                           = Oggetto il cui contatto ha ferito l'infortunato
+AccidentNatureDoubt                      = Eventuali riserve motivate (allega, se necessario, una lettera di accompagnamento)
+AccidentNatureDoubtLink                  = Link alla lettera di accompagnamento
+VictimTransportedTo                      = L'infortunato è stato trasportato a
+VictimWorkHours                          = Orario di lavoro dell'infortunato il giorno dell'infortunio
+WorkHoursMorningDateStart                = Inizio dell'orario di lavoro dell'infortunato (mattina)
+WorkHoursMorningDateEnd                  = Fine dell'orario di lavoro dell'infortunato (mattina)
+WorkHoursAfternoonDateStart              = Inizio dell'orario di lavoro dell'infortunato (pomeriggio)
+WorkHoursAfternoonDateEnd                = Fine dell'orario di lavoro dell'infortunato (pomeriggio)
+AccidentNoticed                          = Informazione dell'infortunio
+Found                                    = Constatato
+Known                                    = Conosciuto
+AccidentNoticeDate                       = Data in cui si è venuti a conoscenza dell'infortunio
+AccidentNoticeBy                         = La persona che ha informato dell'infortunio
+ByEmployer                               = Dal datore di lavoro
+ByEmployees                              = Dai suoi preposti
+AccidentDescribedByVictim                = L'infortunio è stato descritto dall'infortunato
+RegisteredInAccidentRegister             = L'infortunio è iscritto nel registro degli infortuni sul lavoro lievi
+RegisterDate                             = Data di iscrizione nel registro degli infortuni sul lavoro lievi
+RegisterNumber                           = Numero di iscrizione nel registro degli infortuni sul lavoro lievi
+Consequence                              = Conseguenze
+WithoutWorkStop                          = Senza assenza dal lavoro
+LessThanFourDays                         = Meno di 4 giorni
+LessThanTwentyOneDays                    = Meno di 21 giorni
+LessThanThreeMonth                       = Meno di 3 mesi
+LessThanSixMonths                        = Meno di 6 mesi
+LongTimeWorkStop                         = Più di 6 mesi
+WithWorkStop                             = Con assenza dal lavoro
+Fatal                                    = Decesso
+PoliceReport                             = Verbale di polizia
+PoliceReportBy                           = La persona che ha redatto il verbale di polizia
+FirstPersonNoticedIsWitness              = Persona avvisata
+Witness                                  = Testimone
+FirstPersonNoticed                       = Prima persona avvisata
+ThirdPartyResponsability                 = L'infortunio è stato causato da un terzo?
+FkSocResponsible                         = Azienda del terzo responsabile
+FkSocResponsibleInsuranceSociety         = Compagnia assicurativa del terzo
+LesionLocalization                       = Sede delle lesioni
+LesionNature                             = Natura delle lesioni
+AccidentInvestigation                    = Indagine sull'infortunio
+Accidentinvestigation                    = Indagine sull'infortunio
+AccidentInvestigationLink                = Link all'indagine sull'infortunio
+AccidentLocation                         = Luogo dell'infortunio
+DigiriskDolibarrActionTrigger            = Trigger degli eventi Digirisk
+CollateralVictim                         = Infortunato collaterale
+FromDigirisk                             = Da
+At                                       = A
+AndFrom                                  = E da
+ExternalAccident                         = L'infortunio è avvenuto in uno stabilimento diverso da quello di appartenenza dell'infortunato?
+AccidentAttendants                       = Infortunio - Partecipanti
+UserEmployer                             = Responsabile dell'azienda
+SignatureUserEmployer                    = Firma del responsabile dell'azienda
+CerfaLink                                = Link al modulo Cerfa
+WorkStopDays                             = Numero di giorni di assenza dal lavoro
+AccidentLesionList                       = Elenco delle lesioni collegate all'infortunio
+DocumentsMetaData                        = File allegati complementari
+WorkStopDocument                         = Dichiarazione di assenza dal lavoro
+AccidentMetaDataSave                     = I dati complementari dell'infortunio sono stati registrati
+ErrorFieldNotEmpty                       = Errore: il campo <b>'%s'</b> non può essere vuoto
+ErrorFieldMustBeGreaterOrEqualZero       = Errore: il campo <b>'%s'</b> deve essere maggiore o uguale a 0
+ConfirmDeleteAccidentWorkStop            = Sei sicuro di voler eliminare l'assenza dal lavoro <b>%s</b> sull'infortunio?
+AccidentMetaDataLesion                   = Dati complementari delle lesioni
+TotalWorkStopDays                        = Numero totale di giorni di assenza dal lavoro
+RegisterAccident                         = Infortunio lieve
+AccidentsLinked                          = Infortunio/i collegato/i
+GaugeCounter                             = Questo campo è utilizzato nel contatore dell'indicatore
+DateStartWorkStop                        = Data di inizio dell'assenza dal lavoro
+DateEndWorkStop                          = Data di fine dell'assenza dal lavoro
+ReturnWorkDate                           = Data di ripresa dell'attività
+DayWithoutAccident                       = Giorni senza infortuni
+AccidentRepartition                      = Ripartizione degli infortuni per tipo
+AccidentByYear                           = Ripartizione degli infortuni per anno
+NbAccidentsByEmployees                   = Numero di infortuni per dipendente
+AccidentRegister                         = Infortunio per registro
+AccidentWithoutRegister                  = Infortuni senza registro
+AccidentWithRegister                     = Infortuni con registro
+WorkStopDurationDistribution             = Ripartizione del tempo per assenza dal lavoro
+WorkStopDurationDistributionDigiriskElem = Ripartizione del tempo di assenza dal lavoro per GP/UT
+WorkStopDuration                         = Durata dell'assenza dal lavoro
+NoAbsence                                = Nessuna assenza
+UpTo4Days                                = Fino a 4 giorni
+UpTo21Days                               = Fino a 21 giorni
+UpTo3Months                              = Fino a 3 mesi
+UpTo6Months                              = Fino a 6 mesi
+MoreThan6Months                          = Più di 6 mesi
+FrequencyIndex                           = Indice di frequenza
+FrequencyRate                            = Tasso di frequenza
+GravityIndex                             = Indice di gravità
+GravityRate                              = Tasso di gravità
+AccidentRateIndicator                    = Tassi e indici degli indicatori di performance sugli infortuni
+NbPresquAccidents                        = Numero di mancati infortuni
+NbAccidentInvestigations                 = Numero di indagini sugli infortuni
+AccidentInvestigationsMin                = indagini sugli infortuni
+NbWorkedHours                            = Numero di ore lavorate
+ConfirmDeleteAccident                    = Sei sicuro di voler eliminare l'infortunio?
+TheAccident                              = l'infortunio
+AccidentInvestigation                    = Indagine sull'infortunio
+Accident_investigation                   = Indagine sull'infortunio
+AccidentInvestigationDocument            = Documento di indagine sull'infortunio
+Accidentinvestigationdocument            = Documento di indagine sull'infortunio
+accidentinvestigationdocument.odt        = Indagine sull'infortunio
+NewAccidentInvestigation                 = Nuova indagine sull'infortunio
+UpdateAccidentInvestigation              = Modifica un'indagine sull'infortunio
+AccidentInvestigationList                = Elenco delle indagini sugli infortuni
+TheAccidentinvestigation                 = l'indagine sull'infortunio
+SeniorityInPosition                      = Anzianità nella mansione
+VictimSkills                             = Competenze dell'infortunato
+CollectiveEquipment                      = Dispositivi di Protezione Collettiva (DPC)
+IndividualEquipment                      = Dispositivi di Protezione Individuale (DPI)
+Circumstances                            = Circostanze
+CurativeAction                           = Azioni curative
+CorrectiveAction                         = Azioni correttive
+PreventiveAction                         = Azioni preventive
+DigiriskActionType                       = Tipo di azione Digirisk
+Actions                                  = Azioni
+ActionsTab                               = Azioni
+CurativeActions                          = Azioni curative
+PreventiveActions                        = Azioni preventive
+TotalPlannedBudget                       = Budget previsto
+AccidentInvestigationDocumentPDF         = EA-A4-VERTICALE
+PreventionPlanDocumentPDF                = PP-A4-VERTICALE
+PreventionPlanDocumentPDFDescription     = Genera il piano di prevenzione in PDF
+AccidentInvestigationDocumentPDFDescription = Genera l'indagine sull'infortunio in PDF
+AccidentInvestigationDocumentGeneratedAt = Generato il
+CorrectiveActions                        = Azioni correttive
+AddCurativeAction                        = Aggiungi un'azione curativa
+AddCorrectiveAction                      = Aggiungi un'azione correttiva
+InvestigationNotValidatedYet             = Convalida prima l'indagine sull'infortunio per poter creare azioni
+ActionLabel                              = Denominazione dell'azione
+ActionDeadline                           = Scadenza
+ActionAssignedTo                         = Assegnata a
+ActionProgress                           = Avanzamento
+MarkAsDone                               = Segna come completata
+XActionsOfY                              = %s / %s completate
+NoActionsYet                             = Nessuna azione al momento
+ActionAdded                              = L'azione è stata creata
+ActionClosed                             = L'azione è stata chiusa
+ActionsAreProjectTasks                   = Le azioni sono sottoattività del progetto Dolibarr
+SeeProjectTasksView                      = Vedi l'attività padre
+OpenTask                                 = Apri l'attività
+AccidentInvestigationValidated           = L'indagine sull'infortunio è stata convalidata
+AccidentInvestigationReOpened            = L'indagine sull'infortunio è stata riaperta
+AccidentInvestigationTaskCreated         = Le attività dell'indagine sull'infortunio sono state create
+AccidentInvestigationTaskDeleted         = Le attività dell'indagine sull'infortunio sono state eliminate
+CausalityTree                            = Albero delle cause
+TaskWillBeCreatedAfterValidation         = Le attività saranno create dopo la convalida dell'indagine sull'infortunio
+AccidentInvestigationCreated             = Creazione di un'indagine sull'infortunio
+AccidentInvestigationModified            = Modifica di un'indagine sull'infortunio
+AccidentInvestigationDeleted             = Eliminazione di un'indagine sull'infortunio
+AccidentInvestigationValidate            = Convalida di un'indagine sull'infortunio
+AccidentInvestigationUnValidate          = Riapertura di un'indagine sull'infortunio
+AccidentInvestigationLock                = Blocco dell'indagine sull'infortunio
+AccidentInvestigationSigned              = Firma di un'indagine sull'infortunio
+CloneWorkStop                            = Clonare le assenze dal lavoro?
+CloneMetadata                            = Clonare i dati complementari?
+CloneLesion                              = Clonare i dati complementari delle lesioni?
+CloneFrom                                = Clone di
+AccidentInvestigationRole                = I ruoli dell'indagine sull'infortunio
+LesionsOrWorkStop                        = lesioni o assenze dal lavoro
+AccidentsCategoriesArea                  = Spazio dei tag/categorie degli infortuni
+AddAccidentIntoCategory                  = Assegna questa categoria all'infortunio
+PreventionplansCategoriesArea            = Spazio dei tag/categorie dei piani di prevenzione
+AddPreventionplanIntoCategory            = Assegna questa categoria al piano di prevenzione
+FirepermitsCategoriesArea                = Spazio dei tag/categorie dei permessi di lavoro a caldo
+AddFirepermitIntoCategory                = Assegna questa categoria al permesso di lavoro a caldo
+RisksCategoriesArea                      = Spazio dei tag/categorie dei rischi
+AddRiskIntoCategory                      = Assegna questa categoria al rischio
+AddTicketIntoCategory                    = Assegna questa categoria al ticket
+StartDateInvestigate                     = Data di inizio dell'indagine
+EndDateInvestigate                       = Data di fine dell'indagine
+YearType                                 = Tipo di anno
+AllYears                                 = Tutti gli anni
+FiscalYear                               = Anno fiscale
+CalendarYear                             = Anno solare
+
+# AccidentTooltip - Suggerimenti sugli infortuni
+VictimActivityTooltip              = Precisa l'attività o la mansione dell'infortunato al momento dell'infortunio, cioè cosa stava facendo l'infortunato
+AccidentNatureTooltip              = Descrivi l'evento che ha portato all'infortunio, come si è verificato l'infortunio (problema elettrico, fuga di gas, rottura di materiale, scivolamento, caduta, sforzo fisico, aggressione...), o come si è ferito l'infortunato (urto, collisione, schiacciamento, puntura, annegamento, contatto con una sostanza...)
+AccidentObjectTooltip              = Cioè con cosa si è ferito l'infortunato: materiale, rifiuto, utensile (cacciavite, taglierino, trapano...), macchina, veicolo, carrello elevatore, sostanza chimica, elemento di costruzione (porta, muro...), pavimento...
+AccidentNatureDoubtTooltip         = Indica, se del caso, le riserve motivate, che potranno essere prese in considerazione solo se riguardano le circostanze di tempo e di luogo dell'infortunio o l'esistenza di una causa totalmente estranea al lavoro (art. R. 441-11 del Codice della sicurezza sociale francese)
+VictimWorkHoursTooltip             = Indica le ore di lavoro effettuate dal tuo dipendente, o le ore previste, il giorno dell'infortunio
+ConsequenceTooltip                 = Se l'infortunato ha interrotto il lavoro su prescrizione di un medico, devi OBBLIGATORIAMENTE compilare e inviare il modulo «attestation de salaire accident du travail ou maladie professionnelle» - riferimento S6202, alla Cassa primaria del luogo di residenza abituale dell'infortunato. <br> Successivamente, in caso di nuova assenza dopo un periodo di cure o una ripresa del lavoro, in un mese diverso, dovrai adempiere alla stessa formalità
+FirstPersonNoticedIsWitnessTooltip = Indica il cognome, il nome e l'indirizzo del testimone. <br> In assenza di testimoni, indica la prima persona dell'azienda che è stata avvisata dell'infortunio
+ThirdPartyResponsabilityTooltip    = Quando sei a conoscenza del coinvolgimento di un terzo, qualunque sia la sua quota di responsabilità, in un infortunio sul lavoro o in itinere, questa menzione deve essere obbligatoriamente riportata in questa parte
+FrequencyIndexTooltip              = Numero di infortuni per dipendente x 1 000
+FrequencyRateTooltip               = Numero di infortuni per ore lavorate x 1 000 000
+GravityRateTooltip                 = Numero di giorni di assenza dal lavoro per ore lavorate x 1 000
+NbWorkedHoursTooltip               = Il numero di ore lavorate è stato inserito manualmente
+DocumentGeneratedWithVersioning    = Documento generato durante il versionamento
+
+# Dizionario
+UsualWorkplace                  = Luogo di lavoro abituale
+OccasionalWorkplace             = Luogo di lavoro occasionale
+LocationOfTheMeal               = Luogo del pasto
+OnTheWayBetweenHomeAndWorkplace = Durante il tragitto tra il domicilio e il luogo di lavoro
+OnTheWayBetweenMealAndWorkplace = Durante il tragitto tra il lavoro e il luogo del pasto
+DuringATripForTheEmployer       = Durante una trasferta per il datore di lavoro
+
+Trunk             = Tronco
+Hand              = Mano
+LowerLimbs        = Arti inferiori
+UpperLimbs        = Arti superiori
+MultipleLocations = Localizzazioni multiple
+Foot              = Piede
+Head              = Testa
+Eyes              = Occhi
+InternalSeating   = Localizzazioni interne
+Neck              = Collo
+Back              = Schiena
+WholeBody         = Tutto il corpo
+NotSpecified      = Non precisato
+
+PainEffortLumbago           = Dolore da sforzo, lombalgia
+Contusion                   = Contusione
+Wounds                      = Ferite
+Sprain                      = Distorsione
+FracturePitting             = Frattura o incrinatura
+MultipleInjuries            = Lesioni di natura multipla
+MuscleOrTendonTear          = Strappo muscolare o tendineo
+PresenceOfForeignBody       = Presenza di corpo estraneo
+Burns                       = Ustione
+UnspecifiedAndMiscellaneous = Non precisato e vari
+Other                       = Altro
+CutOff                      = Taglio
+
+Investigator = Investigatore
+Rescuer      = Soccorritore
+
+#
+# ListingRisksDocument - Elenco dei rischi con documenti
+#
+
+# Permesso
+ListingRisksDocumentMin = elenchi dei rischi con documenti
+
+# Dati
+ListingRisksDocument            = Elenco dei rischi
+Listingrisksdocument            = Elenco dei rischi
+ListingRisksHeader              = Rischi - %s
+ListingRisksDocumentGenerated   = Generazione dell'elenco dei rischi con documenti
+listingrisksdocument.odt        = Elenco dei rischi con documenti
+listingrisksdocument_custom.odt = Elenco dei rischi con documenti personalizzato
+
+#
+# ListingRisksPhoto - Elenco dei rischi con foto
+#
+
+# Permesso
+ListingRisksPhotosMin = elenchi dei rischi con foto
+
+# Dati
+ListingRisksPhoto            = Elenco dei rischi con foto
+Listingrisksphoto            = Elenco dei rischi con foto
+ListingRisksPhotoGenerated   = Generazione dell'elenco dei rischi con foto
+listingrisksphoto.odt        = Elenco dei rischi con foto
+listingrisksphoto_custom.odt = Elenco dei rischi con foto personalizzato
+
+
+#
+# ListingRisksAction - Elenco dei rischi con azioni correttive
+#
+
+# Permesso
+ListingRisksActionsMin = elenchi dei rischi con azioni correttive
+
+# Dati
+ListingRisksAction                        = Elenco dei rischi con azioni correttive
+Listingrisksaction                        = Elenco dei rischi con azioni correttive
+ListingRisksActionGenerated               = Generazione dell'elenco dei rischi con azioni correttive
+listingrisksaction.odt                    = Elenco dei rischi con azioni correttive
+listingrisksaction_custom.odt             = Elenco dei rischi con azioni correttive personalizzato
+DigiriskListingRisksActionData            = Dati configurabili degli elenchi dei rischi con azioni correttive
+ShowTaskDoneListingRisksActionDescription = Consente di mostrare o meno le attività completate nell'elenco dei rischi con azioni correttive
+
+
+#
+# RiskAssessmentDocument - Documento di valutazione dei rischi
+#
+
+# Permesso
+
+RiskAssessmentDocumentsMin = Documenti di valutazione dei rischi
+
+# Dati
+RiskAssessmentDocument                                    = Documento di valutazione dei rischi
+Riskassessmentdocument                                    = Documento di valutazione dei rischi
+RiskAssessmentDocumentGenerated                           = Generazione del documento di valutazione dei rischi
+AuditStartDate                                            = Data di inizio dell'audit
+AuditEndDate                                              = Data di fine dell'audit
+Recipient                                                 = Destinatario
+ImportantNote                                             = Osservazione importante
+SitePlans                                                 = Ubicazione delle planimetrie
+SetStartEndDateBeforeSendEmail                            = Definisci la data di inizio e la data di fine dell'audit in questa pagina per inviare un'email
+NoSitePlans                                               = Nessuna planimetria dell'azienda inserita
+riskassessmentdocument.odt                                = Documento di valutazione dei rischi
+riskassessmentdocument_custom.odt                         = Documento di valutazione dei rischi personalizzato
+DigiriskRiskAssessmentDocumentData                        = Dati configurabili del documento di valutazione dei rischi
+ActionPreventionCompletedTaskDone                         = Le azioni completate non sono visualizzate
+AppliedOn                                                 = Attivo su:
+RiskAssessmentDocumentMethod                              = * Fase 1: Raccolta delle informazioni<br />- Visita dei locali<br />- Raccolta dei dati del personale<br /><br />* Fase 2: Definizione della metodologia e del documento<br />- Convalida delle schede standard di unità di lavoro<br />- Convalida della struttura delle unità<br /><br />* Fase 3: Realizzazione dello studio dei rischi<br />- Sensibilizzazione del personale ai rischi e ai pericoli<br />- Creazione delle unità di lavoro con il personale e il/i responsabile/i<br />- Valutazione dei rischi per unità di lavoro con il personale<br /><br />* Fase 4<br />- Elaborazione e redazione del documento di valutazione dei rischi
+RiskAssessmentDocumentSources                             = La sensibilizzazione ai rischi è definita nell'ED840 pubblicato dall'INRS.<br />In questo documento troverai:<br />- La definizione di un rischio e di un pericolo, con uno schema esplicativo<br />- Le spiegazioni sui diversi metodi di valutazione
+RiskAssessmentDocumentImportantNote                       = Note importanti:<br />Puoi leggere la documentazione di DigiRisk qui<br /><a href="https://wiki.dolibarr.org/index.php?title=Module_Digirisk" target="_blank">https://wiki.dolibarr.org/index.php?title=Module_Digirisk</a><br />Puoi seguire il progetto qui:<br /><a href="https://github.com/Evarisk/Digirisk/projects?type=classic" target="_blank">https://github.com/Evarisk/Digirisk/projects?type=classic</a><br />Segnala un errore qui<br /><a href="https://github.com/Evarisk/Digirisk/issues" target="_blank">https://github.com/Evarisk/Digirisk/issues</a>
+GenerateZipArchiveWithDigiriskElementDocuments            = Generazione di un archivio ZIP con il documento di valutazione dei rischi
+GenerateZipArchiveWithDigiriskElementDocumentsDescription = Generazione automatica di un archivio ZIP contenente il documento di valutazione dei rischi e tutte le schede di mansione durante la generazione del documento di valutazione dei rischi
+RiskAssessmentDocumentDescription                         = Piano d'azione del documento di valutazione dei rischi
+ErrorFailToFetchDigiriskElements                          = Errore: impossibile recuperare i raggruppamenti e le unità di lavoro da includere nell'archivio ZIP
+ErrorNoDocumentModelFound                                 = Errore: nessun modello di documento disponibile per <b>%s</b>
+ErrorFailToGenerateDigiriskElementDocument                = Errore: la generazione del documento di <b>%s</b> non è riuscita, non è presente nell'archivio ZIP
+
+# Boxes - Widget
+NextGenerateDate  = Prossima generazione
+LastGenerateDate  = Ultima generazione
+DelayGenerateDate = Giorni rimanenti
+NoDelay           = Nessun ritardo
+
+# Email
+RiskAssessmentDocumentLabel   = Riepilogo del documento di valutazione dei rischi
+RiskAssessmentDocumentSubject = Email documento di valutazione dei rischi
+RiskAssessmentDocumentContent = In allegato trovi lo ZIP e il documento ODT del documento di valutazione dei rischi.
+
+
+
+#
+# AuditReportDocument - Rapporto di audit
+#
+
+# Dati
+AuditReportDocument     = Rapporto di audit
+Auditreportdocument     = Rapporto di audit
+AuditReportDocumentsMin = rapporti di audit
+auditreportdocument.odt = Rapporto di audit
+
+
+
+#
+# GroupmentDocument - Scheda di raggruppamento
+#
+
+# Permesso
+
+# Dati
+GroupmentDocument                        = Scheda di raggruppamento
+Groupmentdocument                        = Scheda di raggruppamento
+DocumentModelStandardPDF                 = Modello PDF standard
+GroupmentDocumentGenerated               = Generazione della scheda di raggruppamento
+groupmentdocument.odt                    = Scheda di raggruppamento
+groupmentdocument_custom.odt             = Scheda di raggruppamento personalizzata
+groupmentdocumentinherited.odt           = Scheda di raggruppamento - Rischi ereditati
+groupmentdocumentinherited_custom.odt    = Scheda di raggruppamento - Rischi ereditati personalizzata
+groupmentdocumentshared.odt              = Scheda di raggruppamento - Rischi condivisi
+groupmentdocumentshared_custom.odt       = Scheda di raggruppamento - Rischi condivisi personalizzata
+DigiriskGroupmentDocumentData            = Dati configurabili delle schede di raggruppamento
+ShowTaskDoneGroupmentDocumentDescription = Consente di mostrare o meno le attività completate nella scheda di raggruppamento
+
+#
+# WorkUnitDocumment - Scheda di unità di lavoro
+#
+
+# Permesso
+
+# Dati
+WorkUnitDocument                        = Scheda di unità di lavoro
+Workunitdocument                        = Scheda di unità di lavoro
+WorkUnitDocumentGenerated               = Generazione della scheda di unità di lavoro
+workunitdocument.odt                    = Scheda di unità di lavoro
+workunitdocument_custom.odt             = Scheda di unità di lavoro personalizzata
+workunitdocumentinherited.odt           = Scheda di unità di lavoro - Rischi ereditati
+workunitdocumentinherited_custom.odt    = Scheda di unità di lavoro - Rischi ereditati personalizzata
+workunitdocumentshared.odt              = Scheda di unità di lavoro - Rischi condivisi
+workunitdocumentshared_custom.odt       = Scheda di unità di lavoro - Rischi condivisi personalizzata
+workunitdocumentcomplete.odt            = Scheda di unità di lavoro - Tutti i rischi (propri, ereditati, condivisi)
+workunitdocumentcomplete_custom.odt     = Scheda di unità di lavoro - Tutti i rischi personalizzata
+DigiriskWorkUnitDocumentData            = Dati configurabili delle schede di unità di lavoro
+ShowTaskDoneWorkUnitDocumentDescription = Consente di mostrare o meno le attività completate nella scheda di unità di lavoro
+
+
+#
+# DigiriskElement - Elemento Digirisk
+#
+
+# Permessi
+DigiriskElementsMin = elementi Digirisk (raggruppamento e unità di lavoro)
+
+# Dati
+NewDigiriskElement                  = Nuovo elemento Digirisk
+Digiriskelement                     = Raggruppamento / Unità di lavoro
+GPUTOrganization                    = Organizzazione dei GP/UT
+DigiriskElement                     = Elemento Digirisk
+HiddenElements                      = Cestino
+DigiriskElementCreated              = Creazione di un elemento Digirisk
+DigiriskElementModified             = Modifica di un elemento Digirisk
+DigiriskElementDeleted              = Eliminazione di un elemento Digirisk
+ElementType                         = Tipo di elemento
+ParentElement                       = Elemento padre
+OrganizationSaved                   = L'organizzazione dei raggruppamenti e delle unità di lavoro è stata salvata
+OrganizationNotSaved                = Non è stato possibile salvare l'organizzazione dei raggruppamenti e delle unità di lavoro
+UnsavedChanges                      = Modifiche non salvate
+SavingInProgress                    = Salvataggio in corso...
+Saved                               = Salvato
+ErrorSaving                         = Errore durante il salvataggio
+DigiriskElementOrganization         = Organizzazione della struttura
+ShareDigiriskelement                = Attiva la condivisione dei raggruppamenti e delle unità di lavoro
+DIGIRISKELEMENTSharing              = Condivisione dei raggruppamenti e delle unità di lavoro
+DIGIRISKELEMENTSharingDescription   = Selezione delle entità che condivideranno i propri raggruppamenti e unità di lavoro con questa entità.
+DigiriskElementSharedTooltip        = Questa opzione consente di condividere i raggruppamenti e le unità di lavoro. <br> INFO: se desideri visualizzare le attività, devi attivare l'opzione di condivisione dei progetti.
+PleaseSelectADigiriskElement        = Seleziona un raggruppamento o un'unità di lavoro...
+Registers                           = Registri
+ShowInSelectOnPublicTicketInterface = Deve comparire nell'elenco degli elementi dell'interfaccia pubblica dei ticket
+Organization                        = Organizzazione GP/UT
+YouDontHaveOrganization             = Non hai creato raggruppamenti o unità di lavoro, vai su "Documento di valutazione dei rischi" o fai clic <b> qui </b> per crearne.
+
+
+#
+# Groupment - Raggruppamento
+#
+
+# Dati
+Groupment                  = Raggruppamento
+GroupmentManagement        = Gestione dei dati dei raggruppamenti
+NewGroupment               = Nuovo raggruppamento
+ModifyGroupment            = Modifica raggruppamento
+TrashGroupment             = Raggruppamento cestino
+DeletedElements            = Cestino
+DeletedDigiriskElement     = Raggruppamenti / Unità di lavoro spostati nel cestino
+ShowDeletedDigiriskElement = Mostra i raggruppamenti / le unità di lavoro che si trovano nel cestino
+
+#
+# WorkUnit - Unità di lavoro
+#
+
+# Dati
+WorkUnit           = Unità di lavoro
+Workunit           = Unità di lavoro
+WorkUnitManagement = Gestione dei dati delle unità di lavoro
+NewWorkUnit        = Nuova unità di lavoro
+ModifyWorkUnit     = Modifica unità di lavoro
+
+
+#
+# Evaluator - Valutatore
+#
+
+# Permessi
+EvaluatorsMin = valutatori
+
+# Dati
+Evaluator                    = Valutatore
+Evaluators                   = Valutatori
+EvaluatorCreated             = Creazione di un valutatore
+EvaluatorModified            = Modifica di un valutatore
+EvaluatorDeleted             = Eliminazione di un valutatore
+TheEvaluator                 = Il valutatore
+EvaluatorWellCreated         = Valutatore creato
+EvaluatorNotCreated          = Errore durante la creazione del valutatore
+EvaluatorList                = Elenco dei valutatori
+AssignmentDate               = Data di assegnazione
+EvaluationDuration           = Durata
+UserAssigned                 = Utente assegnato
+AddEvaluatorTitle            = Aggiunta di un valutatore
+AddEvaluatorButton           = Aggiungi il valutatore
+EvaluatorConfig              = Configurazione dei dati dei valutatori
+DeleteEvaluatorMessage       = Eliminazione del valutatore
+DigiriskEvaluatorData        = Dati configurabili dei valutatori
+EvaluatorDuration            = Durata della valutazione da parte del valutatore
+EvaluatorDurationDescription = Il tempo impiegato dal valutatore per realizzare la sua valutazione dei rischi
+NbEmployeesInvolved          = Dipendenti coinvolti
+NbEmployees                  = Dipendenti
+NbEmployeesInvolvedTooltip   = Dipendenti (valutatori) unici
+NbEmployeesTooltip           = Se la gestione centralizzata degli utenti e dei gruppi sull'entità principale è attiva.<br>Il numero di dipendenti corrisponde al numero di utenti condivisi/assegnati a un gruppo e anche al numero di amministratori dell'entità principale
+NbEmployeesConfTooltip       = Il numero di dipendenti è stato inserito manualmente
+
+
+#
+# DigiriskStandard - Standard Digirisk
+#
+
+# Dati
+DigiriskStandardInformation = Informazione
+Digiriskstandard            = Standard Digirisk
+DigiriskStandardMin         = standard Digirisk
+TheDigiriskstandard         = lo standard Digirisk
+
+
+#
+# RisksAnalysis - Analisi dei rischi
+#
+
+# Dati
+RiskAnalysis = Analisi dei rischi
+UpdateData   = Aggiorna
+
+#
+# Risks - Rischi
+#
+
+# Permessi
+RisksMin = rischi
+
+# Dati
+Risks                                    = Rischi
+Risk                                     = Rischio
+Riskprofessionals                        = Rischi professionali
+RiskCreated                              = Creazione di un rischio
+RiskModified                             = Modifica di un rischio
+RiskDeleted                              = Eliminazione di un rischio
+RiskConfig                               = Configurazione dei dati dei rischi
+TheRisk                                  = Il rischio
+RiskWellCreated                          = Rischio creato
+RiskNotCreated                           = Errore durante la creazione del rischio
+RiskWellEdited                           = Rischio modificato
+RiskNotEdited                            = Errore durante la modifica del rischio
+RiskList                                 = Elenco dei rischi
+AddRiskTitle                             = Aggiunta del rischio
+AddRiskButton                            = Aggiungi il rischio
+EditRisk                                 = Modifica del rischio
+LinkedRisk                               = Rischio collegato
+RiskCategory                             = Cat.
+RiskCategoryEdit                         = Categoria di rischio
+RiskCategoryEditDescription              = Attiva la modifica della categoria di un rischio esistente
+HowToEditRiskCategory                    = Per modificare la categoria del rischio, fai clic sul pittogramma della categoria
+DigiriskElementRisksList                 = Elenco dei rischi
+DigiriskElementRisk                      = Rischi
+RiskDescriptionNotEnabled                = Il campo descrizione del rischio non è attivo
+HowToEnableRiskDescription               = Per attivare il campo descrizione del rischio, vai su "Configurazione del modulo -> Documento di valutazione dei rischi"
+HowToEnableRiskCategoryEdit              = Per attivare la modifica della categoria di rischio, vai su "Configurazione del modulo -> Documento di valutazione dei rischi"
+SortRisksListingsByEvaluation            = Ordina i rischi per valutazione
+SortRisksListingsByEvaluationDescription = Attiva l'ordinamento automatico dei rischi per valutazione negli elenchi
+ListingHeaderEvaluation                  = Elenco delle valutazioni
+RiskDescription                          = Descrizione del rischio
+RiskDescriptionDescription               = Attiva il campo descrizione del rischio
+RiskDescriptionNotActivated              = Attiva il campo descrizione del rischio in Configurazione del modulo / Analisi dei rischi / Rischi
+AddRisk                                  = Aggiungi un rischio
+MoveRisk                                 = Sposta il rischio
+MoveRisks                                = Sposta i rischi
+MoveRisksDescription                     = Consente di spostare i rischi da un raggruppamento o da un'unità di lavoro a un altro
+SetConfToMoveRisk                        = Devi prima autorizzare lo spostamento dei rischi in "Configurazione del modulo -> Documento di valutazione dei rischi"
+RiskDescriptionPrefill                   = Precompila la descrizione
+RiskDescriptionPrefillDescription        = Precompila la descrizione del rischio con il nome della categoria
+DigiriskElementSharedRisksList           = Elenco dei rischi condivisi
+ImportSharedRisks                        = Importa rischi condivisi
+SelectAllSharedRisksOfElement            = Seleziona tutti i rischi di questo elemento
+AlreadyImported                          = Già importato
+ShowSharedRisks                          = Rischi condivisi
+ShareRisk                                = Attiva la condivisione dei rischi
+RISKSharing                              = Condivisione dei rischi
+RISKSharingDescription                   = Selezione delle entità che condivideranno i propri rischi con questa entità.
+ShowSharedRisksDescription               = Mostra i rischi condivisi nei documenti e negli elenchi
+UnlinkSharedRisk                         = Scollega il rischio condiviso
+RiskWellUnlinkShared                     = Rischio scollegato
+RiskNotUnlinkShared                      = Errore durante lo scollegamento del rischio
+HasBeenUnlinkSharedM                     = è stato scollegato
+HasNotBeenUnlinkSharedM                  = non è stato scollegato
+RiskSharedTooltip                        = Questa opzione consente di condividere i rischi. <br> INFO: se desideri visualizzare le attività, devi attivare l'opzione di condivisione dei progetti.
+ShowInheritedRisksInListings             = Rischi ereditati - Elenchi <br> (provenienti dai livelli superiori)
+ShowInheritedRisksInListingsDescription  = I rischi ereditati sono quelli definiti a un livello superiore (es.: sito o GP) e applicati automaticamente al GP/UT. <br> Attiva questa opzione per visualizzarli negli elenchi
+ShowInheritedRisksInDocuments            = Rischi ereditati - Documenti <br> (provenienti dai livelli superiori)
+ShowInheritedRisksInDocumentsDescription = I rischi ereditati sono quelli definiti a un livello superiore (es.: sito o GP) e applicati automaticamente al GP/UT. <br> Attiva questa opzione per visualizzarli nei documenti
+DigiriskElementInheritedRisksList        = Elenco dei rischi ereditati
+ConfirmImportSharedRisks                 = Scegli i rischi condivisi da importare
+RisksRepartition                         = Ripartizione dei rischi per valutazione
+ShowRiskOrigin                           = Mostra la provenienza del rischio
+ShowRiskOriginDescription                = Mostra la provenienza dei rischi nei documenti (Documento di valutazione dei rischi, Raggruppamento, Unità di lavoro, Elenco dei rischi con azioni e con foto ecc.).
+SharedRiskImportWithSuccess              = Rischio importato con successo
+RiskImport                               = Importazione di rischi
+RiskUnlink                               = Eliminazione del rischio condiviso
+RiskDeleted                              = Il rischio %s è stato eliminato
+RiskSharedWithEntityRefLabel             = Condivisione del rischio %s con
+RiskUnlinkedFromEntityRefLabel           = Dissociazione del rischio %s da
+TheDigiriskelement                       = l'elemento Digirisk
+DefaultProjectContactType                = Ruolo assegnato per impostazione predefinita al progetto del documento di valutazione dei rischi
+DefaultTaskContactType                   = Ruolo assegnato per impostazione predefinita alle attività del progetto del documento di valutazione dei rischi
+RiskListParentView                       = Mostra tutti gli elementi padre
+RiskListParentViewDescription            = Mostra tutti gli elementi padre di un rischio nell'elenco dei rischi e nei documenti
+CategoryOnRisk                           = Mostra i tag/categorie sui rischi
+CategoryOnRiskDescription                = Consente di assegnare tag/categorie ai rischi e di visualizzarli - da usare con cautela
+AddPsychosocialRisk                      = Aggiungi un rischio psicosociale
+AddPsychosocialRiskTitle                 = Aggiunta di un rischio psicosociale
+AddPsychosocialRiskButton                = Aggiungi il rischio psicosociale
+AddSelectedPsychosocialRisks             = Aggiungi i rischi psicosociali selezionati
+SocialRelationsAtWork                    = Rapporti sociali sul lavoro
+WorkIntensityAndTime                     = Intensità e tempo di lavoro
+EmotionalRequirements                    = Esigenze emotive
+Autonomy                                 = Autonomia
+MeaningOfWork                            = Senso del lavoro
+WorkSituationInsecurity                  = Insicurezza della situazione lavorativa
+PreventionContextInCompany               = Contesto di prevenzione in azienda
+RPSImpactOnCompanyAndEmployees           = Impatto dei rischi psicosociali sull'azienda e sui dipendenti
+PsychosocialRisksFactors                 = Fattori di rischio psicosociale
+CompanyPreventionInformations            = Informazioni sulla prevenzione in azienda
+Weak                                     = Basso
+Moderate                                 = Moderato
+High                                     = Elevato
+Extreme                                  = Estremo
+HereIsTheWorkStationDescription          = Ecco la descrizione della postazione di lavoro
+ImageAnalysis                            = Analisi dell'immagine
+TextAnalysis                             = Analisi del testo
+AnalyzeText                              = Analizza il testo
+EnterTextForAnalysis                     = Inserisci il testo da analizzare
+AIRiskAnalysis                           = Analisi dei rischi tramite IA
+AnalysisInProgress                       = Analisi in corso...
+
+# Statistiche
+GreyRisk                                         = Rischio basso
+OrangeRisk                                       = Rischio da pianificare
+RedRisk                                          = Rischio da trattare
+BlackRisk                                        = Rischio inaccettabile
+RisksNotAssessed                                 = Rischi non valutati
+RisksRepartitionByDangerCategories               = Ripartizione dei rischi per categoria di pericolo
+RiskListsByDangerCategories                      = Elenco dei rischi per categoria di pericolo
+DigiriskElementsRepartitionByDepth               = Ripartizione della struttura dei raggruppamenti di livello %s
+RisksRepartitionByDangerCategoriesAndCriticality = Ripartizione dei rischi per categoria di pericolo e criticità
+NumberOfRisks                                    = Numero di rischi
+DangerCategories                                 = Categorie di pericolo
+RisksRepartitionByDigiriskElement                = Ripartizione dei rischi per raggruppamento / unità di lavoro %s
+
+
+
+#
+# RiskEnvironmentals - Rischi ambientali
+#
+
+# Dati
+Environment                                    = Ambiente
+Riskenvironmental                              = Rischio ambientale
+RiskEnvironmentals                             = Rischi ambientali
+Riskenvironmentals                             = Rischi ambientali
+RiskEnvironmentalsMin                          = rischi ambientali
+AddRiskenvironmentalTitle                      = Aggiunta del rischio ambientale
+DigiriskElementRiskenvironmentalsList          = Elenco dei rischi ambientali
+DigiriskElementInheritedRiskenvironmentalsList = Elenco dei rischi ambientali ereditati
+DigiriskElementSharedRiskenvironmentalsList    = Elenco dei rischi ambientali condivisi
+ImportSharedRiskenvironmentals                 = Importa rischi ambientali condivisi
+SelectAllSharedRiskenvironmentalsOfElement     = Seleziona tutti i rischi ambientali di questo elemento
+ConfirmImportSharedRiskenvironmentals          = Scegli i rischi ambientali condivisi da importare
+EnvironmentDescription                         = Pianificazione - Azioni da attuare a fronte dei rischi e delle opportunità
+
+#
+# ListingRisksEnvironmentalAction - Elenco dei rischi ambientali con azioni correttive
+#
+
+# Permesso
+ListingRisksEnvironmentalActionMin = Elenco dei rischi ambientali con azioni correttive
+
+# Dati
+ListingRisksEnvironmentalAction            = Elenco dei rischi ambientali con azioni correttive
+Listingrisksenvironmentalaction            = Elenco dei rischi ambientali con azioni correttive
+ListingRisksEnvironmentalActionGenerated   = Generazione dell'elenco dei rischi ambientali con azioni correttive
+listingrisksenvironmentalaction.odt        = Elenco dei rischi ambientali con azioni correttive
+listingrisksenvironmentalaction_custom.odt = Elenco dei rischi ambientali con azioni correttive personalizzato
+
+#
+# ListingRisksEnvironmentalDocument - Elenco dei rischi ambientali con documenti
+#
+
+# Dati
+ListingRisksEnvironmentalDocument = Elenco dei rischi ambientali
+
+
+
+#
+# RiskAssessment - Valutazione
+#
+
+# Dati
+RiskAssessment                              = Valutazione
+Riskassessment                              = Valutazione
+RiskAssessments                             = Valutazioni
+RiskAssessmentCreated                       = Creazione di una valutazione
+RiskAssessmentModified                      = Modifica di una valutazione
+RiskAssessmentDeleted                       = Eliminazione di una valutazione
+RiskAssessmentConfig                        = Configurazione dei dati delle valutazioni
+TheRiskAssessment                           = La valutazione
+LastRiskAssessment                          = Ultima valutazione del rischio
+RiskAssessmentWellCreated                   = Valutazione creata
+RiskAssessmentNotCreated                    = Errore durante la creazione della valutazione
+RiskAssessmentWellEdited                    = Valutazione modificata
+RiskAssessmentNotEdited                     = Errore durante la modifica della valutazione
+RiskAssessmentWellDeleted                   = Valutazione eliminata
+RiskAssessmentNotDeleted                    = Errore durante l'eliminazione della valutazione
+EvaluationCreate                            = Aggiunta della valutazione
+EvaluationEdit                              = Modifica della valutazione
+EvaluationMethod                            = Metodo di valutazione
+lastEvaluationOn                            = Ultima valutazione il
+DeleteEvaluation                            = Sei sicuro di voler eliminare la valutazione?
+DigiriskRiskAssessmentData                  = Dati configurabili delle valutazioni
+MultipleRiskAssessmentMethodName            = Metodi di valutazione
+MultipleRiskAssessmentMethodDescription     = Attiva il cambio di metodo di valutazione
+AdvancedRiskAssessmentMethod                = Metodo di valutazione avanzato
+AdvancedRiskAssessmentMethodDescription     = Attiva il metodo di valutazione avanzato
+RiskAssessmentList                          = Elenco delle valutazioni del rischio
+EditRiskAssessment                          = Modifica la valutazione
+ShowAllRiskAssessments                      = Vedi tutte le valutazioni
+ShowAllRiskAssessmentsDescription           = Mostra l'elenco completo delle valutazioni dei rischi nell'elenco dei rischi
+ParentRisk                                  = Rischio padre
+RiskAssessmentDate                          = Data della valutazione
+SimpleEvaluation                            = Valutazione semplice
+AdvancedEvaluation                          = Valutazione avanzata
+CalculatedEvaluation                        = Valutazione calcolata
+SelectEvaluation                            = Seleziona le caselle per calcolare la tua valutazione
+EvaluationList                              = Elenco delle valutazioni del rischio
+HowToSetMultipleRiskAssessmentMethod        = Per configurare l'uso multiplo dei metodi di valutazione, vai su Configurazione del modulo - Analisi dei rischi - Valutazione
+NoFileLinked                                = Nessuna foto collegata
+AddRiskAssessment                           = Aggiungi una valutazione del rischio
+AddRiskAssessmentTask                       = Aggiungi un'attività al rischio
+ListRiskAssessmentTask                      = Elenco delle attività del rischio
+ShowRiskAssessmentDate                      = Data delle valutazioni
+ShowRiskAssessmentDateDescription           = Sostituisce la data di creazione con la data di inizio delle valutazioni nella scheda e nei documenti
+RiskAssessmentHideDateInDocument            = Nascondi la data della valutazione nei documenti
+RiskAssessmentHideDateInDocumentDescription = Nascondi la data della valutazione dalla colonna "Informazioni sulla valutazione" nei documenti
+RiskTaskComplete                            = Attività %s completata
+
+# Statistiche
+TasksRepartition = Ripartizione delle attività per avanzamento reale dichiarato
+TaskAt0Percent   = Attività allo 0
+TaskInProgress   = Attività in corso
+TaskAt100Percent = Attività al 100
+
+
+#
+# RiskSign - Segnaletica
+#
+
+# Permessi
+RiskSignsMin = segnaletica
+
+# Dati
+RiskSign                           = Segnaletica
+RiskSignCreated                    = Creazione di una segnaletica
+RiskSignModified                   = Modifica di una segnaletica
+RiskSignDeleted                    = Eliminazione di una segnaletica
+TheRiskSign                        = La segnaletica
+RiskSignConfig                     = Configurazione dei dati della segnaletica
+RiskSignWellCreated                = Segnaletica creata
+RiskSignNotCreated                 = Errore durante la creazione della segnaletica
+RiskSignWellEdited                 = Segnaletica modificata
+RiskSignNotEdited                  = Errore durante la modifica della segnaletica
+RiskSignWellDeleted                = Segnaletica eliminata
+RiskSignNotDeleted                 = Errore durante l'eliminazione della segnaletica
+RiskSignCategory                   = Categoria
+RiskSignImport                     = Importazione di segnaletica
+RiskSignUnlink                     = Eliminazione della segnaletica condivisa
+AddRiskSignTitle                   = Aggiunta di una segnaletica
+AddRiskSignButton                  = Aggiungi la segnaletica
+EditRiskSign                       = Modifica di una segnaletica
+DeleteRiskSignMessage              = Eliminazione della segnaletica
+DigiriskElementRiskSignList        = Elenco della segnaletica
+RiskSigns                          = Segnaletica
+DigiriskElementSharedRiskSignsList = Elenco della segnaletica condivisa
+ImportSharedRiskSigns              = Importa segnaletica condivisa
+SelectAllSharedRiskSignsOfElement  = Seleziona tutta la segnaletica di questo elemento
+AlreadyImportedF                   = Già importata
+ShowSharedRiskSigns                = Segnaletica condivisa
+ShowSharedRiskSignsDescription     = Mostra la segnaletica condivisa nei documenti e negli elenchi
+DigiriskElementSharedRiskSign      = Segnaletica condivisa
+SharedRiskSigns                    = Segnaletica condivisa
+ShareRisksign                      = Attiva la condivisione della segnaletica
+RISKSIGNSharing                    = Condivisione della segnaletica
+RISKSIGNSharingDescription         = Selezione delle entità che condivideranno la propria segnaletica con questa entità.
+UnlinkSharedRiskSign               = Scollega la segnaletica condivisa
+RiskSignWellUnlinkShared           = Segnaletica scollegata
+RiskSignNotUnlinkShared            = Errore durante lo scollegamento della segnaletica
+HasBeenUnlinkSharedF               = è stata scollegata
+HasNotBeenUnlinkSharedF            = non è stata scollegata
+RiskSignSharedTooltip              = Questa opzione consente di condividere la segnaletica. <br> INFO: se desideri visualizzare le attività, devi attivare l'opzione di condivisione dei progetti.
+ShowInheritedRiskSigns             = Segnaletica ereditata
+ShowInheritedRiskSignsDescription  = Mostra la segnaletica ereditata nei documenti e negli elenchi
+DigiriskElementInheritedRiskSignsList = Elenco della segnaletica ereditata
+ConfirmImportSharedRiskSigns       = Scegli la segnaletica condivisa da importare
+RiskSignSharedWithEntityRefLabel   = Condivisione della segnaletica %s con
+RiskSignUnlinkedFromEntityRefLabel = Dissociazione della segnaletica %s da
+
+#
+# Tasks - Attività
+#
+
+# Dati
+ActionPlan                               = Piano d'azione
+Task                                     = Attività
+TaskCreatedEvent                         = Creazione di un'attività
+TaskModifiedEvent                        = Modifica di un'attività
+TaskDeletedEvent                         = Eliminazione di un'attività
+TheTask                                  = L'attività
+TaskConfig                               = Configurazione dei dati delle attività
+TaskWellCreated                          = Attività creata
+TaskNotCreated                           = Errore durante la creazione dell'attività
+TaskWellEdited                           = Attività modificata
+TaskNotEdited                            = Errore durante la modifica dell'attività
+TaskWellDeleted                          = Attività eliminata
+TaskNotDeleted                           = Errore durante l'eliminazione dell'attività
+TasksManagement                          = Gestione delle attività
+SelectProject                            = Scelta del progetto
+DUProject                                = Progetto collegato alle attività dei rischi
+EnvironmentProject                       = Progetto collegato alle attività dei rischi ambientali
+NoTaskLinked                             = Nessuna attività in corso
+TaskList                                 = Elenco delle attività del rischio
+TaskCreate                               = Aggiunta dell'attività
+TaskEdit                                 = Modifica dell'attività
+HowToSetDUProject                        = Per configurare la scelta del progetto, vai su Configurazione del modulo - Analisi dei rischi - Attività
+DeleteTask                               = Sei sicuro di voler eliminare l'attività?
+ListingHeaderTask                        = Elenco delle attività
+ListingHeaderTaskTooltip                 = Attiva la condivisione dei progetti per visualizzare le attività
+TasksManagementDescription               = Attiva la gestione delle attività
+TaskManagementNotActivated               = Attiva la gestione delle attività in Configurazione del modulo / Analisi dei rischi / Attività
+DigiriskProgress                         = Avanzamento
+ShowTaskStartDate                        = Data di inizio delle attività
+ShowTaskStartDateDescription             = Sostituisce la data di creazione con la data di inizio delle attività nella scheda e nei documenti
+ShowTaskEndDate                          = Data di fine delle attività
+ShowTaskEndDateDescription               = Mostra la data di fine delle attività
+ShowTasksDone                            = Attività completate
+ShowTasksDoneDescription                 = Mostra le attività completate al 100
+ShowTasksDoneDescriptionExtend           = negli elenchi dei rischi
+ShowTaskCalculatedProgress               = Avanzamento dell'attività
+ShowTaskCalculatedProgressDescription    = Mostra l'avanzamento calcolato dell'attività anziché l'avanzamento dichiarato
+ShowAllTasks                             = Tutte le attività di un rischio negli elenchi
+ShowAllTasksDescription                  = Mostra tutte le attività nell'elenco delle attività di un rischio negli elenchi
+DeleteTaskTimeSpent                      = Sei sicuro di voler eliminare %s min di tempo impiegato dall'attività?
+TaskTimeSpentEdit                        = Modifica del tempo impiegato dell'attività
+TheTaskTimeSpent                         = Il tempo impiegato
+TaskTimeSpentCreated                     = Creazione di tempo impiegato
+TaskTimeSpentModified                    = Modifica di tempo impiegato
+TaskTimeSpentDeleted                     = Eliminazione di tempo impiegato
+TaskTimeSpentWellCreated                 = Tempo impiegato creato
+TaskTimeSpentNotCreated                  = Errore durante la creazione del tempo impiegato
+TaskTimeSpentWellEdited                  = Tempo impiegato modificato
+TaskTimeSpentNotEdited                   = Errore durante la modifica del tempo impiegato
+TaskTimeSpentWellDeleted                 = Tempo impiegato eliminato
+TaskTimeSpentNotDeleted                  = Errore durante l'eliminazione del tempo impiegato
+OnTheTask                                = sull'attività
+TaskTimeSpentDuration                    = Durata del tempo impiegato
+TaskTimeSpentDurationDescription         = Il tempo impiegato aggiunto per impostazione predefinita a ogni attività
+NoTaskShared                             = Nessuna attività condivisa
+WarningTaskLabel                         = Attenzione, hai superato il numero massimo di caratteri consentito (255)
+ErrorRecordHasSubTasks                   = L'attività ha elementi figlio
+TotalConsumedTime                        = Totale tempo impiegato sul progetto
+TotalConsumedTimeAmount                  = Costo del tempo impiegato
+NbTasks                                  = Numero di attività
+TotalProgress                            = Avanzamento reale globale delle attività
+TotalBudget                              = Somma del budget delle attività
+TaskTimeSpentDate                        = Data del tempo impiegato
+StartDateCannotBeAfterEndDate            = La data di fine non può essere anteriore alla data di inizio
+TasksFromProject                         = Le attività visualizzate provengono dal progetto definito come "Progetto documento di valutazione dei rischi"
+TaskHideRefInDocument                    = Nascondi il riferimento
+TaskHideRefInDocumentDescription         = Nascondi il riferimento dell'attività nei documenti
+TaskHideResponsibleInDocument            = Nascondi il responsabile
+TaskHideResponsibleInDocumentDescription = Nascondi il responsabile dell'attività nei documenti
+TaskHideDateInDocument                   = Nascondi la data
+TaskHideDateInDocumentDescription        = Nascondi la data di inizio e di fine dell'attività nei documenti
+TaskHideBudgetInDocument                 = Nascondi il budget
+TaskHideBudgetInDocumentDescription      = Nascondi il budget dell'attività nei documenti
+
+#
+# DigiAI - DigiAI
+#
+
+# Dati
+WelcomeToDigiAI = Benvenuto in DigiAI
+UploadAnImage = Carica un'immagine
+OpenAIApiKey = Chiave API OpenAI
+OpenAIApiKeyDescription = Per utilizzare DigiAI devi disporre di una chiave API OpenAI. Puoi ottenerne una creando un account su <a href="https://platform.openai.com/signup" target="_blank">https://platform.openai.com/signup</a>. Dopo la registrazione potrai generare una chiave API nella sezione "API Keys" del tuo cruscotto.
+
+#
+# Ticket - Interfaccia pubblica dei ticket
+#
+
+# Permessi
+TicketTagsConfig                         = Modifica dei registri di sicurezza e salute sul lavoro
+
+# Dati
+Register                                 = Registro
+Send                                     = Invia
+TicketSent                               = Ticket inviato
+FilesLinked                              = Foto / Allegati
+AddDocument                              = Aggiungi documento
+LastnamePlaceholder                      = Esempio: Rossi
+FirstnamePlaceholder                     = Esempio: Mario
+PhonePlaceholder                         = 00.00.00.00.00
+LocationPlaceholder                      = Esempio: Ufficio A
+ServicePlaceholder                       = Esempio: Operatore ecologico
+Location                                 = Luogo
+CategoriesCreated                        = Creazione delle categorie di ticket
+ExtrafieldsCreated                       = Creazione dei campi aggiuntivi dei ticket
+AnticipatedLeave                         = Uscita anticipata
+DGI                                      = Pericolo grave e imminente
+SST                                      = Sicurezza e salute sul lavoro
+PresquAccident                           = Mancato infortunio
+Accident                                 = Infortunio
+EnhancementSuggestion                    = Suggerimento di miglioramento
+MaterialProblem                          = Problema materiale
+HumanProblem                             = Problema umano
+Others                                   = Altro
+AccidentWithoutDIAT                      = Infortunio lieve
+AccidentWithDIAT                         = Infortunio sul lavoro
+Environment                              = Ambiente
+Quality                                  = Qualità
+NonCompliance                            = Non conformità
+FirstName                                = Nome
+LastName                                 = Cognome
+Phone                                    = Telefono
+DeclarationDate                          = Dichiarazione
+DigiriskTicketPublicAccess               = Un'interfaccia pubblica che non richiede alcuna identificazione è disponibile al seguente URL
+TicketActivatePublicInterface            = Attiva l'interfaccia pubblica
+GenerateExtrafields                      = Generazione dei campi aggiuntivi predefiniti dei ticket
+GenerateTicketCategories                 = Generazione delle categorie predefinite dei ticket
+AlreadyGenerated                         = Già generati
+NotGenerated                             = Non ancora generato
+NotCreated                               = Non ancora creati
+ExtrafieldsGeneration                    = Questa opzione consente la generazione dei campi aggiuntivi predefiniti dei ticket. I campi creati saranno: <br> Cognome, Nome, Telefono, GP/UT, Luogo e Data
+CategoriesGeneration                     = Questa opzione consente la generazione delle categorie predefinite dei ticket. Le categorie create saranno: <br> - Registro <br> - - Infortunio <br> - - - Mancato infortunio, Infortunio lieve, Infortunio sul lavoro <br> - - Sicurezza e salute sul lavoro <br> - - - Uscita anticipata, Altro, Problema umano, Problema materiale <br> - - Pericolo grave e imminente <br> - - Qualità <br> - - - Non conformità, Suggerimento di miglioramento <br> - - Ambiente <br> - - - Non conformità, Altro
+TicketSuccess                            = Il tuo registro è stato trasmesso al servizio prevenzione con il numero:
+TicketPublicAccess                       = Link di ritorno all'interfaccia pubblica dei ticket:
+TicketShowCompanyLogo                    = Mostra il logo dell'azienda nell'interfaccia pubblica
+TicketShowCompanyLogoHelp                = Attiva questa opzione per nascondere il logo dell'azienda nelle pagine dell'interfaccia pubblica
+YouMustNotifyYourHierarchy               = Hai l'<b>obbligo</b> di avvisare i tuoi superiori
+GoBackToTicketCreation                   = Vai alla pagina di monitoraggio dei ticket
+SendEmailOnTicketSubmit                  = Invia email alla creazione
+CatTicketsList                           = Elenco dei tag/categorie dei ticket
+SendEmailTo                              = Indirizzo email da notificare
+SendEmailOnTicketSubmitHelp              = Attiva l'invio automatico di un'email alla creazione di un ticket
+MultipleEmailsSeparator                  = Per assegnare più indirizzi email da notificare, separali con un ";". Ad esempio: "aaaa@bbb.cc;dddd@eee.ff"
+TicketCategories                         = Categorie dei ticket
+TicketDocumentsConfig                    = Documenti dei ticket
+TicketExtrafields                        = Campi aggiuntivi dei ticket
+MainCategorySetting                      = Questa opzione consente di definire la categoria le cui sottocategorie compariranno nell'interfaccia pubblica
+TicketCategoriesInDocumentsSetting       = Questa opzione consente di scegliere le categorie di ticket visualizzate nell'elenco dei ticket dei documenti (Documento di valutazione dei rischi, scheda di raggruppamento, ecc.). Se non è selezionata alcuna categoria, vengono visualizzate tutte le categorie
+ParentCategorySetting                    = Questa opzione consente di definire il titolo della categoria padre per l'interfaccia pubblica dei ticket
+ChildCategorySetting                     = Questa opzione consente di definire il titolo della categoria figlia per l'interfaccia pubblica dei ticket
+TicketManagement                         = Gestione dei ticket
+MainCategory                             = Scelta della categoria principale
+TicketCategoriesInDocuments              = Categorie visualizzate nei documenti
+ParentCategoryLabel                      = Titolo della categoria padre
+ChildCategoryLabel                       = Titolo della categoria figlia
+TicketPublicInterfaceEnabled             = L'interfaccia pubblica dei ticket è stata attivata
+TicketPublicInterfaceDisabled            = L'interfaccia pubblica dei ticket è stata disattivata
+TicketPublicInterface                    = Interfaccia pubblica
+EmailsToNotifySet                        = Gli indirizzi email da notificare sono stati registrati
+MainCategorySet                          = La categoria principale è stata definita
+TicketCategoriesInDocumentsSet           = Le categorie visualizzate nei documenti sono state definite
+ParentCategoryLabelSet                   = Il titolo della categoria padre è stato definito
+ChildCategoryLabelSet                    = Il titolo della categoria figlia è stato definito
+TicketPublicInterfaceConfigDocumentation = Per configurare l'interfaccia pubblica dei ticket, consulta la documentazione
+ParentCategory                           = Categoria padre
+TSProject                                = Progetto collegato ai ticket
+TicketDescription                        = Progetto dei ticket
+TicketProjectUpdated                     = Il progetto predefinito dei ticket è stato aggiornato
+QRCodeAlreadyGenerated                   = Codice QR generato
+GenerateQRCode                           = Genera il codice QR
+CompanyQRCodeGeneration                  = Generazione del codice QR dell'entità
+QRCodeGeneration                         = Generazione del codice QR
+MultiCompanyQRCodeGeneration             = Generazione del codice QR multi-entità
+TicketCreationMailWellSent               = Email di conferma della creazione del ticket inviata
+TicketCreationMailSent                   = L'email di creazione del ticket è stata inviata a %s
+HowToSetupTicketCategories               = Per configurare le categorie di ticket, fai clic su questo link:
+ConfigTicketCategories                   = Configurazione delle categorie di ticket
+NewTicketSubmitted                       = Un ticket è stato inviato tramite l'interfaccia pubblica
+ANewTicketHasBeenSubmitted               = Nuovo registro di sicurezza creato per %s
+TicketCreationSubject                    = Creazione di ticket tramite l'interfaccia pubblica di Digirisk
+TicketDocumentCustomDigiriskTemplate     = ODT personalizzato delle schede di ticket
+HowToSetupDigiriskElement                = Per configurare gli elementi di Digirisk (raggruppamenti/unità di lavoro), fai clic su questo link:
+ConfigDigiriskElement                    = Configurazione degli elementi di Digirisk
+ErrorFieldEmail                          = Errore: l'email deve corrispondere al seguente formato: <b>'aaa@aaa.fr'</b>
+ErrorFieldPhone                          = Errore: il telefono deve corrispondere al seguente formato: <b>'0XXXXXXXXXXX'</b> o <b>'+33XXXXXXXXX'</b>
+TicketEmailRequired                      = Email obbligatoria per creare un ticket
+TicketEmailRequiredHelp                  = Attiva questa opzione per rendere obbligatorio l'inserimento di un'email per creare un ticket nell'interfaccia pubblica
+WelcomeToPublicTicketInterface           = Benvenuto nell'interfaccia pubblica dei ticket
+PleaseSelectAnEntity                     = Seleziona un'entità:
+ShowSelectorOnTicketPublicInterface      = Mostra il selettore multi-entità nell'interfaccia pubblica dei ticket anziché l'elenco delle entità
+ShowSelectorOnTicketPublicInterfaceHelp  = Mostra il selettore multi-entità nell'interfaccia pubblica dei ticket anziché l'elenco delle entità con il loro logo
+MultiEntityPublicInterface               = Interfaccia pubblica dei ticket multi-azienda
+TicketCategoriesNotCreated               = Non hai creato categorie di ticket
+TicketPublicInterfaceQRCode              = Codice QR dell'interfaccia pubblica dei ticket
+MultiEntityTicketPublicInterfaceQRCode   = Codice QR dell'interfaccia pubblica dei ticket multi-azienda
+PublicInterfaceConfiguration             = Campi visibili / obbligatori dell'interfaccia pubblica
+TicketNumber                             = N. del ticket
+FromAndDate                              = Provenienza e data
+AuthorRequest                            = Richiedente
+DateCloture                              = Data di chiusura
+
+PublicInterfaceUseSignatory              = Firma obbligatoria per dichiarare questo registro
+ValidateText                             = Condizioni da accettare per la firma
+TicketPublicInterfaceShowCategory        = Mostra la descrizione della categoria
+EmailTemplate                            = Modello di email
+EmailTemplateDescription                 = Modello di email
+
+OpenInNewTab                             = Apri in una nuova scheda
+TicketDigiriskElementRequired            = GP/UT obbligatorio per creare un ticket
+TicketDigiriskElementRequiredHelp        = Attiva questa opzione per rendere obbligatoria la selezione di un GP/UT per creare un ticket nell'interfaccia pubblica
+TicketDigiriskElementHideRef             = Nascondi il riferimento dei GP/UT nel selettore di servizio dell'interfaccia pubblica
+TicketDigiriskElementHideRefHelp         = Attiva questa opzione per nascondere il riferimento di un GP/UT nell'interfaccia pubblica
+TicketDigiriskelementVisible             = Mostra il campo GP/UT per creare un ticket
+TicketServiceVisible                     = Mostra il campo GP/UT per creare un ticket
+TicketDigiriskelementVisibleHelp         = Attiva questa opzione per mostrare il campo GP/UT nell'interfaccia pubblica e renderlo obbligatorio se necessario
+TicketServiceVisibleHelp                 = Attiva questa opzione per mostrare il campo GP/UT nell'interfaccia pubblica e renderlo obbligatorio se necessario
+TicketPhotoVisible                       = Mostra il campo Foto per creare un ticket
+TicketPhotoVisibleHelp                   = Attiva questa opzione per mostrare il campo Foto nell'interfaccia pubblica
+TicketEmailVisible                       = Mostra il campo Email per creare un ticket
+TicketEmailVisibleHelp                   = Attiva questa opzione per mostrare il campo Email nell'interfaccia pubblica e renderlo obbligatorio se necessario
+TicketLastnameVisible                    = Mostra il campo Cognome per creare un ticket
+TicketLastnameVisibleHelp                = Attiva questa opzione per mostrare il campo Cognome nell'interfaccia pubblica e renderlo obbligatorio se necessario
+TicketFirstnameVisible                   = Mostra il campo Nome per creare un ticket
+TicketFirstnameVisibleHelp               = Attiva questa opzione per mostrare il campo Nome nell'interfaccia pubblica e renderlo obbligatorio se necessario
+TicketPhoneVisible                       = Mostra il campo Telefono per creare un ticket
+TicketPhoneVisibleHelp                   = Attiva questa opzione per mostrare il campo Telefono nell'interfaccia pubblica e renderlo obbligatorio se necessario
+TicketLocationVisible                    = Mostra il campo Luogo per creare un ticket
+TicketLocationVisibleHelp                = Attiva questa opzione per mostrare il campo Luogo nell'interfaccia pubblica e renderlo obbligatorio se necessario
+TicketDateVisible                        = Mostra il campo Data per creare un ticket
+TicketDateVisibleHelp                    = Attiva questa opzione per mostrare il campo Data nell'interfaccia pubblica e renderlo obbligatorio se necessario
+QRCodeGenerated                          = Codice QR generato
+FkTicket                                 = Ticket collegato
+PublicTicket                             = Interfaccia pubblica dei ticket
+TicketPublicInterfaceForbidden           = Accesso vietato all'interfaccia pubblica dei ticket
+DefaultUserGroup                         = Gruppo predefinito
+DefaultUserGroupDescription              = Gruppo predefinito nei selettori di gruppi
+ConfigureDefaultUserGroup                = Configura il gruppo predefinito
+RegisterSigned                           = Registro firmato
+
+#Interfaccia pubblica
+TicketPublicInterfaceShowCategoryDescription     = Mostra la descrizione delle categorie di ticket nell'interfaccia pubblica
+TicketPublicInterfaceShowCategoryDescriptionHelp = Attiva questa opzione per mostrare la descrizione delle categorie di ticket nell'interfaccia pubblica
+
+
+# Statistiche
+TicketStatistics    = Statistiche dei ticket
+ExportCSV           = Esportazione CSV
+GenerateCSV         = Genera il file CSV
+SuccessGenerateCSV  = File CSV %s generato con successo
+ErrorMissingData    = Errore: impossibile generare il file CSV, i dati inviati al file non sono corretti. <br> Verifica di avere GP/UT assegnati a dei ticket.
+CSVFileExport       = Esportazione dei registri in formato CSV associati a GP/UT
+ThirdPartyHelp      = Se il filtro "Terzo" è vuoto, nessun terzo viene utilizzato per la ricerca
+GP/UTHelp           = Per impostazione predefinita, il filtro considera tutti i GP/UT
+CategoryTicketHelp  = Per impostazione predefinita, il filtro considera tutte le categorie
+CreatedByHelp       = Se il filtro "Creato da" è vuoto, nessun utente viene utilizzato per la ricerca
+AssignedToHelp      = Se il filtro "Assegnato a" è vuoto, nessun utente viene utilizzato per la ricerca
+StatusHelp          = Per impostazione predefinita, il filtro considera tutti gli stati<br>
+ConcernedTimePeriod = Periodo considerato
+LessThan            = Meno di
+MoreThan            = Più di
+Comparator          = Comparatore
+RangeNumber         = Quantità
+TimeRange           = Unità di tempo
+RangeLabel          = Nome del vincolo
+Inferior            = Inferiore a
+Superior            = Superiore a
+TimeRangeAdded      = Vincolo aggiunto
+TimeRangeDeleted    = Vincolo eliminato
+
+NumberOfTicketsByMainCategorieAndDigiriskElement    = Numero di registri per categoria e per GP
+NumberOfTicketsByMainSubCategorieAndDigiriskElement = Numero di registri per sottocategoria e per GP
+NumberOfTicketsByYear                           = Numero di ticket per anno
+
+# Ticket Management Dashboard - Cruscotto di gestione dei ticket
+TicketManagementDashboard                 = Cruscotto di gestione dei ticket
+RunningTicket                             = Ticket in corso
+NbOfOpenedTicket                          = Numero di ticket aperti
+OldestTicket                              = Ticket più vecchio
+OldestTicketDescription                   = Ticket più vecchio con il tempo trascorso dalla sua creazione
+OldestMessageTicket                       = Ticket più vecchio con un messaggio
+OldestMessageTicketDescription            = Ticket più vecchio con un messaggio e il tempo trascorso dalla creazione del messaggio
+MeanAnswerTime                            = Tempo medio di risposta
+MeanAnswerTimeDescription                 = Tempo medio tra l'apertura e la chiusura, calcolato solo sui ticket chiusi
+MeanFirstResponseTime                     = Tempo medio della prima risposta
+MeanFirstResponseTimeDescription          = Tempo medio tra l'apertura del ticket e il primo messaggio visibile al dichiarante. Le note interne non contano e i ticket senza messaggio pubblico sono esclusi dal calcolo
+NbTicketPerUser                           = Numero medio di ticket assegnati per persona
+NbExchangePerTicket                       = Numero di scambi per ticket
+TicketRepartitionPerUserAndMeanAnswerTime = Ripartizione dei ticket per utente e tempo medio di risposta
+TopSocietyWithMostTickets                 = Top %s delle aziende con più ticket
+TicketsCreatedVersusClosedByMonth         = Ticket creati e chiusi negli ultimi %s mesi
+TicketsCreated                            = Creati
+TicketsClosed                             = Chiusi
+OpenTicketsByStatus                       = Ripartizione dei ticket aperti per stato
+OpenTicketBacklogAge                      = Anzianità dei ticket aperti (dalla creazione)
+BacklogAgeUnderDays                       = Meno di %s giorni
+BacklogAgeBetweenDays                     = Da %s a %s giorni
+BacklogAgeOverDays                        = Più di %s giorni
+ShowSelectedDateTypes                     = Seleziona il tipo di data da visualizzare
+
+# Email
+The                            = Il
+TicketMessage                  = Messaggio del registro
+SeeTicketUrl                   = Vedi il ticket
+AutoNotificationTicket         = Notifica email inviata automaticamente da
+TicketPublicInterfaceOtherName = Interfaccia di gestione dei registri di sicurezza e salute sul lavoro e di pericolo grave e imminente
+
+
+
+# Documento del ticket
+
+# Dati
+TicketDocument                 = Scheda del ticket
+Ticketdocument                 = Scheda del ticket
+ticketdocument.odt             = Scheda del ticket
+ticketdocument_custom.odt      = Scheda personalizzata del ticket
+ticketdocument_events.odt      = Scheda del ticket con eventi
+ticketdocument_sign.odt        = Scheda del ticket con firma
+ticketdocument_event_sign.odt  = Scheda del ticket con evento e firma
+TicketSuccessMessage           = Messaggio di successo del ticket
+TicketSuccessMessageSet        = Il messaggio è stato modificato
+TicketDocumentPDF              = FT-A4-ORIZZONTALE
+TicketDocumentPDFDescription   = Mostra la scheda del ticket
+GeneratedTicketDocumentDate    = Data di esportazione di questo ticket
+
+
+# Documento di progetto
+
+# Modello ODT
+DigiriskTemplateDocumentProject = Modelli di documento delle schede di progetto di Digirisk
+DocumentModelPapripactA3Paysage = Modelli di documento di rapporto previsionale sulle attività dei progetti
+PapripactFullName               = Programma Annuale di Prevenzione dei Rischi Professionali e di Miglioramento delle Condizioni di Lavoro
+
+# Documento di registro
+
+RegisterDocument     = Registro degli infortuni sul lavoro lievi
+Registerdocument     = Registro degli infortuni sul lavoro lievi
+RegisterDocumentsMin = registri degli infortuni sul lavoro lievi
+registerdocument.odt = Registro degli infortuni sul lavoro lievi
+
+#
+# Tools - Strumenti
+#
+
+# Dati
+Tools                                        = Strumenti
+DigiriskDataMigration                        = Gestione dei dati di migrazione
+DataMigrationImport                          = Importazione dei dati della struttura di Digirisk
+DataMigrationImportDescription               = Importazione dei dati della struttura di Digirisk WordPress in formato ZIP
+DataMigrationImportRisks                     = Importazione dei dati dei rischi di Digirisk
+DataMigrationImportRisksDescription          = Importazione dei dati dei rischi di Digirisk WordPress in formato ZIP
+ErrorFileNotWellFormatted                    = Il file non è nel formato corretto o è vuoto. Devi allegare un file di importazione proveniente da Digirisk WordPress denominato DATE_OBJET_export.json
+ErrorFileNotWellFormattedZIP                 = Il file non è nel formato corretto o è vuoto. Devi allegare un file di importazione proveniente da Digirisk WordPress denominato DATE_OBJET_export.zip
+ErrorJsonBadFormatted                        = Il file JSON non è formattato correttamente
+SuccessImport                                = Importazione dei dati riuscita
+DataMigrationImportRiskSigns                 = Importazione dei dati della segnaletica di Digirisk
+DataMigrationImportRiskSignsDescription      = Importazione dei dati della segnaletica di Digirisk WordPress in formato ZIP
+DataMigrationImportGlobal                    = Importazione dei dati globali di Digirisk <br> (Struttura, rischi e segnaletica)
+DataMigrationImportGlobalDescription         = Importazione dei dati globali di Digirisk WordPress in formato ZIP <br> (Struttura, rischi e segnaletica)
+DataMigrationExportGlobal                    = Esportazione dei dati globali di Digirisk <br> (Struttura, rischi e segnaletica)
+DataMigrationExportGlobalDescription         = Esportazione dei dati globali di Digirisk Dolibarr in formato ZIP <br> (Struttura, rischi e segnaletica)
+DataMigrationExportTree                      = Esportazione della struttura di Digirisk <br> (Solo la struttura)
+DataMigrationExportTreeDescription           = Esportazione della struttura di Digirisk Dolibarr in formato ZIP <br> (GP/UT visibili dell'entità corrente, senza i rischi né la segnaletica)
+DataMigrationImportGlobalDolibarrDescription = Importazione dei dati globali di Digirisk Dolibarr in formato ZIP <br> (Struttura, rischi e segnaletica)
+DataMigrationTreeAlreadyImported             = Importazione dei dati della struttura già effettuata
+DataMigrationRisksAlreadyImported            = Importazione dei dati dei rischi già effettuata
+DataMigrationRiskSignsAlreadyImported        = Importazione dei dati della segnaletica già effettuata
+DataMigrationGlobalAlreadyImported           = Importazione dei dati globali (Struttura, rischi e segnaletica) già effettuata
+AdvancedImport                               = Importazione avanzata
+AdvancedImportDescription                    = Consente di importare ogni elemento in modo indipendente (Struttura, rischi e segnaletica)
+DataMigrationWordPressToDolibarr             = Migrazione dei dati da WordPress a Dolibarr
+DataMigrationDolibarrToDolibarr              = Migrazione dei dati da Dolibarr a Dolibarr
+RepairRisks                                  = Ripara i rischi
+NumberOfRisksCorrupted                       = Hai %s rischio/i la cui categoria è danneggiata, vai sulla pagina "Strumenti" per ripararli
+NoRiskToRepair                               = Nessun rischio da riparare
+DigiriskElementSuccessfullyRepaired          = Elementi Digirisk (GP/UT) riparati con successo
+RiskSuccessfullyRepaired                     = Rischi riparati con successo
+RiskAssessmentSuccessfullyRepaired           = Valutazioni riparate con successo
+CorruptedCategoryOnRiskList                  = Elenco dei rischi la cui categoria è danneggiata
+
+# Clean - Pulizia
+Clean                                          = Pulizia
+CleanObject                                    = Pulisci i dati
+CleanDigiriskElementExistParentDigiriskElement = %d elementi Digirisk (GP/UT) hanno un elemento padre non valido
+CleanDigiriskElement                           = Pulisci gli elementi Digirisk (GP/UT)
+CleanRiskFkElement                             = %d rischi hanno un GP/UT non valido
+CleanRiskStatus                                = %d rischi hanno uno stato non valido
+CleanRiskExistFkElement                        = %d rischi sono orfani
+CleanRiskExistRiskAssessment                   = %d rischi non hanno alcuna valutazione
+CleanRisk                                      = Pulisci i rischi
+CleanRiskAssessmentStatus                      = %d valutazioni hanno uno stato non valido
+CleanRiskAssessmentCotation                    = %d valutazioni hanno una quotazione vuota
+CleanRiskAssessmentExistFkRisk                 = %d valutazioni sono orfane
+CleanRiskAssessment                            = Pulisci le valutazioni
+NoDigiriskElementToClean                       = Nessun elemento Digirisk (GP/UT) da pulire
+NoRiskToClean                                  = Nessun rischio da pulire
+NoRiskAssessmentToClean                        = Nessuna valutazione da pulire
+
+
+#
+# Altro
+#
+
+# Dati
+AT = al
+
+LabourInspectorName                 = DREETS
+UrlLabourInspector                  = https://travail-emploi.gouv.fr/ministere/organisation/article/dreets-directions-regionales-de-l-economie-de-l-emploi-du-travail-et-des
+IDCCTooltip                         = Questo campo proviene dal modulo Digirisk per Dolibarr <br> La nomenclatura dei contratti collettivi proviene da travail-emploi.gouv.fr
+NoEmailContact                      = Nessuna email su questo contatto
+AddMedia                            = Aggiungi un file multimediale
+NoMediaLinked                       = Nessun file multimediale collegato
+UserGroup                           = Gruppo di utenti
+ReaderGroup                         = Gruppo di lettori
+UserCreated                         = L'utente è stato creato
+GetAPI                              = Utilizzo delle rotte API Digirisk con il metodo GET
+PostAPI                             = Utilizzo delle rotte API Digirisk con il metodo POST
+MinimizeMenu                        = Riduci il menu
+ActionsLine                         = Azioni
+PhotoWellSent                       = La foto è stata aggiunta alla libreria multimediale
+PhotoNotSent                        = La foto non è stata inviata correttamente
+PhotoWellSaved                      = Il/i file multimediale/i è/sono stato/i aggiunto/i
+PhotoNotSaved                       = Il/i file multimediale/i non è/sono stato/i aggiunto/i
+UseCaptcha                          = Codice grafico (CAPTCHA)
+UseCaptchaDescription               = Utilizzo del codice grafico (CAPTCHA) nelle pagine dell'interfaccia pubblica
+GP/UTParticipation                  = Partecipazione GP/UT
+LabourDoctorName                    = AMETRA
+LabourDoctorFirstName               = Medico
+LabourDoctorLastName                = competente
+DashBoard                           = Cruscotto
+Close                               = Chiudi
+DateRange                           = Intervallo di date
+UseDateRange                        = Utilizza l'intervallo di date
+SiretNumber                         = N. partita IVA
+Society                             = Azienda
+MulticompanyTransverseModeEnabled   = La gestione centralizzata degli utenti e dei gruppi sull'entità principale è attiva.<br>Non puoi quindi creare un utente o un gruppo su questa entità.<br>Accedi all'entità principale per effettuare questa aggiunta.
+ManuelInputNBEmployees              = Inserisci manualmente il numero di dipendenti
+ManuelInputNBEmployeesDescription   = Se l'opzione è attiva, puoi inserire manualmente il numero di dipendenti nella configurazione dell'azienda.<br>In caso contrario, il numero di dipendenti viene calcolato.<br>Consulta la documentazione per maggiori informazioni.
+ManuelInputNBWorkedHours            = Inserisci manualmente il numero di ore lavorate
+ManuelInputNBWorkedHoursDescription = Se l'opzione è attiva, puoi inserire manualmente il numero di ore lavorate nella configurazione dell'azienda.<br>In caso contrario, il numero di ore lavorate viene calcolato.<br>Consulta la documentazione per maggiori informazioni.
+ShowPatchNoteAgain                  = Mostra la nota di aggiornamento
+ShowPatchNoteAgainDescription       = Se l'opzione è attiva, la nota di aggiornamento della versione corrente ricompare nella pagina iniziale di Digirisk.<br>(Richiede che l'opzione «Mostra le note di aggiornamento da GitHub» sia attiva per essere visibile.)
+HowToConfigureSetupConf             = Per configurare i dati dell'azienda collegati a Digirisk,<br>accedi a Digirisk - Configurazione - Impostazioni
+LabourDoctorNameFull                = Associazione dei Medici
+PermissionInheritedFromConfig       = I permessi sono ereditati dalla configurazione generale o dalla configurazione padre
+CategorieManagement                 = Gestione delle categorie
+ShowSelectedRiskTypes               = Seleziona i tipi di rischio da visualizzare
+CharRemaining                       = Caratteri rimanenti
+NumberOfLinkedFiles                 = Numero di file allegati
+ChooseAnImage                       = Scegli un'immagine
+
+# Action Plan - Gantt / Kanban
+ActionPlanGantt                     = Diagramma di Gantt
+ActionPlanKanban                    = Kanban
+ActionPlanView                      = Piano d'azione
+ColumnDraft                         = Bozza
+ColumnInProgress                    = In corso
+ColumnInControl                     = Da controllare
+ColumnDone                          = Completato
+NoTasks                             = Nessuna azione correttiva
+ActionPlanGlobalProgress            = Avanzamento globale del PAPRIPACT
+ActionPlanGlobalProgressInfo        = Media dell'avanzamento di %s azione/i correttiva/e
+KanbanLoadMore                      = Vedi altro (%s)
+KanbanDisplay                       = Visualizzazione del Kanban
+KanbanPageSize                      = Numero di schede per colonna
+KanbanPageSizeDesc                  = Numero di azioni correttive visualizzate subito in ogni colonna; le successive vengono caricate tramite il pulsante «Vedi altro» (migliora le prestazioni con grandi volumi)
+KanbanDraftMax                      = Soglia colonna «Bozza»
+KanbanDraftMaxDesc                  = Avanzamento massimo (%) affinché un'azione resti nella colonna «Bozza»
+KanbanProgressMax                   = Soglia colonna «In corso»
+KanbanProgressMaxDesc               = Avanzamento massimo (%) per la colonna «In corso»
+KanbanControlMax                    = Soglia colonna «Da controllare»
+KanbanControlMaxDesc                = Avanzamento massimo (%) per la colonna «Da controllare»; oltre tale soglia l'azione passa a «Completato»
+PlannedWorkload                     = Carico previsto
+TimeSpent                           = Tempo impiegato
+LinkedRisk                          = Rischio associato
+TaskMovedTo                         = Attività spostata su %s
+
+AddCategory                        = Aggiungi una categoria
+SelectCategory                     = Scegli una categoria
+DateEndBeforeStart                 = Data di fine anteriore a quella di inizio
+InternalUsers                      = Utenti interni
+ExternalContacts                   = Contatti esterni
+AddContributor                     = Aggiungi un collaboratore
+RemoveContact                      = Rimuovi il contatto
+ColumnWidth                        = Larghezza
+ColumnGap                          = Spaziatura
+ActionPlanExportCsv                = Scarica il PAPRIPACT in formato CSV
+ActionPlanExportA3                 = Scarica il PAPRIPACT in PDF A3 orizzontale
+ActionPlanExportGantt              = Scarica il diagramma di Gantt come immagine PNG
+ActionPlanDisplayedProject         = Progetto visualizzato
+ActionPlanChangeProject            = Cambia progetto
+ActionPlanDefaultProject           = Documento di valutazione dei rischi (predefinito)
+ActionPlanNoProjectConfigured      = Nessun progetto configurato
+
+# ActionPlan — Registrazione degli eventi
+ActionPlanLogging                  = Piano d'azione — Cronologia delle modifiche
+ActionPlanLoggingDescription       = Attiva la creazione di eventi durante le modifiche nel Kanban
+ActionPlanLogLabel                 = Modifica della denominazione
+ActionPlanLogLabelDesc             = Crea un evento quando la denominazione di un'attività viene modificata
+ActionPlanLogWorkload              = Modifica del carico
+ActionPlanLogWorkloadDesc          = Crea un evento quando il carico previsto viene modificato
+ActionPlanLogBudget                = Modifica del budget
+ActionPlanLogBudgetDesc            = Crea un evento quando il budget viene modificato
+ActionPlanLogContributorAdd        = Aggiunta di un collaboratore
+ActionPlanLogContributorAddDesc    = Crea un evento quando un collaboratore viene aggiunto
+ActionPlanLogContributorRemove     = Rimozione di un collaboratore
+ActionPlanLogContributorRemoveDesc = Crea un evento quando un collaboratore viene rimosso
+ActionPlanLogProgress              = Modifica dell'avanzamento
+ActionPlanLogProgressDesc          = Crea un evento quando l'avanzamento viene modificato
+ActionPlanLogTag                   = Modifica dei tag
+ActionPlanLogTagDesc               = Crea un evento quando un tag viene aggiunto o rimosso
+ActionPlanLogDateStart             = Modifica della data di inizio
+ActionPlanLogDateStartDesc         = Crea un evento quando la data di inizio viene modificata
+ActionPlanLogDateEnd               = Modifica della data di fine
+ActionPlanLogDateEndDesc           = Crea un evento quando la data di fine viene modificata
+ActionPlanTaskLabelChanged         = Denominazione modificata: "%s" → "%s"
+ActionPlanTaskWorkloadChanged      = Carico modificato: %s → %s
+ActionPlanTaskBudgetChanged        = Budget modificato: %s → %s
+ActionPlanTaskContributorAdded     = Collaboratore aggiunto: %s
+ActionPlanTaskContributorRemoved   = Collaboratore rimosso: ID %s
+ActionPlanTaskProgressChanged      = Avanzamento modificato: %s%% → %s%%
+ActionPlanTaskTagAdded             = Tag aggiunto: %s
+ActionPlanTaskTagRemoved           = Tag rimosso: ID %s
+ActionPlanTaskDateStartChanged     = Data di inizio modificata: %s → %s
+ActionPlanTaskDateEndChanged       = Data di fine modificata: %s → %s
+
+# ===========================================================================
+# Filtri del piano d'azione — issue #4907 (GP/UT, livello di rischio, tag)
+# ===========================================================================
+ActionPlanElement                    = GP/UT
+ActionPlanFilterElementChildren      = Con i sottoelementi
+ActionPlanFilterElementChildrenHelp  = Includi le azioni correttive dei GP/UT figli del GP/UT selezionato
+ActionPlanFilterScale                = Livello di rischio
+ActionPlanFilterAllScales            = Tutti i livelli
+ActionPlanFilterTags                 = Tag
+ActionPlanFilterCount                = %s azione/i correttiva/e visualizzata/e su %s
+ActionPlanDictionaries               = Elenchi del Kanban
+ActionPlanDictionariesDesc           = Gestisci i valori proposti negli elenchi del piano d'azione e dei Kanban
+ActionPlanTagDictionary              = Tag delle azioni correttive
+ActionPlanTagDictionaryDesc          = Tag (categorie di attività) proposti sulle schede e nel filtro del Kanban del piano d'azione
+ActionPlanTicketDictionaries         = Dizionari dei Kanban ticket
+ActionPlanTicketDictionariesDesc     = Tipi, gruppi e gravità che compongono le colonne dei Kanban ticket
+ActionPlanManageDictionary           = Gestisci
+
+# ===========================================================================
+# Scheda azione ticket — issue #4443 (interfaccia a 1 clic)
+# ===========================================================================
+TicketActionCard                     = Azione ticket
+TicketActionCardPickerIntro          = Seleziona un ticket per effettuare un'azione rapida con 1 clic.
+TicketActionCardStatusSection        = Stato
+TicketActionCardAssignSection        = Assegnazione
+TicketActionCardContentSection       = Contenuto
+TicketActionCardDangerSection        = Zona sensibile
+TicketActionMarkRead                 = Segna come letto
+TicketActionInProgress               = Metti in corso
+TicketActionWaiting                  = Metti in attesa
+TicketActionClose                    = Chiudi
+TicketActionCancel                   = Annulla ticket
+TicketActionAssignSelf               = Assegna a me
+TicketActionAssignOther              = Assegna a...
+TicketActionAddMessage               = Aggiungi un messaggio
+TicketActionLinkAccident             = Collega un infortunio
+TicketActionOpenFull                 = Dettagli completi
+TicketActionMarkedRead               = Ticket segnato come letto
+TicketActionInProgressDone           = Ticket messo in corso
+TicketActionWaitingDone              = Ticket messo in attesa
+TicketActionClosedDone               = Ticket chiuso
+TicketActionCancelledDone            = Ticket annullato
+TicketActionAssignedSelfDone         = Ticket assegnato a te
+TicketActionAssignedOtherDone        = Ticket assegnato
+TicketActionCloseConfirm             = Conferma la chiusura
+TicketActionCancelConfirm            = Conferma l'annullamento
+TicketActionCardRegistresSection      = Informazioni registri
+TicketMessageTitle                    = Titolo del messaggio
+TicketResponsibleAndProgress          = Responsabile e avanzamento
+TicketActionCardClassificationSection = Classificazione
+TicketActionCardDatesSection          = Date chiave
+TicketActionCardIdentificationSection = Identificazione
+TicketActionCardOtherFieldsSection    = Altre informazioni
+TicketActionCardEventsSection         = Eventi recenti
+TicketActionCardRelatedSection        = Oggetti collegati
+UnknownFieldToUpdate                  = Campo sconosciuto: %s
+Saved                                 = Salvato
+SeeAll                                = Vedi tutto
+LayoutCustomize                       = Personalizza
+LayoutDone                            = Completato
+LayoutControls                        = Controlli di layout
+LayoutWidthHalf                       = Mezza colonna
+LayoutWidthFull                       = Colonna intera
+LayoutWidthSpan                       = Larghezza piena
+LayoutSaved                           = Layout salvato
+LayoutReset                           = Reimposta
+LayoutResetTitle                      = Reimposta il layout (torna ai valori predefiniti)
+LayoutDensity                         = Densità di visualizzazione
+LayoutDensityCompact                  = Compatta
+LayoutDensityCozy                     = Comoda
+LayoutDensitySpacious                 = Ampia
+AddTag                                = Aggiungi un tag
+TagAdded                              = Tag aggiunto
+TagRemoved                            = Tag rimosso
+Preview                               = Anteprima
+OpenInNewTab                          = Apri in una nuova scheda
+FileDeleted                           = File eliminato
+OtherTicket                           = altro ticket
+OtherTickets                          = altri ticket
+SeeOtherTicketsForThisCompany         = Vedi la cronologia dei ticket di questo cliente
+StatusTimeline                        = Cronologia dello stato
+WatchTicket                           = Segui questo ticket
+UnwatchTicket                         = Non seguire più questo ticket
+TicketWatched                         = Ticket seguito
+TicketUnwatched                       = Ticket rimosso dai seguiti
+WatchedTicket                         = Ticket seguito
+WatchedOnly                           = Solo i seguiti
+AllTickets                            = Tutti
+NoWatchedTicket                       = Nessun ticket seguito
+FileUploaded                          = File inviato
+UploadFile                            = Scegli un file
+OrDropAnywhere                        = o trascina e rilascia sulla scheda
+Messages                              = Messaggi
+TypeYourReply                         = Scrivi la tua risposta…
+PrivateMessage                        = Messaggio privato
+Send                                  = Invia
+NoMessageYet                          = Nessun messaggio al momento
+BeFirstToReply                        = Sii il primo a rispondere
+MessagePosted                         = Messaggio inviato
+MessageEdited                         = Messaggio modificato
+MessageDeleted                        = Messaggio eliminato
+ConfirmDeleteMessage                  = Eliminare questo messaggio?
+ReplyByEmail                          = Invia via email
+SentByMail                            = Inviato via email
+MailSentToNRecipients                 = email inviata a %d destinatario/i
+MailNotSent                           = invio dell'email non riuscito
+NoRecipientFound                      = nessun destinatario trovato
+OriginalMessage                       = Messaggio originale
+JustNow                               = proprio ora
+NMinAgo                               = %d min fa
+NHAgo                                 = %d h fa
+NDAgo                                 = %d g fa
+NAttachedFiles                        = %d file allegato/i
+Quote                                 = Cita
+NotAllowed                            = Azione non autorizzata
+Private                               = Privato
+Unknown                               = Sconosciuto
+LayoutTagsMode                        = Visualizzazione dei tag
+LayoutTagsModeChips                   = Elenco completo (chip)
+LayoutTagsModeSelector                = Selettore a discesa
+LayoutActionsMode                     = Visualizzazione delle azioni
+LayoutActionsModeBar                  = Barra delle azioni
+LayoutActionsModeMenu                 = Menu (⋮)
+Move                                  = Sposta
+Hide                                  = Nascondi
+Show                                  = Mostra
+
+# ===========================================================================
+# Kanban ticket — configurazione della registrazione — issue #4753
+# ===========================================================================
+TicketKanban                           = Kanban ticket
+TicketKanbanLogging                    = Kanban ticket — Cronologia delle modifiche
+TicketKanbanLoggingDescription         = Attiva la creazione di eventi durante le modifiche nel kanban
+TicketKanbanLogStatus                  = Modifica dello stato
+TicketKanbanLogStatusDesc              = Crea un evento quando lo stato di un ticket viene modificato tramite il kanban
+TicketKanbanLogAssignee                = Modifica dell'assegnatario
+TicketKanbanLogAssigneeDesc            = Crea un evento quando l'assegnatario di un ticket viene modificato tramite il kanban
+TicketKanbanLogCategoryAdd             = Aggiunta di un tag
+TicketKanbanLogCategoryAddDesc         = Crea un evento quando un tag viene aggiunto a un ticket tramite il kanban
+TicketKanbanLogCategoryRemove          = Rimozione di un tag
+TicketKanbanLogCategoryRemoveDesc      = Crea un evento quando un tag viene rimosso da un ticket tramite il kanban
+TicketKanbanLogType                    = Modifica del tipo
+TicketKanbanLogTypeDesc                = Crea un evento quando il tipo di un ticket viene modificato tramite il kanban
+TicketKanbanLogGroup                   = Modifica del gruppo
+TicketKanbanLogGroupDesc               = Crea un evento quando il gruppo di un ticket viene modificato tramite il kanban
+TicketKanbanLogSeverity                = Modifica della gravità
+TicketKanbanLogSeverityDesc            = Crea un evento quando la gravità di un ticket viene modificata tramite il kanban
+TicketKanbanLogSubject                 = Modifica dell'oggetto
+TicketKanbanLogSubjectDesc             = Crea un evento quando l'oggetto di un ticket viene modificato tramite il kanban
+TicketKanbanLogDeadline                = Modifica della scadenza
+TicketKanbanLogDeadlineDesc            = Crea un evento quando la scadenza di un ticket viene modificata tramite il kanban
+TicketKanbanClosedLimit                = Limite ticket chiusi
+TicketKanbanClosedLimitDesc            = Numero massimo di ticket chiusi/annullati visualizzati nel kanban (0 = illimitato)
+
+# ===========================================================================
+# Ticket — tracciabilità delle modifiche — issue #4885
+# ===========================================================================
+TicketLogModifications                 = Tracciabilità delle modifiche
+TicketLogModificationsDesc             = Crea un evento per ogni modifica effettuata dalla scheda del ticket (oggetto, messaggio, registri, assegnatario, terzo, progetto, avanzamento, stato, attività, documenti)
+TicketMessageEdited                    = Messaggio modificato
+TicketMessageDeleted                   = Messaggio eliminato
+TicketTaskCreated                      = Attività creata: %s
+TicketDocumentGenerated                = Documento generato
+TicketFileDeleted                      = File eliminato
+
+# Pannello di creazione rapida di un ticket
+SelectNothing                          = — Seleziona —
+QuickCreateTicket                      = Crea rapidamente un ticket
+TicketSubjectPlaceholder               = Titolo del ticket...
+TicketInitialMessage                   = Messaggio iniziale
+OptionalDescription                    = Descrizione (facoltativa)...
+Unassigned                             = Non assegnato
+QuickCreateAttachments                 = Allegati
+QuickCreateDropzone                    = Trascina e rilascia o fai clic per selezionare
+QuickCreateDropzoneActive              = Rilascia qui…
+QuickCreateAttachmentHint              = Formati accettati: immagini, PDF, documenti. Max 10 MB per file.
+QuickCreateTicketSuccess               = Ticket %s creato con successo.
+
+# MeteoVigilance - Allerta meteo Météo-France
+MeteoVigilance = Allerta meteo Météo-France
+MeteoVigilancePanelTitle = Allerta %s
+MeteoVigilanceAdvice2 = Presta attenzione
+MeteoVigilanceAdvice3 = Presta molta attenzione
+MeteoVigilanceAdvice4 = Massima allerta
+MeteoVigilanceUpdatedAt = Aggiornato %s
+MeteoVigilanceEnabled = Attiva l'allerta meteo
+MeteoVigilanceEnabledDescription = Mostra il widget Allerta meteo Météo-France sul cruscotto (e la barra di allerta in caso di allerta arancione/rossa).
+MeteoVigilanceLevel = Livello di allerta
+MeteoVigilanceActivePhenomena = Fenomeni attivi
+MeteoVigilanceNoAlert = Nessuna allerta particolare
+MeteoVigilanceSource = Fonte
+MeteoVigilanceSeeOnMeteoFrance = Vedi su vigilance.meteofrance.fr
+MeteoVigilanceNotConfigured = Chiave API Météo-France non configurata — fai clic per configurarla
+MeteoVigilanceUnknownDepartment = Dipartimento dell'azienda non determinato
+MeteoVigilanceUnavailable = Dati di allerta momentaneamente non disponibili
+MeteoVigilanceBannerTitle = Allerta %s in corso nel dipartimento %s
+MeteoVigilanceLevel1 = Verde
+MeteoVigilanceLevel2 = Giallo
+MeteoVigilanceLevel3 = Arancione
+MeteoVigilanceLevel4 = Rosso
+MeteoVigilancePhenomenon1 = Vento forte
+MeteoVigilancePhenomenon2 = Pioggia e alluvione
+MeteoVigilancePhenomenon3 = Temporali
+MeteoVigilancePhenomenon4 = Piene
+MeteoVigilancePhenomenon5 = Neve e ghiaccio
+MeteoVigilancePhenomenon6 = Ondata di calore
+MeteoVigilancePhenomenon7 = Freddo intenso
+MeteoVigilancePhenomenon8 = Valanghe
+MeteoVigilancePhenomenon9 = Mareggiate e inondazioni costiere
+MeteoVigilanceSetup = Configurazione dell'allerta meteo
+MeteoVigilanceApiKey = Chiave API Météo-France
+MeteoVigilanceApiKeyDescription = Chiave API del portale Météo-France (crea un account e un'applicazione «Bulletin Vigilance» su <a href="https://portail-api.meteofrance.fr" target="_blank">portail-api.meteofrance.fr</a> per generare la chiave).
+MeteoVigilanceDepartment = Codice dipartimento (sovrascrittura)
+MeteoVigilanceDepartmentDescription = Lascia vuoto per dedurre automaticamente il dipartimento dall'indirizzo dell'azienda. Altrimenti inserisci un codice (es. 35, 2A).
+MeteoVigilanceCacheTTL = Durata della cache (secondi)
+MeteoVigilanceCacheTTLDescription = Durata per cui i dati dell'API sono conservati in cache prima di una nuova chiamata (predefinito 3600).
+MeteoVigilanceSettings = Configurazione dell'allerta meteo
+MeteoVigilanceRefreshNow = Aggiorna ora
+MeteoVigilanceRefreshed = Dati aggiornati: allerta %s nel dipartimento %s
+
+# Sistema di conversazione dei ticket
+Conversation = Conversazione
+PublicMessage = Messaggio pubblico
+ConvTo = A
+ConvCc = Cc
+
+SaveNote = Salva la nota
+
+AddRecipient = Aggiungi un destinatario
+NoRecipientFound = Nessun destinatario
+
+AddFile = Aggiungi un file
+
+MentionAgents = Menziona degli operatori
+YouWereMentionedOnTicket = Sei stato menzionato sul ticket %s
+YouWereMentionedOnTicketBody = %s ti ha menzionato sul ticket %s:
+
+Mentioned = Menzionato
+
+# Creazione rapida mobile del piano di prevenzione
+MobileQuickCreation = Creazione rapida mobile
+MobilePPInteriorCompany = Impresa utilizzatrice (interna)
+MobilePPResponsibleAutoSign = Responsabile (firma automaticamente)
+MobilePPSignatureSaved = Firma registrata
+MobilePPEditSignature = Modifica la firma
+MobilePPDrawSignatureHint = Disegna la tua firma qui sotto e salvala. Sarà riutilizzata per i tuoi prossimi piani.
+MobilePPClearSignature = Cancella
+MobilePPSaveSignature = Salva la mia firma
+MobilePPExteriorCompany = Impresa esterna
+MobileSirenOrSiret = SIREN / SIRET
+MobileSirenOrSiretPlaceholder = 9 o 14 cifre
+MobilePPResponsibleToSign = Responsabile da far firmare
+MobilePPChooseExistingContact = Scegli un contatto esistente
+MobilePPNewContact = Nuovo contatto
+MobilePPEmailForSignatureHelp = Questa email riceverà la richiesta di firma.
+MobilePPPeriod = Periodo di intervento
+MobilePPMaxOneYearHint = Massimo 1 anno tra la data di inizio e la data di fine.
+MobilePPSubmit = Crea il piano di prevenzione
+MobilePPErrorNoSignature = Devi salvare la tua firma prima di creare il piano.
+MobilePPErrorEmptySignature = La firma è vuota.
+MobilePPErrorInvalidSiren = SIREN o SIRET non valido (attese 9 o 14 cifre).
+MobilePPErrorEndBeforeStart = La data di fine deve essere successiva alla data di inizio.
+MobilePPErrorMaxOneYear = La durata non può superare 1 anno.
+MobilePPErrorDatesRequired = Inserisci la data di inizio e la data di fine.
+MobilePPErrorStartRequired = Manca la data di inizio.
+MobilePPErrorEndRequired = Manca la data di fine.
+MobilePPErrorNoProject = Non è configurato alcun progetto di piano di prevenzione predefinito.
+MobilePPCompanyFound = Azienda trovata:
+MobilePPCompanyNotFound = Nessuna azienda trovata nel database: ne sarà creata una nuova.
+MobilePPWarningEmailNotSent = Il piano è stato creato ma non è stato possibile inviare l'email di firma.
+MobilePPWarningEmailNotConfigured = Il piano è stato creato ma l'email non è configurata: richiesta di firma non inviata.
+MobilePPCreated = Piano di prevenzione %s creato.
+MobilePPUpdated = Piano di prevenzione %s aggiornato.
+MobilePPSignatureEmailSubject = Richiesta di firma del piano di prevenzione %s
+MobilePPSignatureEmailContent = Buongiorno,<br><br>Sei invitato a firmare il piano di prevenzione relativo a %s.<br><br><a href="%s">Fai clic qui per firmare</a><br><br>Cordiali saluti.
+MobilePPSuccessTitle = Piano di prevenzione creato
+MobilePPSuccessText = Il responsabile interno ha firmato automaticamente. Una richiesta di firma è stata inviata all'impresa esterna.
+MobilePPViewPlan = Vedi il piano
+MobilePPCreateAnother = Crea un altro piano
+MobileSuccessInteriorSigned = Responsabile interno: firmato
+MobileSuccessExteriorNotified = Impresa esterna: richiesta di firma inviata
+MobileSuccessExteriorNotSigned = Impresa esterna: firma da raccogliere
+MobileSuccessExteriorNotNotified = Impresa esterna: richiesta di firma non inviata
+MobileSuccessExteriorSigned = Impresa esterna: firmato
+MobileSuccessDocumentGenerated = Documento del piano generato
+MobilePPWarningEmailNotSentDetail = Non è stato possibile inviare l'email di firma: %s
+MobilePPWarningNoRecipientEmail = nessun indirizzo email valido per il responsabile esterno
+MobilePPSignatureEmailSentTo = Richiesta di firma inviata a %s
+MobilePPExtSignatureTitle = Firma dell'impresa esterna
+MobilePPExtEmailSentOn = Richiesta inviata a %s il %s
+MobilePPExtEmailNotSent = Richiesta di firma non inviata: trasmetti il link o fai firmare adesso
+MobilePPSpreadDefaultsTitle = Visualizzazione pubblica della diffusione
+MobilePPSpreadShowCount = Mostra il numero di firmatari
+MobilePPSpreadShowName = Mostra il nome e il cognome
+MobilePPSpreadShowContact = Mostra il telefono e l'email
+MobilePPSpreadHidePublicNote = Non mostrare la nota pubblica
+MobilePPExtAlreadySigned = Firmato il %s
+MobilePPExtSignNow = Fai firmare adesso
+MobilePPExtResendEmail = Invia nuovamente l'email
+MobilePPNoTagAvailable = Nessun tag di piano di prevenzione è disponibile.
+MobilePPCreateTag = Crea un tag
+MobileSpreadShareTitle = Condividi la diffusione
+MobileSpreadShareText = Fai scansionare questo codice alle persone interessate. Senza account né accesso, inseriscono i propri dati, caricano i propri documenti e firmano.
+MobileSpreadOpen = Apri la diffusione
+MobilePPRisks = Rischi
+MobilePPAddRisk = Aggiungi un rischio
+MobilePPRiskModalTitle = Scegli un rischio
+MobilePPRiskComment = Commento
+MobilePPRiskDescriptionPlaceholder = Descrivi il rischio in sito
+MobilePPNoRiskYet = Nessun rischio aggiunto al momento.
+MobilePPDeleteRiskTitle = Elimina il rischio
+MobilePPDeleteRiskConfirm = «%s» sarà rimosso dal piano, con la sua descrizione, le sue foto e le sue protezioni.
+MobilePPUserCompany = Impresa utilizzatrice
+MobilePPUserCompanyShort = EU
+MobilePPConcernedCompanies = Riguarda
+MobilePPExteriorCompanyShort = EE
+MobilePPPriorFormalities = Formalità preliminari
+MobilePPPriorVisitDone = Sopralluogo congiunto preliminare effettuato
+MobilePPPriorVisitTextPlaceholder = Quanto è stato constatato durante il sopralluogo
+MobileRiskCompanies = Imprese interessate dai rischi (mobile)
+CertificationDictionary = Certificazioni e abilitazioni
+MobilePPChooseExistingCompany = Scegli un terzo esistente
+MobilePPOrFillManually = o inserisci le informazioni
+MobilePPProtections = Protezioni
+MobilePPAddProtection = Aggiungi una protezione
+MobilePPProtectionModalTitle = Scegli una protezione
+MobilePPMandatory = Obbligatorio
+MobileProtections = Protezioni (mobile)
+MobilePPCertifications = Certificazioni obbligatorie
+MobilePPAddCertification = Aggiungi una certificazione
+MobileCertifications = Certificazioni (mobile)
+MobilePPUploadCertPhoto = Invia una foto
+MobilePPErrorCreatingThirdparty = Errore durante la creazione del terzo.
+MobilePPErrorCreatingContact = Errore durante la creazione del contatto.
+MobilePPErrorUpdatingPlan = Errore durante l'aggiornamento del piano di prevenzione.
+MobilePPErrorCreatingPlan = Errore durante la creazione del piano di prevenzione.
+MobileSuccessViewDocument = Vedi il documento
+MobileSuccessPlanSentByEmailOn = Piano di prevenzione inviato via email il %s
+MobileSuccessExteriorSignedOn = Responsabile dell'Impresa Esterna (EE): Firmato il %s
+MobileSuccessExteriorPendingSignature = Responsabile dell'Impresa Esterna (EE): In attesa di firma
+MobilePPDefaultsTitle = Valori predefiniti (creazione mobile)
+MobilePPDefaultDateStartToday = Data di inizio = data odierna
+MobilePPDefaultDuration = Durata predefinita del periodo (giorni)
+MobilePPEmailAutoSend = Invia automaticamente l'email di firma alla creazione
+
+# Creazione rapida mobile del permesso di lavoro a caldo
+MobileFPPreventionPlanHelp = L'impresa esterna e il periodo del piano selezionato sono ripresi automaticamente.
+MobileFPPeriod = Luogo e periodo dei lavori
+MobileFPMaxOneMonthHint = Massimo un mese tra l'inizio e la fine dei lavori.
+MobileFPErrorMaxOneMonth = La durata non può superare un mese.
+MobileFPErrorNoProject = Non è configurato alcun progetto di permesso di lavoro a caldo predefinito.
+MobileFPWorkTypes = Tipi di lavori
+MobileFPAddWorkType = Aggiungi un tipo di lavori
+MobileFPWorkTypeModalTitle = Scegli un tipo di lavori
+MobileFPSubmit = Crea il permesso di lavoro a caldo
+MobileFPCreated = Permesso di lavoro a caldo %s creato.
+MobileFPUpdated = Permesso di lavoro a caldo %s aggiornato.
+MobileFPSignatureEmailSubject = Richiesta di firma del permesso di lavoro a caldo %s
+MobileFPSignatureEmailContent = Buongiorno,<br><br>Sei invitato a firmare il permesso di lavoro a caldo per %s.<br><br><a href="%s">Fai clic qui per firmare</a><br><br>Cordiali saluti.
+MobileFPSuccessTitle = Permesso di lavoro a caldo creato
+MobileFPViewPermit = Vedi il permesso
+MobileFPCreateAnother = Crea un altro permesso
+
+# Digirisk PWA
+PwaApplication = App mobile
+PwaNavHome = Home
+PwaNavPreventionPlans = Piani
+PwaNavFirePermits = Permessi
+PwaNavMenu = Menu
+PwaNavFavoritesHint = Preferiti visualizzati in basso (max %s)
+PwaNavAddFavorite = Aggiungi ai preferiti
+PwaNavRemoveFavorite = Rimuovi dai preferiti
+PwaHello = Buongiorno %s
+PwaResultCount = %s risultato/i
+AllStatus = Tutti gli stati
+PwaTilePreventionPlanInProgress = Piani in corso
+PwaTilePreventionPlanToSign = Piani da firmare
+PwaTileFirePermitInProgress = Permessi in corso
+PwaTileFirePermitToSign = Permessi da firmare
+
+# Azioni di massa sulle attività
+MassValidateTasks = Convalida le attività
+MassChangeTasksProject = Cambia progetto
+ConfirmMassValidateTasksQuestion = Sei sicuro di voler convalidare le %s attività selezionate? Saranno convalidate solo le attività con stato bozza.
+ConfirmMassChangeTasksProjectQuestion = Sei sicuro di voler collegare le %s attività selezionate al progetto scelto?
+MassValidateTasksSuccess = %s attività convalidate su %s selezionate
+MassChangeTasksProjectSuccess = %s attività collegate al progetto %s
+
+# PDF del piano di prevenzione
+PreventionPlanLegalNotice = Il piano di prevenzione è un documento obbligatorio volto a prevenire i rischi derivanti dall'interferenza tra le attività di più imprese in uno stesso sito, conformemente all'articolo R4512-7 del Codice del lavoro francese.
+PreventionPlanUserCompany = Impresa Utilizzatrice - EU
+PreventionPlanExteriorCompany = Impresa Esterna - EE
+PreventionPlanUserCompanyResponsible = Responsabile dell'Impresa Utilizzatrice (EU)
+PreventionPlanExteriorCompanyResponsible = Responsabile dell'Impresa Esterna (EE)
+EmergencyNumbers = Numeri di emergenza
+Firefighters = Vigili del fuoco
+AnyEmergency = Qualsiasi emergenza
+PriorVisitIntro = L'impresa utilizzatrice ha effettuato, prima dell'esecuzione dell'operazione, un sopralluogo congiunto preliminare in data %s. Durante questa visita l'impresa utilizzatrice ha presentato i seguenti punti (art. R. 4512-2 e R. 4512-3 del Codice del lavoro francese):
+PriorVisitCheckList = Luoghi di lavoro|Impianti ivi presenti|Materiali eventualmente messi a disposizione delle imprese esterne|Delimitare l'area di intervento delle imprese esterne|Segnalare le zone di quest'area che possono presentare pericoli per i lavoratori|Indicare le vie di circolazione che potranno utilizzare i lavoratori nonché i veicoli e i mezzi di qualsiasi natura appartenenti alle imprese esterne|Definire le vie di accesso dei lavoratori ai locali e agli impianti a uso delle EE (in particolare i servizi igienici, gli spogliatoi collettivi e i locali di ristoro)
+PriorVisitComments = Sono stati rilevati i seguenti commenti:
+InterventionPeriodSentence = Questo piano inizia il %s e termina il %s. Gli interventi si svolgeranno nei seguenti orari:
+RiskAnalysisIntro = Hai previsto %s intervento/i per questo piano di prevenzione: di seguito il dettaglio delle azioni previste, i rischi generati e i mezzi di prevenzione attuati.
+PreventionPlanAttendants = Operatori: Impresa Esterna (EE) e subappaltatori
+Morning = Mattina
+Afternoon = Pomeriggio
+Signatures = Firme
+SignaturePending = In attesa
+PreventionPlanRiskPhotos = Foto del rischio
+InterventionPeriodOnly = Questo piano inizia il %s e termina il %s.
+
+DigiRisk=DigiRisk
+DigiriskIdentification=DESCRIZIONE E CARATTERISTICHE
+DigiriskSecurity=SICUREZZA
+DigiriskUserManual=ISTRUZIONI D'USO SEMPLIFICATE
+DigiriskQualification=QUALIFICA E ABILITAZIONE
+DigiriskHygiene=IGIENE E PULIZIA
+DigiriskMaintenance=MANUTENZIONE E CONTROLLI
+DangerCategory=Famiglia di rischio
+SelectDangerCategory=Scegli una famiglia di rischio
+DescribeRiskOnProduct=Descrivi il rischio su questo prodotto...
+ConfirmDeleteProductRisk=Eliminare questo rischio?
+AddProductRisk=Aggiungi un rischio di prodotto
+ClickToAddContent=Fai clic per aggiungere contenuto...
+AddProtection=Aggiungi una protezione
+
+SelectProtection=Scegli una protezione DPI
+TechnicalSheet=Scheda tecnica
+DigiriskRisks=RISCHI E PROTEZIONI
+MobileSuccessInteriorSignedOn=Responsabile dell'Impresa Utilizzatrice (EU): Firmato il %s
+
+MobileSuccessPlanSentByEmailOn = Piano di prevenzione inviato via email il %s
+MobileSuccessExteriorSignedOn = Responsabile dell'Impresa Esterna (EE): Firmato il %s
+MobileSuccessExteriorPendingSignature = Responsabile dell'Impresa Esterna (EE): In attesa di firma
+
+MobilePPErrorInvalidEmail = Rispetta il formato dell'email.
+MobilePPErrorInvalidPhone = Rispetta il formato del telefono.
+MobilePPExtSendEmail = Invia l'email
+MobilePPErrorMailServerNotConfigured = Il tuo server di posta non è configurato, contatta l'amministratore.
+MobilePPDoliletterNotInstalled = Il modulo Doliletter non è installato. La diffusione dei piani di prevenzione e dei permessi di lavoro a caldo non sarà disponibile (contatta il tuo amministratore)
+
+# Stati e tipi per i suggerimenti
+preventionplan = Piano di prevenzione
+Locked = Bloccato
+InProgress = In corso
+ValidatePendingSignature = In attesa di firma
+Archived = Archiviato
+
+ProductFIChaptersManagement=Personalizzazione dei capitoli della scheda di istruzione
+ProductFIChaptersManagementSub=Personalizzazione della scheda "Scheda di istruzione" e della scheda "Rischi" nella scheda prodotto
+DefaultContent=Contenuto predefinito
+CustomSvgUploaded=SVG personalizzato
+DeleteCustomSvg=Elimina
+DefaultSvgUsed=SVG predefinito
+
+PwaTilePreventionPlanLocked = Piani convalidati
+PwaTileFirePermitLocked = Permessi convalidati
+
+# ===========================================================================
+# Dizionario delle colonne Kanban del piano d'azione — issue #5017
+# ===========================================================================
+ActionPlanColumnDictionary           = Colonne del Kanban del piano d'azione
+ActionPlanColumnDictionaryDesc       = Colonne visualizzate sul Kanban del PAPRIPACT quando la modalità dizionario è attiva: denominazione, intervallo di avanzamento, colore e icona
+KanbanColumnSource                   = Origine delle colonne
+KanbanColumnSourceDesc               = Suddividi il Kanban con le soglie percentuali indicate sotto (funzionamento storico) o con il dizionario delle colonne
+KanbanColumnSourceThresholds         = Soglie percentuali (predefinito)
+KanbanColumnSourceDictionary         = Dizionario delle colonne
+ActionPlanColumnProgressHelp         = Limiti di avanzamento coperti dalla colonna, da 0 a 100
+ActionPlanColumnColorHelp            = Colore esadecimale della colonna, ad esempio #3085d6
+ActionPlanColumnPictoHelp            = Nome dell'icona Font Awesome, ad esempio fa-check
+Progress_min                         = Avanzamento min.
+Progress_max                         = Avanzamento max.
+Picto                                = Icona
+
+# Monitoraggio del tempo impiegato
+GenerateTimeSpentReport = Genera il monitoraggio del tempo (PDF)
+TimeSpentReport = Monitoraggio del tempo impiegato
+TimeSpentReportUsersHelp = Lascia vuoto per includere tutte le persone che hanno registrato del tempo su questo progetto.
+TimeSpentReportSummary = Riepilogo per utente
+TimeSpentReportGrandTotal = Totale generale
+TimeSpentReportGeneratedAt = Generato il
+TimeSpentReportWholePeriod = Dall'inizio del progetto
+TimeSpentReportNoData = Nessun tempo impiegato corrisponde agli utenti e al periodo selezionati.
+TimeSpentDocumentPDFDescription = Tempo impiegato su un progetto, raggruppato per utente
+
+# Allineamento del permesso di lavoro a caldo mobile al piano di prevenzione - issue #5042
+MobileProgress = Avanzamento
+MobileStepDone = FATTO
+MobileStepInProgress = IN CORSO
+MobileStepTodo = DA FARE
+MobileStepSignedOn = FIRMATO IL
+MobilePPStepCreated = PP creato
+MobileFPStepCreated = PL creato
+MobileStepUserCompanyResponsible = Resp. EU
+MobileStepExteriorCompanyResponsible = Resp. EE
+MobileStepLock = Blocca
+MobileStepArchive = Archivia
+MobileLock = Blocca
+MobileResponsibleShort = Resp.
+MobileMailSentTo = Email inviata a
+MobilePPMotif = Motivo dell'intervento
+MobilePPSchedules = Orari di intervento
+MobilePPConfigHours = Configura qui i tuoi orari
+MobilePPCopyCompanyHours = Copia gli orari dell'azienda
+FirePermitUserCompany = Impresa Utilizzatrice - EU
+FirePermitExteriorCompany = Impresa Esterna - EE
+MobileFPMotif = Motivo dei lavori
+MobileFPMotifPlaceholder = Es.: saldatura su struttura
+MobileFPNoMotif = Nessun motivo indicato
+MobileFPSchedules = Orari dei lavori
+MobileFPWorkTypeDescriptionPlaceholder = Descrivi i lavori in sito
+MobileFPNoWorkTypeYet = Nessun tipo di lavori aggiunto al momento.
+MobileFPDeleteWorkTypeTitle = Elimina il tipo di lavori
+MobileFPDeleteWorkTypeConfirm = «%s» sarà rimosso dal permesso, con la sua descrizione, il suo materiale, le sue foto e le sue protezioni.
+MobileFPNoTagAvailable = Nessun tag di permesso di lavoro a caldo è disponibile.
+MobileFPErrorUpdatingPermit = Errore durante l'aggiornamento del permesso di lavoro a caldo.
+MobileFPErrorCreatingPermit = Errore durante la creazione del permesso di lavoro a caldo.
+MobileFPLockNeedsSignature = Il permesso deve essere firmato prima di poter essere bloccato.
+MobileFPSpreadAvailableOnceSignedAndLocked = La diffusione sarà disponibile non appena il permesso sarà firmato dai responsabili e bloccato.
+MobileFPDefaultDateStartToday = Data di inizio = data odierna
+MobileFPDefaultDuration = Durata predefinita del periodo (giorni)
+firepermit = Permesso di lavoro a caldo
+ErrorRecordIsLocked = Questo record è bloccato, non può più essere modificato.
+MobilePPEmailTemplateExt = Modello di email per il responsabile dell'impresa esterna
+MobilePPEmailTemplateInt = Modello di email per gli operatori dell'impresa esterna
+
+#
+# ListingRisksDocument PDF - Elenco dei rischi in formato PDF
+#
+
+ListingRisksDocumentPDF            = Elenco dei rischi PDF
+ListingRisksDocumentPDFDescription = Elenco dei rischi in PDF nativo, aperto sul mini documento di valutazione dei rischi dell'elemento
+ListingRisksDocumentPDFTitle       = VALUTAZIONE DEI RISCHI
+ListingRisksEstablishment          = Stabilimento
+ListingRisksCoverContent           = Sommario
+ListingRisksCoverHierarchy         = Gerarchia
+ListingRisksCoverDuerpFollowUp     = Monitoraggio del documento di valutazione dei rischi
+ListingRisksCoverEmergencyNumbers  = Numeri di emergenza
+ListingRisksCoverReportIncident    = Segnalare un infortunio o un problema
+ListingRisksCoverRegisters         = Registri di sicurezza e salute sul lavoro e di pericolo grave e imminente
+ListingRisksCoverIllustration      = Immagine illustrativa
+NoPreventionOfficerAssigned        = Nessun responsabile della prevenzione designato
+NoEmergencyNumberConfigured        = Nessun numero di emergenza configurato
+NoResponsibleAssigned              = Nessun responsabile designato
+ListingRisksLegalTitle             = Quadro normativo
+RiskDefinitionTitle                = Definizione di rischio
+RiskDefinitionText                 = Rischio: s. masc. Pericolo o inconveniente a cui ci si espone. Fare qualcosa a proprio rischio e pericolo, assumendosi l'intera responsabilità delle conseguenze. Un rischio calcolato. Correre rischi: esporsi a un pericolo.
+DangerDefinitionTitle              = Definizione di pericolo
+DangerDefinitionText               = Pericolo: s. masc. (dal latino volgare dominiarium «potere», da dominus «padrone»; in origine il fatto di essere alla mercé di qualcuno). Ciò che minaccia la sicurezza o la vita di qualcuno; ciò che rischia di compromettere una situazione, un'impresa, ecc.
+SingleDocumentTitle                = Il documento di valutazione dei rischi
+SingleDocumentText                 = Il documento di valutazione dei rischi è disciplinato dagli articoli da R4121-1 a 4 del Codice del lavoro francese. I principi generali di prevenzione impongono l'ordine di trattamento del rischio.
+PreventionPrinciplesTitle          = I principi generali di prevenzione - Articolo L4121-2
+PreventionPrinciplesIntro          = Il datore di lavoro attua le misure previste dall'articolo L. 4121-1 sulla base dei seguenti principi generali di prevenzione:
+PreventionPrinciple1               = Evitare i rischi.
+PreventionPrinciple2               = Valutare i rischi che non possono essere evitati.
+PreventionPrinciple3               = Combattere i rischi alla fonte.
+PreventionPrinciple4               = Adeguare il lavoro all'uomo, in particolare per quanto riguarda la concezione dei posti di lavoro e la scelta delle attrezzature di lavoro e dei metodi di lavoro e di produzione, al fine soprattutto di limitare il lavoro monotono e il lavoro a ritmo predeterminato e di ridurne gli effetti sulla salute.
+PreventionPrinciple5               = Tenere conto dello stato di evoluzione della tecnica.
+PreventionPrinciple6               = Sostituire ciò che è pericoloso con ciò che non è pericoloso o con ciò che lo è meno.
+PreventionPrinciple7               = Pianificare la prevenzione integrando in un insieme coerente la tecnica, l'organizzazione del lavoro, le condizioni di lavoro, le relazioni sociali e l'influenza dei fattori ambientali, in particolare i rischi legati alle molestie morali e alle molestie sessuali, nonché quelli legati ai comportamenti sessisti.
+PreventionPrinciple8               = Adottare misure di protezione collettiva dando loro priorità rispetto alle misure di protezione individuale.
+PreventionPrinciple9               = Impartire ai lavoratori istruzioni adeguate.
+ListingRisksCotationMethodTitle    = Metodo di calcolo dei punteggi
+ListingRisksCotationMethodText     = Il punteggio di un rischio è un valore da 0 a 100 attribuito durante la sua valutazione. Il livello di rischio riportato nell'elenco ne deriva direttamente, secondo la griglia sottostante.
+ListingRisksCotationLevel          = Livello
+ListingRisksCotationRange          = Punteggio
+ListingRisksCotationMeaning        = Significato
+ListingRisksCotationAction         = Comportamento da adottare
+ListingRisksCotationAction1        = Mantenere i mezzi di prevenzione in essere.
+ListingRisksCotationAction2        = Inserire un'azione nel programma annuale di prevenzione.
+ListingRisksCotationAction3        = Avviare un'azione di prevenzione a breve termine.
+ListingRisksCotationAction4        = Agire immediatamente, l'esposizione deve cessare.
+ListingRisksListTitle              = Elenco dei rischi
+ListingRisksActionPlan             = Azioni del programma annuale di prevenzione
+ListingRisksCotationColumn         = Pt.
+ListingRisksRiskColumn             = Rischio
+ListingRisksAssessmentColumn       = Informazioni sulla valutazione
+NoRiskAssessed                     = Nessun rischio valutato su questo perimetro

--- a/langs/it_IT/index.php
+++ b/langs/it_IT/index.php
@@ -1,0 +1,2 @@
+<?php
+//Silence is golden

--- a/langs/nl_NL/digiriskdolibarr.lang
+++ b/langs/nl_NL/digiriskdolibarr.lang
@@ -1,0 +1,2387 @@
+# Copyright (C) 2021-2023 EVARISK <technique@evarisk.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#
+# Algemeen
+#
+
+# Module label 'ModuleDigiriskdolibarrName'
+ModuleDigiriskdolibarrName = Digirisk
+
+# Module description 'ModuleDigiriskdolibarrDesc'
+ModuleDigiriskdolibarrDesc = Digirisk voor Dolibarr
+
+# Ontbrekende module Saturne
+SaturneModuleMissing = De module Saturne is vereist voor Digirisk. Download deze gratis in de Dolistore (https://dolistore.com/en/modules/1906-Saturne.html) en installeer deze voordat u Digirisk activeert.
+
+# Kolom met tutorialafbeeldingen op de instellingenpagina's
+TutoImage = Afbeelding
+
+#
+# Beheerpagina
+#
+
+# Gegevens
+DigiriskdolibarrSetup       = Instellingen van de module Digirisk
+DigiriskdolibarrSetupPage        = Instellingenpagina van de module Digirisk
+AgendaModuleRequired        = Zorg ervoor dat de module Agenda is geactiveerd om de traceerbaarheid van de acties in Digirisk te waarborgen
+DigiriskDolibarrDescription = Digirisk voor Dolibarr
+HowToSetupOtherModules      = Voor meer functies in Digirisk kunt u tal van modules activeren (leveranciersbeheer, facturen, enz.) via deze link:
+ConfigMyModules             = Instellingen van de modules
+AvoidLogoProblems              = Raadpleeg deze instellingsadviezen om problemen met logo's in de gegenereerde documenten te voorkomen:
+LogoHelpLink                = https://wiki.dolibarr.org/index.php?title=Premiers_paramétrages
+SecurityConfiguration       = Instellingen van de veiligheidsgegevens
+SocialConfiguration          = Instellingen van de sociale gegevens
+Uncompleted                     = Niet ingevuld
+DigiriskData                 = Configureerbare gegevens van Digirisk
+DigiriskManagement          = Doorverwijzing na het inloggen
+DigiriskDescription          = Standaard doorverwijzen naar de welkomstpagina van Digirisk in plaats van die van Dolibarr.
+HowToSetupIHM                   = Voor meer mogelijkheden voor de weergave van Dolibarr (instelling van de achtergrondafbeelding, enz.) kunt u naar deze link gaan:
+ConfigIHM                    = Instellingen van de weergave
+ConfigDico                     = Ga naar de instellingenpagina van de woordenboeken
+LinkedProject               = Gekoppeld project
+DigiriskUpdate                  = Update van Digirisk:
+Security                       = Veiligheid
+HowToSharedElement          = Ga naar deze link voor meer informatie over de instellingen van de gedeelde elementen:
+
+HowToSharedElementLink        = https://wiki.dolibarr.org/index.php?title=Module_Digirisk#Configuration
+ConfigSharedElement         = Instellingen van de gedeelde elementen (risico's/signaleringen)
+DisabledSharedElement       = Optie uitgeschakeld omdat Multi-company niet is geactiveerd of de instellingen van de gedeelde elementen (risico's/signaleringen) niet zijn uitgevoerd
+DigiriskEventAutoDesc       = Bepaal hier de gebeurtenissen waarvoor Digirisk automatisch een vermelding in de agenda aanmaakt. Elke gebeurtenis bevat de informatie over de uitgevoerde actie.
+DigiriskActionsEvents       = Gebeurtenissen waarvoor Digirisk automatisch een gebeurtenis in de agenda moet invoegen.
+DigiriskDolibarr            = Digirisk
+Create                      = Aanmaken
+
+# Ticket
+MultiCompanyTicketPublicInterfaceConfig = Instellingen van de openbare ticketinterface voor meerdere bedrijven
+Subtitle                                = Ondertitel
+
+# DigiriskElement
+DigiriskElementDepthGraph            = Diepteniveau in de grafieken van de Digirisk-elementen
+DigiriskElementDepthGraphDescription = Met deze optie kiest u het diepteniveau in de grafieken van de Digirisk-elementen <br> Standaard: niveau 1
+
+# WHSRegister = Register arbeidsveiligheid en -gezondheid
+TicketsPublicInterfaceConfig         = Instellingen van de openbare ticketinterface
+WHSRegister                          = Register arbeidsveiligheid en -gezondheid
+CurrentTicketPublicInterfaceURL      = URL van de openbare ticketinterface
+MulticompanyTicketPublicInterfaceURL = URL van de openbare ticketinterface voor meerdere bedrijven
+OriginURL                            = Oorspronkelijke URL
+ShortURL                             = Verkorte URL
+ExternalURL                          = Externe URL
+AddExtraField                        = Een extra veld aanmaken
+IfEmptyVisibleAllCategories          = Indien leeg, zichtbaar in alle categorieën
+
+# DigiQuali Sheet - Sjablonen
+LinkDigiriskdolibarr_digiriskstandard                 = De koppeling met de hoofdentiteiten van Digirisk Standard activeren
+LinkDigiriskdolibarr_digiriskstandardDescription      = Maakt de koppeling mogelijk tussen de standaardentiteiten van Digirisk en de sjablonen
+LinkDigiriskdolibarr_digiriskelement                  = De koppeling met de groeperingen en werkeenheden activeren
+LinkDigiriskdolibarr_digiriskelementDescription       = Maakt de koppeling mogelijk tussen de groeperingen en werkeenheden en de sjablonen
+LinkDigiriskdolibarr_risk                             = De koppeling met de risico's activeren
+LinkDigiriskdolibarr_riskDescription                  = Maakt de koppeling mogelijk tussen de risico's en de sjablonen
+LinkDigiriskdolibarr_riskassessment                   = De koppeling met de beoordelingen activeren
+LinkDigiriskdolibarr_riskassessmentDescription        = Maakt de koppeling mogelijk tussen de beoordelingen en de sjablonen
+LinkDigiriskdolibarr_evaluator                        = De koppeling met de beoordelaars activeren
+LinkDigiriskdolibarr_evaluatorDescription             = Maakt de koppeling mogelijk tussen de beoordelaars en de sjablonen
+LinkDigiriskdolibarr_risksign                         = De koppeling met de signaleringen activeren
+LinkDigiriskdolibarr_risksignDescription              = Maakt de koppeling mogelijk tussen de signaleringen en de sjablonen
+LinkDigiriskdolibarr_preventionplan                   = De koppeling met de preventieplannen activeren
+LinkDigiriskdolibarr_preventionplanDescription        = Maakt de koppeling mogelijk tussen de preventieplannen en de sjablonen
+LinkDigiriskdolibarr_firepermit                       = De koppeling met de vuurvergunningen activeren
+LinkDigiriskdolibarr_firepermitDescription            = Maakt de koppeling mogelijk tussen de vuurvergunningen en de sjablonen
+LinkDigiriskdolibarr_accident                         = De koppeling met de ongevallen activeren
+LinkDigiriskdolibarr_accidentDescription              = Maakt de koppeling mogelijk tussen de ongevallen en de sjablonen
+LinkDigiriskdolibarr_accidentinvestigation            = De koppeling met de ongevalsonderzoeken activeren
+LinkDigiriskdolibarr_accidentinvestigationDescription = Maakt de koppeling mogelijk tussen de onderzoeken en de sjablonen
+
+#
+# DigiriskDolibarr
+#
+
+# Recht
+LireDigirisk                 = Het Digirisk-dashboard raadplegen
+ReadDigirisk                 = Het Digirisk-dashboard raadplegen (lezen)
+YouDontHaveTheRightToSeeThis = U hebt niet het recht om de groeperingen en werkeenheden te bekijken
+CanNotDoThis                 = U hebt niet het recht om dit te doen
+EnableDigiriskdolibarr       = Activeer de module DigiriskDolibarr om toegang te krijgen tot deze pagina
+
+# Gegevens
+DigiriskMenu          = Voeg informatie over uw bedrijf/organisatie toe. Klik op de knop "Opslaan" onderaan de pagina om deze te bewaren
+DigiriskConfigSociety = Instellingen van het bedrijf
+PermissionDenied      = Toegang geweigerd
+AddUser               = Een gebruiker aanmaken
+StartDate             = Begindatum
+EndDate               = Einddatum
+NoPhoneNumber         = Geen telefoonnummer
+HasBeenCreatedF       = is aangemaakt
+HasBeenCreatedM       = is aangemaakt
+HasNotBeenCreatedF    = is niet aangemaakt
+HasNotBeenCreatedM    = is niet aangemaakt
+YourDocuments         = Documenten
+NoData                = N.v.t.
+HasBeenEditedF        = is bewerkt
+HasBeenEditedM        = is bewerkt
+HasNotBeenEditedF     = is niet bewerkt
+HasNotBeenEditedM     = is niet bewerkt
+
+HasBeenDeletedF    = is verwijderd
+HasBeenDeletedM    = is verwijderd
+HasNotBeenDeletedF = is niet verwijderd
+HasNotBeenDeletedM = is niet verwijderd
+
+DigiriskUserGroup                 = Digirisk - Gebruikers
+DigiriskUserGroupDescription      = De DigiRisk-gebruikersgroep heeft het recht om de DigiRisk-objecten te raadplegen en te wijzigen
+DigiriskAdminUserGroup            = DigiRisk - Beheerders
+DigiriskAdminUserGroupDescription = De beheerdersgroep heeft alle rechten op DigiRisk en de vereiste modules
+DigiriskReaderGroup               = DigiRisk - Lezers
+DigiriskReaderGroupDescription    = De lezersgroep heeft alle leesrechten op DigiRisk en de vereiste modules
+
+ContractType              = Contracttype
+Apprentice/Student        = Leerling/Student
+Interim                   = Uitzendkracht
+ProfessionalQualification = Beroepskwalificatie
+DigiriskDocumentation     = Documentatie van Digirisk
+
+SelectUser               = Een gebruiker selecteren
+LabourInspectorFirstName = Arbeids-
+LabourInspectorLastName  = inspectie
+LabourInspector          = Arbeidsinspectie
+LabourInspectorSociety   = Relatie Arbeidsinspectie
+LabourInspectorAssigned  = Arbeidsinspectie
+
+SocieteSchedules = Openingstijden van het bedrijf
+weekDayDefault   = Zie website
+weekEndDefault   = Gesloten Gesloten
+
+#
+# DigriskDocuments - Digirisk-documenten
+#
+
+# Gegevens
+DigiriskDocuments              = Digirisk-document
+Responsible                    = Verantwoordelijke
+ContactsAction                 = Contacten van de actie
+PERCOTooltip                   = Vink dit vakje aan als uw bedrijf over een collectief pensioenspaarplan (PERCO) beschikt
+PEETooltip                     = Vink dit vakje aan als uw bedrijf over een bedrijfsspaarplan (PEE) beschikt
+ShowPictoName                  = De naam van het gevarenpictogram weergeven
+ShowPictoNameDescription       = De naam van het gevarenpictogram van het risico in de documenten weergeven <br> Handig als u de tabel naar een rekenblad wilt overzetten
+RiskAssessmentColor            = Kleur van de beoordelingen
+RiskAssessmentColorDescription = Geeft de kleur van de beoordelingen weer in het document Papripact-A3-Liggend
+
+#
+# LegalDisplay - Wettelijke aanplakking
+#
+
+# Recht
+LegalDisplaysMin = Wettelijke aanplakkingen
+
+# Gegevens
+LegalDisplay             = Wettelijke aanplakking
+Legaldisplay             = Wettelijke aanplakking
+HowToSetDataLegalDisplay = Ga naar Start - Instellingen - Bedrijf/Organisatie - Veiligheid om de gegevens van de wettelijke aanplakking in te stellen
+
+LegalDisplayDocumentGenerated       = Genereren van de wettelijke aanplakking
+LabourDoctor                        = Bedrijfsarts
+LabourInspector                     = Arbeidsinspectie
+FireBrigade                         = Brandweer
+AllEmergencies                      = Elke noodsituatie
+RightsDefender                      = Ombudsman
+PoisonControlCenter                 = Antigifcentrum
+Police                              = Politie noodhulp
+SafetyInstructions                  = Veiligheidsinstructies
+ResponsibleToNotify                 = Te waarschuwen verantwoordelijke
+PreventionOfficers                  = Preventiemedewerkers
+PreventionOfficer                   = Preventiemedewerker
+LocationOfDetailedInstructions      = Locatie van de gedetailleerde instructie
+LocationOfDetailedInstructionsValue = Geen gedetailleerde instructie op deze locatie
+FirstAid                            = Eerste hulp
+FirstAidValue                       = <h2>Lijst van de op locatie aanwezige bedrijfshulpverleners (Naam, Bedrijf, Telefoon)</h2><br><br>Elk team moet zo zijn samengesteld dat aan elk teamlid onder alle omstandigheden eerste hulp kan worden verleend.<br />De bedrijfshulpverleners moeten duidelijk herkenbaar zijn en bij iedereen bekend zijn.<h2>Handelwijze bij een ongeval</h2><br><br><h3>Licht ongeval</h3><br><ul><li> - Verzorging door de bedrijfshulpverleners</li><br><li> - Aanwezigheid van een verbanddoos</li></ul><br><br>Elke machine is voorzien van ten minste één verbanddoos waarmee lichte verwondingen kunnen worden verzorgd.<br><br><h3>Ernstig ongeval</h3><br><ul><li> - Waarschuw de op locatie aanwezige bedrijfshulpverlener</li><br><li> - Start de noodprocedure</li><br><li> - Informeer de verantwoordelijke van het inlenend bedrijf, wachtdienst exploitatie 24 u</li><br><li> - Neem contact op bij een ongeval</li></ul><br><br>Het inlenend bedrijf vermeldt de alarmnummers in de bijlage. <br />
+AddPhoneNumber                      = Een telefoonnummer aan de gebruiker toevoegen
+ConfigureLabourInspector            = Een arbeidsinspectie instellen
+SocietyAdditionalDetails            = Aanvullende informatie over het bedrijf
+GeneralMeansAtDisposal              = Beschikbaar gestelde algemene middelen
+GeneralMeansAtDisposalValue         = <h2>Beschikbaar gestelde hulpmiddelen</h2><br><ul><li> - Verbandkamer</li><br><li> - Onze bedrijfshulpverleners zijn herkenbaar aan hun helm en werkkleding met het BHV-insigne</li><br><li> - Verbanddozen voor lichte ongevallen op elke locatie beschikbaar</li></ul><br><br><h2>Instructies bij een licht ongeval</h2><br><ul><li> - Neem contact op met de dichtstbijzijnde bedrijfshulpverlener</li><br><li> - Verzorging met de beschikbaar gestelde verbanddoos</li><br><li> - Melding op locatie:</li></ul><br><br><h2>Instructies bij een ongeval</h2><br><ul><li> - Brandweer: 18</li><br><li> - Ambulance: 15</li><br><li> - Politie en marechaussee: 17</li><br><li> - Europees alarmnummer: 112</li></ul><br><br><h2>Instructies bij brand</h2><br>Ga bij brand in deze volgorde te werk:<br><ol><li> - Sla het alarm.</li><br><li> - Bestrijd het vuur (als het niet te groot is) met een brandblusser.</li><br><li> - Is het vuur na het gebruik van één brandblusser niet gedoofd, of is het vuur al te groot, waarschuw dan de brandweer.</li><br><li> - Sluit de deuren en ramen voordat u het pand verlaat.</li><br><li> - Vraag de opgeleide teams om hulp.</li><br></ol>
+GeneralInstructions                 = Algemene instructies
+GeneralInstructionsValue            = <h2>Alle installaties</h2><br><br><p>Roken, vuur maken of het gebruik van open vuur is streng verboden in en op de installaties.<br />Als voor de werkzaamheden open vuur nodig is (laswerkzaamheden, enz.), moet er verplicht een vuurvergunning worden afgegeven (zie voorbeeld in bijlage 9.5).<br />In het algemeen is de toegang tot de installaties verboden voor onbevoegden.<br />Elke medewerker moet zijn bevoegdheidsbewijzen en opleidingscertificaten bij zich hebben. Hij moet ze op locatie kunnen tonen op verzoek van het inlenend bedrijf.</p><br><br><h2>Bevoegdheden</h2><br>Elke betrokken persoon moet beschikken over een kopie van de volgende bevoegdheidsbewijzen:<br><ul><li> - Elektrische bevoegdheid afhankelijk van de uit te voeren werkzaamheden</li><br><li> - Opleidingscertificaat of bevoegdheid voor werken op hoogte en redding op hoogte</li></ul><br>En deze op eenvoudig verzoek van het inlenend bedrijf, de werkverantwoordelijke of een beëdigd inspecteur kunnen tonen<br><br><h2>Persoonlijke beschermingsmiddelen</h2><br>Elke betrokken persoon moet kunnen beschikken over de volgende persoonlijke beschermingsmiddelen, afhankelijk van de uitgevoerde werkzaamheden en de in de risicoanalyse vastgestelde beschermingsmaatregelen.<br><br><h3>Diverse werkzaamheden</h3><br><ul><li> - Helm ontworpen voor werken op hoogte (EN397) met kinriem en/of met elektrische isolatie (elektrische omgeving)</li><br><li> - Veiligheidsschoenen</li><br><li> - Gehoorbescherming, indien nodig</li><br><li> - Overige (nader te bepalen): afhankelijk van de uitgevoerde werkzaamheden en de bijbehorende risico's.</li></ul><br><br><h3>Elektrische werkzaamheden</h3><br><ul><li> - Isolerende mat of isolerende kruk</li><br><li> - Handschoenen die geschikt zijn voor het spanningsbereik</li><br><li> - Helmen voor elektrische werkzaamheden met gelaatsscherm (EN166)</li><br><li> - Voorgeschreven PBM voor werkzaamheden aan middenspanning (UTE C 18-510)</li></ul><br><br><h3>Overige</h3><br>Opmerking: de externe ondernemingen moeten hun medewerkers de hierboven genoemde PBM ter beschikking stellen. In de transformatorstations bevinden zich een kruk en een reddingsstok.<br><br><h3>Werken op hoogte</h3><br><ul><li> - Voorgeschreven PBM (harnas, helm, 2 lijnen met schokdemper of dubbele Y-lijn, karabijnhaken, valstopapparaat, enz.) met geldige keuring</li><br><li> - Automatisch evacuatiesysteem:</li><br><li> - Aantal: 1 evacuatieset (bedoeld voor 2 personen)</li><li>Locatie: in de hoogwerker</li><br><li> - Denk aan een extra evacuatieset als er meer dan twee personen in de hoogwerker staan</li><br><li> - Overig (nader te bepalen): gebruikt valstopapparaat: HACA met referentie 0529 7103 (borstbevestiging op het harnas)</li></ul><br><br>De valstopapparaten moeten compatibel zijn met het vaste beveiligingssysteem van de machines. De valstopapparaten moeten voldoen aan de laatste norm en met succes de aanvullende beproevingen hebben doorstaan (aanvullende tests CNB/P/11.073 van 13-10-2010) die verplicht zijn gesteld door het advies van het Franse ministerie van Arbeid van 28 september 2010, om de conformiteit met de eisen van richtlijn 89/686/EEG te waarborgen.
+RulesOfProcedure                    = Huishoudelijk reglement
+RulesOfProcedureValue               = Beschikbaar op de verplichte aanplakking in de pauzeruimte
+CollectiveAgreement                 = Collectieve arbeidsovereenkomsten
+CollectiveAgreementValue            = Beschikbaar op de website van de overheid:<br /><a href="https://www.service-public.fr/particuliers/vosdroits/F78" target="_blank">https://www.service-public.fr/particuliers/vosdroits/F78</a>
+legaldisplay.odt                    = Wettelijke aanplakking
+legaldisplay_custom.odt             = Aangepaste wettelijke aanplakking
+
+#
+# InformationsSharing - Informatieverspreiding
+#
+
+# Recht
+InformationsSharingsMin = Informatieverspreidingen
+
+# Gegevens
+InformationsSharing                  = Informatieverspreiding
+Informationssharing                  = Informatieverspreiding
+InformationsSharingDocumentGenerated = Genereren van de informatieverspreiding
+HowToSetDataInformationsSharing      = Ga naar Start - Instellingen - Bedrijf/Organisatie - Sociaal om de gegevens van de informatieverspreiding in te stellen
+ConfigureSecurityAndSocialData       = De bedrijfsgegevens instellen
+LastMainDoc                          = Laatst gegenereerde document
+
+ParticipationAgreement      = Winstdelingsovereenkomsten
+ParticipationAgreementValue = Ja, alle medewerkers met een lopende arbeidsovereenkomst voor onbepaalde of bepaalde tijd met het bedrijf, van welke aard ook, kunnen aanspraak maken op de winstdeling.<br />Er geldt echter een anciënniteitsvoorwaarde: 6 maanden in het bedrijf.<br />Voor de bepaling van de vereiste anciënniteit worden alle arbeidsovereenkomsten meegeteld die tijdens de berekeningsperiode en de 12 daaraan voorafgaande maanden zijn uitgevoerd.<br />De anciënniteit wordt beoordeeld op de afsluitdatum van het betreffende boekjaar of op de vertrekdatum bij beëindiging van de overeenkomst tijdens het boekjaar.
+TermsAndConditions          = Voorwaarden
+
+ESC                  = Sociaal en Economisch Comité
+StaffRepresentatives = Personeelsvertegenwoordigers
+ElectionDate         = Verkiezingsdatum
+ElectionDateCSE      = Verkiezingsdatum van het Sociaal en Economisch Comité
+ElectionDateDP       = Verkiezingsdatum van de personeelsvertegenwoordigers
+
+Titulars                       = Vaste leden
+Alternates                     = Plaatsvervangers
+informationssharing.odt        = Informatieverspreiding
+informationssharing_custom.odt = Aangepaste informatieverspreiding
+ActionOnUser                   = Betrokken gebruiker
+HarassmentOfficer              = Verantwoordelijke voor intimidatie
+HarassmentOfficerCSE           = Verantwoordelijke voor intimidatie van het Sociaal en Economisch Comité
+ExceptionsToWorkingHours       = Afwijkingen van de werktijden
+PermanentDerogation            = Permanente afwijking
+PermanentDerogationValue       = Nee
+OccasionalDerogation           = Incidentele afwijking
+OccasionalDerogationValue      = Ja
+
+
+#
+# PreventionPlan - Preventieplan
+#
+
+# Recht
+PreventionPlansMin = preventieplannen
+
+# Gegevens
+
+PreventionPlan                                        = Preventieplan
+Preventionplan                                        = Preventieplan
+ThePreventionplan                                     = het preventieplan
+PreventionPlanDocument                                = Preventieplan
+Preventionplandocument                                = Preventieplan
+PreventionPlanDocumentGenerated                       = Genereren van het preventieplan
+PreventionPlanList                                    = Lijst van de preventieplannen
+PreventionPlanLine                                    = risico('s)
+PreventionPlanLineCreated                             = Aanmaken van een risico in het preventieplan
+PreventionPlanLineModified                            = Wijzigen van een risico in het preventieplan
+PreventionPlanLineDeleted                             = Verwijderen van een risico uit het preventieplan
+NewPreventionPlan                                     = Nieuw preventieplan
+PriorVisit                                            = Gezamenlijke voorinspectie
+PriorVisitYesNo                                       = Voorbereidend bezoek uitgevoerd
+PriorVisitText                                        = Notitie van de inspectie
+CSSCTIntervention                                     = Tussenkomst van het CSSCT
+CSSCTInterventionText                                 = Tussenkomst van het CSSCT?
+MasterWorker                                          = Verantwoordelijke van het inlenend bedrijf
+MasterWorker                                          = Verantwoordelijke van het inlenend bedrijf
+ExtSociety                                            = Externe onderneming
+ExtSocietyResponsible                                 = Verantwoordelijke van de externe onderneming
+ExtSocietyResponsible                                 = Verantwoordelijke van de externe onderneming
+ExtSocietyAttendant                                   = Medewerker van de externe onderneming
+ActionsDescription                                    = Beschrijving van de werkzaamheden
+INRSRisk                                              = Risico (INRS)
+PreventionMethod                                      = Preventiemiddelen
+PreventionplanSchedules                               = Werktijden van het preventieplan
+Attendants                                            = Deelnemers
+ModifyPreventionPlan                                  = Het preventieplan wijzigen
+ActionsDescriptionTooltip                             = Beschrijving van de door de medewerker uitgevoerde werkzaamheden
+INRSRiskTooltip                                       = Lijst van de risicocategorieën uit het referentiekader van het INRS
+PreventionMethodTooltip                               = Preventiemiddel dat moet worden ingezet om het risico te beperken
+LockPreventionPlan                                    = Het preventieplan vergrendelen
+ConfirmLockPreventionPlan                             = Weet u zeker dat u het preventieplan wilt vergrendelen?<br>Deze vergrendeling legt de gegevens en het genereren van het document vast.
+AllSignatoriesMustHaveSigned                          = Alle deelnemers moeten hebben ondertekend om het object te vergrendelen
+ValidatePreventionPlan                                = Het preventieplan valideren
+ConfirmValidatePreventionPlan                         = Weet u zeker dat u het preventieplan wilt valideren? <br> De validatie stelt de deelnemers in staat het document te ondertekenen, maar <b> verhindert het toevoegen van nieuwe deelnemers of het wijzigen van het preventieplan </b>.
+ReOpenPreventionPlan                                  = Het preventieplan heropenen
+ConfirmReOpenPreventionPlan                           = Weet u zeker dat u het preventieplan wilt heropenen? Het heropenen maakt het wijzigen van het preventieplan en het toevoegen van nieuwe deelnemers mogelijk, maar <b>alle handtekeningen op het document gaan verloren</b>.
+PreventionPlanRiskList                                = Lijst van de risico's van het preventieplan
+ActionsPreventionPlanRisk                             = Acties
+PreventionPlanDescription                             = Project van de preventieplannen
+PriorVisitDate                                        = Datum van de gezamenlijke voorinspectie
+AddPreventionPlanLine                                 = Toevoegen van het risico
+UpdatePreventionPlanLine                              = Bijwerken van het risico
+DeletePreventionPlanLine                              = Verwijderen van het risico
+PreventionPlanDet                                     = Risico van het preventieplan
+Preventionplandet                                     = Risico van het preventieplan
+PreventionPlanMessage                                 = aan het preventieplan
+PreventionPlanMustBeValidated                         = Het preventieplan moet gevalideerd zijn om het te kunnen heropenen
+PreventionPlanMustBeInProgress                        = Het preventieplan moet lopend zijn om toegang te krijgen tot deze functie
+PreventionPlanMustBeInProgressToValidate              = Het preventieplan is al gevalideerd
+CSEMustBeAlerted3DaysBeforeVisit                      = Het CSE moet 3 dagen vóór de gezamenlijke voorinspectie worden geïnformeerd (art. R. 4514-1 1°, R. 4514-3 en R. 4514-9 van het Franse arbeidswetboek)
+PreventionPlanData                                    = Gegevens van het preventieplan
+MasterWorkerDescription                               = De gebruiker die standaard als verantwoordelijke van het inlenend bedrijf wordt gebruikt
+NoPreventionPlanRisk                                  = Geen risico in het preventieplan
+NoPreventionPlanLinked                                = Geen gekoppeld preventieplan
+PreventionPlanLinked                                  = Gekoppeld preventieplan
+PreventionPlanManagement                              = Beheer van de preventieplannen
+PPRProject                                            = Aan de preventieplannen gekoppeld project
+NewLabelForClonePreventionPlan                        = Naam van het nieuwe preventieplan
+ClonePreventionPlanRisk                               = De risico's van het preventieplan klonen
+CloneAttendantsPreventionPlan                         = De deelnemers van het preventieplan klonen
+CloneSchedulePreventionPlan                           = De werktijden van het preventieplan klonen
+ConfirmClonePreventionPlan                            = Weet u zeker dat u het preventieplan <b> %s </b> wilt klonen?
+preventionplandocument.odt                            = Preventieplan
+preventionplandocument_custom.odt                     = Aangepast preventieplan
+ErrorThirdPartyHasAtLeastOneChildOfTypePreventionPlan = De relatie is gekoppeld aan ten minste één onderliggend element van het type preventieplan:
+ErrorContactHasAtLeastOneChildOfTypePreventionPlan    = Het contact is gekoppeld aan ten minste één onderliggend element van het type preventieplan:
+ConfirmDeletePreventionPlan                           = Weet u zeker dat u dit preventieplan wilt verwijderen?
+PreventionPlanRole                                    = De rollen van het preventieplan
+
+# E-mail
+PreventionPlanLabel   = Samenvatting van het preventieplan
+PreventionPlanSubject = E-mail preventieplan
+PreventionPlanContent = Bijgaand vindt u het ODT-document van het preventieplan.
+
+# Triggers
+PreventionPlanCreated          = Aanmaken van een preventieplan
+PreventionPlanModified         = Wijzigen van een preventieplan
+PreventionPlanDeleted          = Verwijderen van een preventieplan
+PreventionPlanInProgress       = Heropenen van het preventieplan
+PreventionPlanPendingSignature = Het preventieplan in afwachting van ondertekening zetten
+PreventionPlanLocked           = Vergrendelen van het preventieplan
+PreventionPlanArchived         = Archiveren van het preventieplan
+PreventionPlanSentByMail       = Versturen van het preventieplan per e-mail
+
+#
+# FirePermit - Vuurvergunning
+#
+
+# Recht
+FirePermitMin  = vuurvergunning
+FirePermitsMin = vuurvergunningen
+
+# Gegevens
+NewFirePermit                                     = Nieuwe vuurvergunning
+ModifyFirePermit                                  = De vuurvergunning wijzigen
+FirePermitList                                    = Lijst van de vuurvergunningen
+FirePermit                                        = Vuurvergunning
+Firepermit                                        = Vuurvergunning
+TheFirepermit                                     = de vuurvergunning
+FirePermitDocument                                = Vuurvergunning
+Firepermitdocument                                = Vuurvergunning
+FirePermitDocumentGenerated                       = Genereren van de vuurvergunning
+FirePermitCreated                                 = Aanmaken van een vuurvergunning
+FirePermitModified                                = Wijzigen van een vuurvergunning
+FirePermitDeleted                                 = Verwijderen van een vuurvergunning
+FirePermitInProgress                              = Heropenen van de vuurvergunning
+FirePermitPendingSignature                        = De vuurvergunning in afwachting van ondertekening zetten
+FirePermitLocked                                  = Vergrendelen van de vuurvergunning
+FirePermitArchived                                = Archiveren van de vuurvergunning
+FirePermitSignatureAddAttendant                   = Deelnemer toegevoegd aan de vuurvergunning
+FirePermitSentByMail                              = Versturen van de vuurvergunning per e-mail
+FirePermitLine                                    = risico('s)
+FirePermitDet                                     = Risico van de vuurvergunning
+Firepermitdet                                     = Risico van de vuurvergunning
+FirePermitLineCreated                             = Aanmaken van een risico in de vuurvergunning
+FirePermitLineModified                            = Wijzigen van een risico in de vuurvergunning
+FirePermitLineDeleted                             = Verwijderen van een risico uit de vuurvergunning
+FirePermitRiskList                                = Lijst van de risico's van de vuurvergunning
+AddFirePermitLine                                 = Toevoegen van het risico
+UpdateFirePermitLine                              = Bijwerken van het risico
+DeleteFirePermitLine                              = Verwijderen van het risico
+FirePermitMessage                                 = aan de vuurvergunning
+UsedMaterialTooltip                               = Te gebruiken materieel om het risico te beperken
+ActionsFirePermitRisk                             = Acties
+ConfirmValidateFirePermit                         = Weet u zeker dat u de vuurvergunning wilt valideren? <br> De validatie stelt de deelnemers in staat het document te ondertekenen, maar <b> verhindert het toevoegen van nieuwe deelnemers of het wijzigen van de vuurvergunning </b>.
+ConfirmReOpenFirePermit                           = Weet u zeker dat u de vuurvergunning wilt heropenen? Het heropenen maakt het wijzigen van de vuurvergunning en het toevoegen van nieuwe deelnemers mogelijk, maar <b>alle handtekeningen op het document gaan verloren</b>.
+ConfirmLockFirePermit                             = Weet u zeker dat u de vuurvergunning wilt vergrendelen?<br>Deze vergrendeling legt de gegevens en het genereren van het document vast.
+FirePermitMustBeInProgress                        = De vuurvergunning moet lopend zijn om toegang te krijgen tot deze functie
+NewLabelForCloneFirePermit                        = Naam van de nieuwe vuurvergunning
+CloneFirePermitRisk                               = De risico's van de vuurvergunning klonen
+CloneAttendantsFirePermit                         = De deelnemers van de vuurvergunning klonen
+CloneScheduleFirePermit                           = De werktijden van de vuurvergunning klonen
+ConfirmCloneFirePermit                            = Weet u zeker dat u de vuurvergunning <b> %s </b> wilt klonen?
+FirePermitDescription                             = Project van de vuurvergunningen
+FirePermitData                                    = Gegevens van de vuurvergunning
+FirePermitManagement                              = Beheer van de vuurvergunningen
+FPRProject                                        = Aan de vuurvergunningen gekoppeld project
+firepermitdocument.odt                            = Vuurvergunning
+firepermitdocument_custom.odt                     = Aangepaste vuurvergunning
+UsedEquipment                                     = Gebruikt materieel
+ErrorThirdPartyHasAtLeastOneChildOfTypeFirePermit = De relatie is gekoppeld aan ten minste één onderliggend element van het type vuurvergunning:
+ErrorContactHasAtLeastOneChildOfTypeFirePermit    = Het contact is gekoppeld aan ten minste één onderliggend element van het type vuurvergunning:
+ConfirmDeleteFirePermit                           = Weet u zeker dat u deze vuurvergunning wilt verwijderen?
+FirePermitRole                                    = De rollen van de vuurvergunning
+FirepermitSchedules                               = Werktijden van de vuurvergunning
+
+# E-mail
+FirePermitLabel   = Samenvatting van de vuurvergunning
+FirePermitSubject = E-mail vuurvergunning
+FirePermitContent = Bijgaand vindt u het ODT-document van de vuurvergunning.
+
+
+#
+# Accident - Ongeval
+#
+
+# Recht
+AccidentsMin = ongevallen
+
+# Trigger
+AccidentCreateTrigger         = Ongeval %s aangemaakt
+ActionsOnAccident             = Aan het ongeval gekoppelde gebeurtenissen
+AccidentGeneratedWithDolibarr = Ongeval gegenereerd met Dolibarr
+AccidentWorkStopCreateTrigger = Ziekteverzuim %s toegevoegd aan het ongeval
+AccidentWorkStopModifyTrigger = Ziekteverzuim %s gewijzigd bij het ongeval
+AccidentWorkStopDeleteTrigger = Ziekteverzuim %s verwijderd uit het ongeval
+AccidentModifyTrigger         = Ongeval %s gewijzigd
+AccidentDeleteTrigger         = Ongeval %s verwijderd
+AccidentMetaDataCreateTrigger = Opslaan van de aanvullende gegevens van het ongeval
+AccidentLesionCreateTrigger   = Letsel %s toegevoegd aan het ongeval
+AccidentLesionModifyTrigger   = Letsel %s gewijzigd bij het ongeval
+AccidentLesionDeleteTrigger   = Letsel %s verwijderd uit het ongeval
+ACC_USER_EMPLOYERSigned       = Handtekening van de verantwoordelijke van het bedrijf
+VictimAndCaregivers           = Slachtoffer en zorgverlener
+Victim                        = Slachtoffer
+Caregiver                     = Zorgverlener
+
+# Nummeringsmodel
+DigiriskAccidentNumberingModule         = Nummeringsmodel van de ongevallen van Digirisk
+DigiriskAccidentStandardModel           = Geeft het nummer terug in de vorm ACCn, waarbij n een doorlopende teller is zonder onderbreking en zonder terugzetting op 0.
+DigiriskAccidentWorkStopNumberingModule = Nummeringsmodel van het aan het ongeval gekoppelde ziekteverzuim
+DigiriskAccidentWorkStopStandardModel   = Geeft het nummer terug in de vorm ACCWn, waarbij n een doorlopende teller is zonder onderbreking en zonder terugzetting op 0.
+DigiriskAccidentLesionNumberingModule   = Nummeringsmodel van het aan het ongeval gekoppelde letsel
+DigiriskAccidentLesionStandardModel     = Geeft het nummer terug in de vorm ACCLn, waarbij n een doorlopende teller is zonder onderbreking en zonder terugzetting op 0.
+DigiriskAccidentDocumentNumberingModule = Nummeringsmodel van de ongevalsfiches van Digirisk
+DigiriskAccidentDocumentStandardModel   = Geeft het nummer terug in de vorm ACCDn, waarbij n een doorlopende teller is zonder onderbreking en zonder terugzetting op 0.
+
+# ODT-sjabloon
+DigiriskTemplateDocumentAccident       = Documentsjablonen van de ongevallen van Digirisk
+AccidentDocumentCustomDigiriskTemplate = Aangepaste ODT van de ongevallen
+AccidentDocumentDigiriskTemplate       = Standaard-ODT van de ongevallen
+AccidentDocument                       = Ongevalsfiche
+AccidentDocumentGeneratedWithDolibarr  = Ongeval gegenereerd met Dolibarr
+
+# Gegevens
+NewAccident                              = Nieuw ongeval
+ModifyAccident                           = Het ongeval wijzigen
+AccidentList                             = Lijst van de ongevallen
+Accident                                 = Ongeval
+AccidentCreated                          = Aanmaken van een ongeval
+DeleteAccident                           = Het ongeval verwijderen?
+AccidentModified                         = Wijzigen van een ongeval
+AccidentDeleted                          = Verwijderen van een ongeval
+AccidentLine                             = risico('s)
+AccidentDate                             = Datum van het ongeval
+AccidentSchedule                         = Tijden van het ongeval
+AccidentRiskList                         = Lijst van aanvullende informatie over het ongeval
+Accidentworkstop                         = Ziekteverzuim
+AccidentWorkStopCreated                  = Aanmaken van een ziekteverzuim
+AccidentWorkStopModified                 = Wijzigen van een ziekteverzuim
+AccidentWorkStopDeleted                  = Verwijderen van een ziekteverzuim
+AddAccidentWorkStop                      = Toevoegen van een ziekteverzuim aan het ongeval
+UpdateAccidentWorkStop                   = Bijwerken van een ziekteverzuim bij het ongeval
+DeleteAccidentWorkStop                   = Verwijderen van een ziekteverzuim uit het ongeval
+Accidentlesion                           = Letsel
+AccidentLesionCreated                    = Aanmaken van een letsel
+AccidentLesionModified                   = Wijzigen van een letsel
+AccidentLesionDeleted                    = Verwijderen van een letsel
+AddAccidentLesion                        = Toevoegen van een letsel aan het ongeval
+UpdateAccidentLesion                     = Bijwerken van een letsel bij het ongeval
+DeleteAccidentLesion                     = Verwijderen van een letsel uit het ongeval
+AccidentDescription                      = Project van de ongevallen
+AccidentManagement                       = Beheer van de ongevallen
+AccidentWorkstopManagement               = Beheer van het ziekteverzuim
+AccidentLesionManagement                 = Beheer van het letsel
+AccidentInvestigationManagement          = Beheer van de ongevalsonderzoeken
+ACCProject                               = Aan de ongevallen gekoppeld project
+UserVictim                               = Slachtoffer van het ongeval
+AccidentType                             = Type ongeval
+WorkAccidentStatement                    = Arbeidsongeval
+CommutingAccident                        = Woon-werkongeval
+AccidentMetaData                         = Aanvullende gegevens
+RelativeLocation                         = Aanvullende gegevens over de plaats van het ongeval
+VictimActivity                           = Activiteit van het slachtoffer op het moment van het ongeval
+AccidentNature                           = Aard van het ongeval
+AccidentObject                           = Voorwerp waarvan het contact het slachtoffer heeft verwond
+AccidentNatureDoubt                      = Eventuele gemotiveerde voorbehouden (voeg zo nodig een begeleidende brief bij)
+AccidentNatureDoubtLink                  = Link naar de begeleidende brief
+VictimTransportedTo                      = Het slachtoffer is vervoerd naar
+VictimWorkHours                          = Werktijd van het slachtoffer op de dag van het ongeval
+WorkHoursMorningDateStart                = Begin van de werktijd van het slachtoffer (ochtend)
+WorkHoursMorningDateEnd                  = Einde van de werktijd van het slachtoffer (ochtend)
+WorkHoursAfternoonDateStart              = Begin van de werktijd van het slachtoffer (middag)
+WorkHoursAfternoonDateEnd                = Einde van de werktijd van het slachtoffer (middag)
+AccidentNoticed                          = Melding van het ongeval
+Found                                    = Vastgesteld
+Known                                    = Bekend
+AccidentNoticeDate                       = Datum waarop het ongeval bekend werd
+AccidentNoticeBy                         = Persoon die het ongeval heeft gemeld
+ByEmployer                               = Door de werkgever
+ByEmployees                              = Door zijn medewerkers
+AccidentDescribedByVictim                = Het ongeval is beschreven door het slachtoffer
+RegisteredInAccidentRegister             = Het ongeval is opgenomen in het register van lichte arbeidsongevallen
+RegisterDate                             = Datum van opname in het register van lichte arbeidsongevallen
+RegisterNumber                           = Nummer van opname in het register van lichte arbeidsongevallen
+Consequence                              = Gevolgen
+WithoutWorkStop                          = Zonder ziekteverzuim
+LessThanFourDays                         = Minder dan 4 dagen
+LessThanTwentyOneDays                    = Minder dan 21 dagen
+LessThanThreeMonth                       = Minder dan 3 maanden
+LessThanSixMonths                        = Minder dan 6 maanden
+LongTimeWorkStop                         = Meer dan 6 maanden
+WithWorkStop                             = Met ziekteverzuim
+Fatal                                    = Overlijden
+PoliceReport                             = Politierapport
+PoliceReportBy                           = Persoon die het politierapport heeft opgesteld
+FirstPersonNoticedIsWitness              = Gewaarschuwde persoon
+Witness                                  = Getuige
+FirstPersonNoticed                       = Eerste gewaarschuwde persoon
+ThirdPartyResponsability                 = Is het ongeval veroorzaakt door een derde?
+FkSocResponsible                         = Bedrijf van de aansprakelijke derde
+FkSocResponsibleInsuranceSociety         = Verzekeringsmaatschappij van de derde
+LesionLocalization                       = Locatie van het letsel
+LesionNature                             = Aard van het letsel
+AccidentInvestigation                    = Ongevalsonderzoek
+Accidentinvestigation                    = Ongevalsonderzoek
+AccidentInvestigationLink                = Link naar het ongevalsonderzoek
+AccidentLocation                         = Plaats van het ongeval
+DigiriskDolibarrActionTrigger            = Trigger van de Digirisk-gebeurtenissen
+CollateralVictim                         = Nevenslachtoffer
+FromDigirisk                             = Van
+At                                       = Tot
+AndFrom                                  = En van
+ExternalAccident                         = Heeft het ongeval plaatsgevonden in een andere vestiging dan die waaraan het slachtoffer verbonden is?
+AccidentAttendants                       = Ongeval - Deelnemers
+UserEmployer                             = Verantwoordelijke van het bedrijf
+SignatureUserEmployer                    = Handtekening van de verantwoordelijke van het bedrijf
+CerfaLink                                = Link naar het Cerfa-formulier
+WorkStopDays                             = Aantal dagen ziekteverzuim
+AccidentLesionList                       = Lijst van het aan het ongeval gekoppelde letsel
+DocumentsMetaData                        = Aanvullende bijlagen
+WorkStopDocument                         = Verzuimmelding
+AccidentMetaDataSave                     = De aanvullende gegevens van het ongeval zijn opgeslagen
+ErrorFieldNotEmpty                       = Fout: het veld <b>'%s'</b> mag niet leeg zijn
+ErrorFieldMustBeGreaterOrEqualZero       = Fout: het veld <b>'%s'</b> moet groter dan of gelijk aan 0 zijn
+ConfirmDeleteAccidentWorkStop            = Weet u zeker dat u het ziekteverzuim <b>%s</b> bij het ongeval wilt verwijderen?
+AccidentMetaDataLesion                   = Aanvullende gegevens van het letsel
+TotalWorkStopDays                        = Totaal aantal dagen ziekteverzuim
+RegisterAccident                         = Licht ongeval
+AccidentsLinked                          = Gekoppeld(e) ongeval(len)
+GaugeCounter                             = Dit veld wordt gebruikt in de teller van de meter
+DateStartWorkStop                        = Begindatum van het ziekteverzuim
+DateEndWorkStop                          = Einddatum van het ziekteverzuim
+ReturnWorkDate                           = Datum van werkhervatting
+DayWithoutAccident                       = Dagen zonder ongeval(len)
+AccidentRepartition                      = Verdeling van de ongevallen per type
+AccidentByYear                           = Verdeling van de ongevallen per jaar
+NbAccidentsByEmployees                   = Aantal ongevallen per medewerker
+AccidentRegister                         = Ongeval per register
+AccidentWithoutRegister                  = Ongevallen zonder register
+AccidentWithRegister                     = Ongevallen met register
+WorkStopDurationDistribution             = Verdeling van de tijd per ziekteverzuim
+WorkStopDurationDistributionDigiriskElem = Verdeling van de verzuimtijd per GP/UT
+WorkStopDuration                         = Duur van het ziekteverzuim
+NoAbsence                                = Geen verzuim
+UpTo4Days                                = Tot 4 dagen
+UpTo21Days                               = Tot 21 dagen
+UpTo3Months                              = Tot 3 maanden
+UpTo6Months                              = Tot 6 maanden
+MoreThan6Months                          = Meer dan 6 maanden
+FrequencyIndex                           = Frequentie-index
+FrequencyRate                            = Frequentiegraad
+GravityIndex                             = Ernstindex
+GravityRate                              = Ernstgraad
+AccidentRateIndicator                    = Graden en indexen van de prestatie-indicatoren voor ongevallen
+NbPresquAccidents                        = Aantal bijna-ongevallen
+NbAccidentInvestigations                 = Aantal ongevalsonderzoeken
+AccidentInvestigationsMin                = ongevalsonderzoeken
+NbWorkedHours                            = Aantal gewerkte uren
+ConfirmDeleteAccident                    = Weet u zeker dat u het ongeval wilt verwijderen?
+TheAccident                              = het ongeval
+AccidentInvestigation                    = Ongevalsonderzoek
+Accident_investigation                   = Ongevalsonderzoek
+AccidentInvestigationDocument            = Document van het ongevalsonderzoek
+Accidentinvestigationdocument            = Document van het ongevalsonderzoek
+accidentinvestigationdocument.odt        = Ongevalsonderzoek
+NewAccidentInvestigation                 = Nieuw ongevalsonderzoek
+UpdateAccidentInvestigation              = Een ongevalsonderzoek wijzigen
+AccidentInvestigationList                = Lijst van de ongevalsonderzoeken
+TheAccidentinvestigation                 = het ongevalsonderzoek
+SeniorityInPosition                      = Anciënniteit in de functie
+VictimSkills                             = Vaardigheden van het slachtoffer
+CollectiveEquipment                      = Collectieve beschermingsmiddelen (CBM)
+IndividualEquipment                      = Persoonlijke beschermingsmiddelen (PBM)
+Circumstances                            = Omstandigheden
+CurativeAction                           = Curatieve acties
+CorrectiveAction                         = Corrigerende acties
+PreventiveAction                         = Preventieve acties
+DigiriskActionType                       = Digirisk-actietype
+Actions                                  = Acties
+ActionsTab                               = Acties
+CurativeActions                          = Curatieve acties
+PreventiveActions                        = Preventieve acties
+TotalPlannedBudget                       = Voorzien budget
+AccidentInvestigationDocumentPDF         = EA-A4-STAAND
+PreventionPlanDocumentPDF                = PP-A4-STAAND
+PreventionPlanDocumentPDFDescription     = Het preventieplan als PDF genereren
+AccidentInvestigationDocumentPDFDescription = Het ongevalsonderzoek als PDF genereren
+AccidentInvestigationDocumentGeneratedAt = Gegenereerd op
+CorrectiveActions                        = Corrigerende acties
+AddCurativeAction                        = Een curatieve actie toevoegen
+AddCorrectiveAction                      = Een corrigerende actie toevoegen
+InvestigationNotValidatedYet             = Valideer eerst het ongevalsonderzoek om acties te kunnen aanmaken
+ActionLabel                              = Naam van de actie
+ActionDeadline                           = Vervaldatum
+ActionAssignedTo                         = Toegewezen aan
+ActionProgress                           = Voortgang
+MarkAsDone                               = Als voltooid markeren
+XActionsOfY                              = %s / %s voltooid
+NoActionsYet                             = Nog geen actie
+ActionAdded                              = De actie is aangemaakt
+ActionClosed                             = De actie is afgesloten
+ActionsAreProjectTasks                   = De acties zijn subtaken van het Dolibarr-project
+SeeProjectTasksView                      = Bovenliggende taak bekijken
+OpenTask                                 = De taak openen
+AccidentInvestigationValidated           = Het ongevalsonderzoek is gevalideerd
+AccidentInvestigationReOpened            = Het ongevalsonderzoek is heropend
+AccidentInvestigationTaskCreated         = De taken van het ongevalsonderzoek zijn aangemaakt
+AccidentInvestigationTaskDeleted         = De taken van het ongevalsonderzoek zijn verwijderd
+CausalityTree                            = Oorzakenboom
+TaskWillBeCreatedAfterValidation         = De taken worden aangemaakt na de validatie van het ongevalsonderzoek
+AccidentInvestigationCreated             = Aanmaken van een ongevalsonderzoek
+AccidentInvestigationModified            = Wijzigen van een ongevalsonderzoek
+AccidentInvestigationDeleted             = Verwijderen van een ongevalsonderzoek
+AccidentInvestigationValidate            = Valideren van een ongevalsonderzoek
+AccidentInvestigationUnValidate          = Heropenen van een ongevalsonderzoek
+AccidentInvestigationLock                = Vergrendelen van het ongevalsonderzoek
+AccidentInvestigationSigned              = Ondertekenen van een ongevalsonderzoek
+CloneWorkStop                            = Het ziekteverzuim klonen?
+CloneMetadata                            = De aanvullende gegevens klonen?
+CloneLesion                              = De aanvullende gegevens van het letsel klonen?
+CloneFrom                                = Kloon van
+AccidentInvestigationRole                = De rollen van het ongevalsonderzoek
+LesionsOrWorkStop                        = letsel of ziekteverzuim
+AccidentsCategoriesArea                  = Ruimte voor tags/categorieën van de ongevallen
+AddAccidentIntoCategory                  = Deze categorie aan het ongeval toewijzen
+PreventionplansCategoriesArea            = Ruimte voor tags/categorieën van de preventieplannen
+AddPreventionplanIntoCategory            = Deze categorie aan het preventieplan toewijzen
+FirepermitsCategoriesArea                = Ruimte voor tags/categorieën van de vuurvergunningen
+AddFirepermitIntoCategory                = Deze categorie aan de vuurvergunning toewijzen
+RisksCategoriesArea                      = Ruimte voor tags/categorieën van de risico's
+AddRiskIntoCategory                      = Deze categorie aan het risico toewijzen
+AddTicketIntoCategory                    = Deze categorie aan het ticket toewijzen
+StartDateInvestigate                     = Begindatum van het onderzoek
+EndDateInvestigate                       = Einddatum van het onderzoek
+YearType                                 = Type jaar
+AllYears                                 = Alle jaren
+FiscalYear                               = Boekjaar
+CalendarYear                             = Kalenderjaar
+
+# AccidentTooltip - Tooltips van de ongevallen
+VictimActivityTooltip              = Geef de activiteit of de taak van het slachtoffer op het moment van het ongeval aan, dat wil zeggen wat het slachtoffer aan het doen was
+AccidentNatureTooltip              = Beschrijf de gebeurtenis die tot het ongeval heeft geleid, hoe het ongeval is gebeurd (elektrisch probleem, gaslek, materiaalbreuk, uitglijden, val, lichamelijke inspanning, agressie...), of hoe het slachtoffer gewond is geraakt (stoten, botsing, beknelling, prik, verdrinking, contact met een stof...)
+AccidentObjectTooltip              = Dat wil zeggen waarmee het slachtoffer gewond is geraakt: materiaal, afval, gereedschap (schroevendraaier, mes, boormachine...), machine, voertuig, heftruck, chemische stof, bouwelement (deur, muur...), vloer...
+AccidentNatureDoubtTooltip         = Vermeld indien van toepassing de gemotiveerde voorbehouden, die alleen in aanmerking kunnen worden genomen als ze betrekking hebben op de omstandigheden van tijd en plaats van het ongeval of op het bestaan van een oorzaak die volledig losstaat van het werk (art. R. 441-11 van het Franse socialezekerheidswetboek)
+VictimWorkHoursTooltip             = Vermeld de door uw medewerker gewerkte uren, of de geplande uren, op de dag van het ongeval
+ConsequenceTooltip                 = Als het slachtoffer op voorschrift van een arts het werk heeft gestaakt, moet u VERPLICHT het formulier «attestation de salaire accident du travail ou maladie professionnelle» - referentie S6202 - invullen en versturen naar het ziekenfonds van de gewone woonplaats van het slachtoffer. <br> Vervolgens moet u dezelfde formaliteit opnieuw vervullen bij een nieuw verzuim na een behandelperiode of een werkhervatting in een andere maand
+FirstPersonNoticedIsWitnessTooltip = Vermeld de achternaam, de voornaam en het adres van de getuige. <br> Bij afwezigheid van een getuige vermeldt u de eerste persoon in het bedrijf die van het ongeval op de hoogte is gesteld
+ThirdPartyResponsabilityTooltip    = Wanneer u weet dat een derde betrokken is bij een arbeids- of woon-werkongeval, ongeacht diens aandeel in de aansprakelijkheid, moet dit verplicht in dit deel worden vermeld
+FrequencyIndexTooltip              = Aantal ongevallen per medewerker x 1 000
+FrequencyRateTooltip               = Aantal ongevallen per gewerkte uren x 1 000 000
+GravityRateTooltip                 = Aantal dagen ziekteverzuim per gewerkte uren x 1 000
+NbWorkedHoursTooltip               = Het aantal gewerkte uren is handmatig ingevoerd
+DocumentGeneratedWithVersioning    = Document gegenereerd bij het versiebeheer
+
+# Woordenboek
+UsualWorkplace                  = Gebruikelijke werkplek
+OccasionalWorkplace             = Incidentele werkplek
+LocationOfTheMeal               = Plaats van de maaltijd
+OnTheWayBetweenHomeAndWorkplace = Tijdens het traject tussen de woning en de werkplek
+OnTheWayBetweenMealAndWorkplace = Tijdens het traject tussen het werk en de plaats van de maaltijd
+DuringATripForTheEmployer       = Tijdens een verplaatsing voor de werkgever
+
+Trunk             = Romp
+Hand              = Hand
+LowerLimbs        = Onderste ledematen
+UpperLimbs        = Bovenste ledematen
+MultipleLocations = Meerdere locaties
+Foot              = Voet
+Head              = Hoofd
+Eyes              = Ogen
+InternalSeating   = Inwendige locaties
+Neck              = Nek
+Back              = Rug
+WholeBody         = Hele lichaam
+NotSpecified      = Niet gespecificeerd
+
+PainEffortLumbago           = Pijn door inspanning, spit
+Contusion                   = Kneuzing
+Wounds                      = Wonden
+Sprain                      = Verstuiking
+FracturePitting             = Breuk of barst
+MultipleInjuries            = Letsel van uiteenlopende aard
+MuscleOrTendonTear          = Spier- of peesscheur
+PresenceOfForeignBody       = Aanwezigheid van een vreemd voorwerp
+Burns                       = Brandwond
+UnspecifiedAndMiscellaneous = Niet gespecificeerd en overige
+Other                       = Overige
+CutOff                      = Snijwond
+
+Investigator = Onderzoeker
+Rescuer      = Hulpverlener
+
+#
+# ListingRisksDocument - Risicolijst met documenten
+#
+
+# Recht
+ListingRisksDocumentMin = risicolijsten met documenten
+
+# Gegevens
+ListingRisksDocument            = Risicolijst
+Listingrisksdocument            = Risicolijst
+ListingRisksHeader              = Risico's - %s
+ListingRisksDocumentGenerated   = Genereren van de risicolijst met documenten
+listingrisksdocument.odt        = Risicolijst met documenten
+listingrisksdocument_custom.odt = Aangepaste risicolijst met documenten
+
+#
+# ListingRisksPhoto - Risicolijst met foto's
+#
+
+# Recht
+ListingRisksPhotosMin = risicolijsten met foto's
+
+# Gegevens
+ListingRisksPhoto            = Risicolijst met foto's
+Listingrisksphoto            = Risicolijst met foto's
+ListingRisksPhotoGenerated   = Genereren van de risicolijst met foto's
+listingrisksphoto.odt        = Risicolijst met foto's
+listingrisksphoto_custom.odt = Aangepaste risicolijst met foto's
+
+
+#
+# ListingRisksAction - Risicolijst met corrigerende acties
+#
+
+# Recht
+ListingRisksActionsMin = risicolijsten met corrigerende acties
+
+# Gegevens
+ListingRisksAction                        = Risicolijst met corrigerende acties
+Listingrisksaction                        = Risicolijst met corrigerende acties
+ListingRisksActionGenerated               = Genereren van de risicolijst met corrigerende acties
+listingrisksaction.odt                    = Risicolijst met corrigerende acties
+listingrisksaction_custom.odt             = Aangepaste risicolijst met corrigerende acties
+DigiriskListingRisksActionData            = Configureerbare gegevens van de risicolijsten met corrigerende acties
+ShowTaskDoneListingRisksActionDescription = Maakt het mogelijk de voltooide taken al dan niet weer te geven in de risicolijst met corrigerende acties
+
+
+#
+# RiskAssessmentDocument - Risico-inventarisatie
+#
+
+# Recht
+
+RiskAssessmentDocumentsMin = Risico-inventarisaties
+
+# Gegevens
+RiskAssessmentDocument                                    = Risico-inventarisatie
+Riskassessmentdocument                                    = Risico-inventarisatie
+RiskAssessmentDocumentGenerated                           = Genereren van de risico-inventarisatie
+AuditStartDate                                            = Begindatum van de audit
+AuditEndDate                                              = Einddatum van de audit
+Recipient                                                 = Ontvanger
+ImportantNote                                             = Belangrijke opmerking
+SitePlans                                                 = Locatie van de plattegronden
+SetStartEndDateBeforeSendEmail                            = Stel op deze pagina de begin- en einddatum van de audit in om een e-mail te versturen
+NoSitePlans                                               = Geen plattegrond van het bedrijf ingevuld
+riskassessmentdocument.odt                                = Risico-inventarisatie
+riskassessmentdocument_custom.odt                         = Aangepaste risico-inventarisatie
+DigiriskRiskAssessmentDocumentData                        = Configureerbare gegevens van de risico-inventarisatie
+ActionPreventionCompletedTaskDone                         = De voltooide acties worden niet weergegeven
+AppliedOn                                                 = Actief op:
+RiskAssessmentDocumentMethod                              = * Stap 1: Verzamelen van de informatie<br />- Bezoek aan de locaties<br />- Verzamelen van de personeelsgegevens<br /><br />* Stap 2: Bepalen van de methodiek en het document<br />- Valideren van de standaardfiches van de werkeenheden<br />- Valideren van de structuur van de eenheden<br /><br />* Stap 3: Uitvoeren van het risico-onderzoek<br />- Bewustmaken van het personeel voor risico's en gevaren<br />- Aanmaken van de werkeenheden met het personeel en de verantwoordelijke(n)<br />- Beoordelen van de risico's per werkeenheid met het personeel<br /><br />* Stap 4<br />- Verwerken en opstellen van de risico-inventarisatie
+RiskAssessmentDocumentSources                             = De bewustmaking voor risico's is beschreven in de ED840 uitgegeven door het INRS.<br />In dit document vindt u:<br />- De definitie van een risico en van een gevaar, met een verklarend schema<br />- De uitleg over de verschillende beoordelingsmethoden
+RiskAssessmentDocumentImportantNote                       = Belangrijke opmerkingen:<br />U kunt de documentatie van DigiRisk hier lezen<br /><a href="https://wiki.dolibarr.org/index.php?title=Module_Digirisk" target="_blank">https://wiki.dolibarr.org/index.php?title=Module_Digirisk</a><br />U kunt het project hier volgen:<br /><a href="https://github.com/Evarisk/Digirisk/projects?type=classic" target="_blank">https://github.com/Evarisk/Digirisk/projects?type=classic</a><br />Meld hier een fout<br /><a href="https://github.com/Evarisk/Digirisk/issues" target="_blank">https://github.com/Evarisk/Digirisk/issues</a>
+GenerateZipArchiveWithDigiriskElementDocuments            = Genereren van een ZIP-archief met de risico-inventarisatie
+GenerateZipArchiveWithDigiriskElementDocumentsDescription = Automatisch genereren van een ZIP-archief met de risico-inventarisatie en alle functiefiches bij het genereren van de risico-inventarisatie
+RiskAssessmentDocumentDescription                         = Actieplan van de risico-inventarisatie
+ErrorFailToFetchDigiriskElements                          = Fout: de groeperingen en werkeenheden voor het ZIP-archief konden niet worden opgehaald
+ErrorNoDocumentModelFound                                 = Fout: geen documentsjabloon beschikbaar voor <b>%s</b>
+ErrorFailToGenerateDigiriskElementDocument                = Fout: het genereren van het document van <b>%s</b> is mislukt, het ontbreekt in het ZIP-archief
+
+# Boxes - Widget
+NextGenerateDate  = Volgende generatie
+LastGenerateDate  = Laatste generatie
+DelayGenerateDate = Resterende dagen
+NoDelay           = Geen achterstand
+
+# E-mail
+RiskAssessmentDocumentLabel   = Samenvatting van de risico-inventarisatie
+RiskAssessmentDocumentSubject = E-mail risico-inventarisatie
+RiskAssessmentDocumentContent = Bijgaand vindt u het ZIP-bestand en het ODT-document van de risico-inventarisatie.
+
+
+
+#
+# AuditReportDocument - Auditrapport
+#
+
+# Gegevens
+AuditReportDocument     = Auditrapport
+Auditreportdocument     = Auditrapport
+AuditReportDocumentsMin = auditrapporten
+auditreportdocument.odt = Auditrapport
+
+
+
+#
+# GroupmentDocument - Fiche van de groepering
+#
+
+# Recht
+
+# Gegevens
+GroupmentDocument                        = Fiche van de groepering
+Groupmentdocument                        = Fiche van de groepering
+DocumentModelStandardPDF                 = Standaard-PDF-sjabloon
+GroupmentDocumentGenerated               = Genereren van de fiche van de groepering
+groupmentdocument.odt                    = Fiche van de groepering
+groupmentdocument_custom.odt             = Aangepaste fiche van de groepering
+groupmentdocumentinherited.odt           = Fiche van de groepering - Overgeërfde risico's
+groupmentdocumentinherited_custom.odt    = Aangepaste fiche van de groepering - Overgeërfde risico's
+groupmentdocumentshared.odt              = Fiche van de groepering - Gedeelde risico's
+groupmentdocumentshared_custom.odt       = Aangepaste fiche van de groepering - Gedeelde risico's
+DigiriskGroupmentDocumentData            = Configureerbare gegevens van de fiches van de groeperingen
+ShowTaskDoneGroupmentDocumentDescription = Maakt het mogelijk de voltooide taken al dan niet weer te geven in de fiche van de groepering
+
+#
+# WorkUnitDocumment - Fiche van de werkeenheid
+#
+
+# Recht
+
+# Gegevens
+WorkUnitDocument                        = Fiche van de werkeenheid
+Workunitdocument                        = Fiche van de werkeenheid
+WorkUnitDocumentGenerated               = Genereren van de fiche van de werkeenheid
+workunitdocument.odt                    = Fiche van de werkeenheid
+workunitdocument_custom.odt             = Aangepaste fiche van de werkeenheid
+workunitdocumentinherited.odt           = Fiche van de werkeenheid - Overgeërfde risico's
+workunitdocumentinherited_custom.odt    = Aangepaste fiche van de werkeenheid - Overgeërfde risico's
+workunitdocumentshared.odt              = Fiche van de werkeenheid - Gedeelde risico's
+workunitdocumentshared_custom.odt       = Aangepaste fiche van de werkeenheid - Gedeelde risico's
+workunitdocumentcomplete.odt            = Fiche van de werkeenheid - Alle risico's (eigen, overgeërfd, gedeeld)
+workunitdocumentcomplete_custom.odt     = Aangepaste fiche van de werkeenheid - Alle risico's
+DigiriskWorkUnitDocumentData            = Configureerbare gegevens van de fiches van de werkeenheden
+ShowTaskDoneWorkUnitDocumentDescription = Maakt het mogelijk de voltooide taken al dan niet weer te geven in de fiche van de werkeenheid
+
+
+#
+# DigiriskElement - Digirisk-element
+#
+
+# Rechten
+DigiriskElementsMin = Digirisk-elementen (groepering en werkeenheid)
+
+# Gegevens
+NewDigiriskElement                  = Nieuw Digirisk-element
+Digiriskelement                     = Groepering / Werkeenheid
+GPUTOrganization                    = Organisatie van de GP/UT
+DigiriskElement                     = Digirisk-element
+HiddenElements                      = Prullenbak
+DigiriskElementCreated              = Aanmaken van een Digirisk-element
+DigiriskElementModified             = Wijzigen van een Digirisk-element
+DigiriskElementDeleted              = Verwijderen van een Digirisk-element
+ElementType                         = Elementtype
+ParentElement                       = Bovenliggend element
+OrganizationSaved                   = De organisatie van de groeperingen en de werkeenheden is opgeslagen
+OrganizationNotSaved                = De organisatie van de groeperingen en de werkeenheden kon niet worden opgeslagen
+UnsavedChanges                      = Niet-opgeslagen wijzigingen
+SavingInProgress                    = Bezig met opslaan...
+Saved                               = Opgeslagen
+ErrorSaving                         = Fout bij het opslaan
+DigiriskElementOrganization         = Organisatie van de structuur
+ShareDigiriskelement                = Het delen van de groeperingen en werkeenheden activeren
+DIGIRISKELEMENTSharing              = Delen van de groeperingen en werkeenheden
+DIGIRISKELEMENTSharingDescription   = Selectie van de entiteiten die hun groeperingen en werkeenheden met deze entiteit delen.
+DigiriskElementSharedTooltip        = Met deze optie kunt u de groeperingen en werkeenheden delen. <br> INFO: als u de taken wilt kunnen weergeven, moet u de optie voor het delen van projecten activeren.
+PleaseSelectADigiriskElement        = Een groepering of een werkeenheid selecteren...
+Registers                           = Registers
+ShowInSelectOnPublicTicketInterface = Moet verschijnen in de elementenlijst van de openbare ticketinterface
+Organization                        = Organisatie GP/UT
+YouDontHaveOrganization             = U hebt geen groeperingen of werkeenheden aangemaakt, ga naar "Risico-inventarisatie" of klik <b> hier </b> om er aan te maken.
+
+
+#
+# Groupment - Groepering
+#
+
+# Gegevens
+Groupment                  = Groepering
+GroupmentManagement        = Beheer van de gegevens van de groeperingen
+NewGroupment               = Nieuwe groepering
+ModifyGroupment            = Groepering wijzigen
+TrashGroupment             = Prullenbakgroepering
+DeletedElements            = Prullenbak
+DeletedDigiriskElement     = Groeperingen / Werkeenheden in de prullenbak geplaatst
+ShowDeletedDigiriskElement = De groeperingen / werkeenheden weergeven die zich in de prullenbak bevinden
+
+#
+# WorkUnit - Werkeenheid
+#
+
+# Gegevens
+WorkUnit           = Werkeenheid
+Workunit           = Werkeenheid
+WorkUnitManagement = Beheer van de gegevens van de werkeenheden
+NewWorkUnit        = Nieuwe werkeenheid
+ModifyWorkUnit     = Werkeenheid wijzigen
+
+
+#
+# Evaluator - Beoordelaar
+#
+
+# Rechten
+EvaluatorsMin = beoordelaars
+
+# Gegevens
+Evaluator                    = Beoordelaar
+Evaluators                   = Beoordelaars
+EvaluatorCreated             = Aanmaken van een beoordelaar
+EvaluatorModified            = Wijzigen van een beoordelaar
+EvaluatorDeleted             = Verwijderen van een beoordelaar
+TheEvaluator                 = De beoordelaar
+EvaluatorWellCreated         = Beoordelaar aangemaakt
+EvaluatorNotCreated          = Fout bij het aanmaken van de beoordelaar
+EvaluatorList                = Lijst van de beoordelaars
+AssignmentDate               = Toewijzingsdatum
+EvaluationDuration           = Duur
+UserAssigned                 = Toegewezen gebruiker
+AddEvaluatorTitle            = Toevoegen van een beoordelaar
+AddEvaluatorButton           = De beoordelaar toevoegen
+EvaluatorConfig              = Instellingen van de gegevens van de beoordelaars
+DeleteEvaluatorMessage       = Verwijderen van de beoordelaar
+DigiriskEvaluatorData        = Configureerbare gegevens van de beoordelaars
+EvaluatorDuration            = Duur van de beoordeling door de beoordelaar
+EvaluatorDurationDescription = De tijd die de beoordelaar nodig heeft om zijn risicobeoordeling uit te voeren
+NbEmployeesInvolved          = Betrokken medewerkers
+NbEmployees                  = Medewerkers
+NbEmployeesInvolvedTooltip   = Unieke medewerkers (beoordelaars)
+NbEmployeesTooltip           = Als het centrale beheer van gebruikers en groepen op de hoofdentiteit is geactiveerd.<br>Het aantal medewerkers komt overeen met het aantal gedeelde/aan een groep toegewezen gebruikers en ook met het aantal beheerders van de hoofdentiteit
+NbEmployeesConfTooltip       = Het aantal medewerkers is handmatig ingevoerd
+
+
+#
+# DigiriskStandard - Digirisk-standaard
+#
+
+# Gegevens
+DigiriskStandardInformation = Informatie
+Digiriskstandard            = Digirisk-standaard
+DigiriskStandardMin         = Digirisk-standaarden
+TheDigiriskstandard         = de Digirisk-standaard
+
+
+#
+# RisksAnalysis - Risicoanalyse
+#
+
+# Gegevens
+RiskAnalysis = Risicoanalyse
+UpdateData   = Bijwerken
+
+#
+# Risks - Risico's
+#
+
+# Rechten
+RisksMin = risico's
+
+# Gegevens
+Risks                                    = Risico's
+Risk                                     = Risico
+Riskprofessionals                        = Beroepsrisico's
+RiskCreated                              = Aanmaken van een risico
+RiskModified                             = Wijzigen van een risico
+RiskDeleted                              = Verwijderen van een risico
+RiskConfig                               = Instellingen van de gegevens van de risico's
+TheRisk                                  = Het risico
+RiskWellCreated                          = Risico aangemaakt
+RiskNotCreated                           = Fout bij het aanmaken van het risico
+RiskWellEdited                           = Risico bewerkt
+RiskNotEdited                            = Fout bij het bewerken van het risico
+RiskList                                 = Risicolijst
+AddRiskTitle                             = Toevoegen van het risico
+AddRiskButton                            = Het risico toevoegen
+EditRisk                                 = Bewerken van het risico
+LinkedRisk                               = Gekoppeld risico
+RiskCategory                             = Cat.
+RiskCategoryEdit                         = Risicocategorie
+RiskCategoryEditDescription              = Het wijzigen van de categorie van een bestaand risico activeren
+HowToEditRiskCategory                    = Klik op het pictogram van de categorie om de categorie van het risico te wijzigen
+DigiriskElementRisksList                 = Lijst van de risico's
+DigiriskElementRisk                      = Risico's
+RiskDescriptionNotEnabled                = Het veld beschrijving van het risico is niet geactiveerd
+HowToEnableRiskDescription               = Ga naar "Module-instellingen -> Risico-inventarisatie" om het veld beschrijving van het risico te activeren
+HowToEnableRiskCategoryEdit              = Ga naar "Module-instellingen -> Risico-inventarisatie" om het wijzigen van de risicocategorie te activeren
+SortRisksListingsByEvaluation            = De risico's op beoordeling sorteren
+SortRisksListingsByEvaluationDescription = Het automatisch sorteren van de risico's op beoordeling in de lijsten activeren
+ListingHeaderEvaluation                  = Lijst van de beoordelingen
+RiskDescription                          = Beschrijving van het risico
+RiskDescriptionDescription               = Het veld beschrijving van het risico activeren
+RiskDescriptionNotActivated              = Activeer het veld beschrijving van het risico in Module-instellingen / Risicoanalyse / Risico's
+AddRisk                                  = Een risico toevoegen
+MoveRisk                                 = Het risico verplaatsen
+MoveRisks                                = De risico's verplaatsen
+MoveRisksDescription                     = Maakt het mogelijk risico's van de ene groepering of werkeenheid naar de andere te verplaatsen
+SetConfToMoveRisk                        = U moet eerst het verplaatsen van risico's toestaan in "Module-instellingen -> Risico-inventarisatie"
+RiskDescriptionPrefill                   = De beschrijving vooraf invullen
+RiskDescriptionPrefillDescription        = De beschrijving van het risico vooraf invullen met de naam van de categorie
+DigiriskElementSharedRisksList           = Lijst van de gedeelde risico's
+ImportSharedRisks                        = Gedeelde risico's importeren
+SelectAllSharedRisksOfElement            = Alle risico's van dit element selecteren
+AlreadyImported                          = Al geïmporteerd
+ShowSharedRisks                          = Gedeelde risico's
+ShareRisk                                = Het delen van de risico's activeren
+RISKSharing                              = Delen van de risico's
+RISKSharingDescription                   = Selectie van de entiteiten die hun risico's met deze entiteit delen.
+ShowSharedRisksDescription               = De gedeelde risico's weergeven in de documenten en de lijsten
+UnlinkSharedRisk                         = Het gedeelde risico ontkoppelen
+RiskWellUnlinkShared                     = Risico ontkoppeld
+RiskNotUnlinkShared                      = Fout bij het ontkoppelen van het risico
+HasBeenUnlinkSharedM                     = is ontkoppeld
+HasNotBeenUnlinkSharedM                  = is niet ontkoppeld
+RiskSharedTooltip                        = Met deze optie kunt u de risico's delen. <br> INFO: als u de taken wilt kunnen weergeven, moet u de optie voor het delen van projecten activeren.
+ShowInheritedRisksInListings             = Overgeërfde risico's - Lijsten <br> (afkomstig van de hogere niveaus)
+ShowInheritedRisksInListingsDescription  = Overgeërfde risico's zijn de risico's die op een hoger niveau (bijv. locatie of GP) zijn vastgesteld en automatisch op de GP/UT worden toegepast. <br> Activeer deze optie om ze in de lijsten weer te geven
+ShowInheritedRisksInDocuments            = Overgeërfde risico's - Documenten <br> (afkomstig van de hogere niveaus)
+ShowInheritedRisksInDocumentsDescription = Overgeërfde risico's zijn de risico's die op een hoger niveau (bijv. locatie of GP) zijn vastgesteld en automatisch op de GP/UT worden toegepast. <br> Activeer deze optie om ze in de documenten weer te geven
+DigiriskElementInheritedRisksList        = Lijst van de overgeërfde risico's
+ConfirmImportSharedRisks                 = Kies de te importeren gedeelde risico's
+RisksRepartition                         = Verdeling van de risico's per beoordeling
+ShowRiskOrigin                           = De herkomst van het risico weergeven
+ShowRiskOriginDescription                = De herkomst van de risico's weergeven in de documenten (Risico-inventarisatie, Groepering, Werkeenheden, Risicolijst met acties en met foto's enz.).
+SharedRiskImportWithSuccess              = Risico met succes geïmporteerd
+RiskImport                               = Import van risico's
+RiskUnlink                               = Verwijderen van het gedeelde risico
+RiskDeleted                              = Het risico %s is verwijderd
+RiskSharedWithEntityRefLabel             = Delen van het risico %s met
+RiskUnlinkedFromEntityRefLabel           = Ontkoppelen van het risico %s van
+TheDigiriskelement                       = het Digirisk-element
+DefaultProjectContactType                = Standaardrol toegekend aan het project van de risico-inventarisatie
+DefaultTaskContactType                   = Standaardrol toegekend aan de taken van het project van de risico-inventarisatie
+RiskListParentView                       = Alle bovenliggende elementen weergeven
+RiskListParentViewDescription            = Alle bovenliggende elementen van een risico weergeven in de risicolijst en in de documenten
+CategoryOnRisk                           = De tags/categorieën op de risico's weergeven
+CategoryOnRiskDescription                = Maakt het mogelijk tags/categorieën aan de risico's toe te kennen en weer te geven - met voorzichtigheid gebruiken
+AddPsychosocialRisk                      = Een psychosociaal risico toevoegen
+AddPsychosocialRiskTitle                 = Toevoegen van een psychosociaal risico
+AddPsychosocialRiskButton                = Het psychosociale risico toevoegen
+AddSelectedPsychosocialRisks             = De geselecteerde psychosociale risico's toevoegen
+SocialRelationsAtWork                    = Sociale verhoudingen op het werk
+WorkIntensityAndTime                     = Werkintensiteit en werktijd
+EmotionalRequirements                    = Emotionele eisen
+Autonomy                                 = Autonomie
+MeaningOfWork                            = Zingeving van het werk
+WorkSituationInsecurity                  = Onzekerheid van de werksituatie
+PreventionContextInCompany               = Preventiecontext in het bedrijf
+RPSImpactOnCompanyAndEmployees           = Impact van de psychosociale risico's op het bedrijf en de medewerkers
+PsychosocialRisksFactors                 = Psychosociale risicofactoren
+CompanyPreventionInformations            = Informatie over de preventie in het bedrijf
+Weak                                     = Laag
+Moderate                                 = Matig
+High                                     = Hoog
+Extreme                                  = Extreem
+HereIsTheWorkStationDescription          = Dit is de beschrijving van de werkplek
+ImageAnalysis                            = Beeldanalyse
+TextAnalysis                             = Tekstanalyse
+AnalyzeText                              = De tekst analyseren
+EnterTextForAnalysis                     = Voer de te analyseren tekst in
+AIRiskAnalysis                           = Risicoanalyse door AI
+AnalysisInProgress                       = Analyse bezig...
+
+# Statistieken
+GreyRisk                                         = Laag risico
+OrangeRisk                                       = Te plannen risico
+RedRisk                                          = Te behandelen risico
+BlackRisk                                        = Onaanvaardbaar risico
+RisksNotAssessed                                 = Niet-beoordeelde risico's
+RisksRepartitionByDangerCategories               = Verdeling van de risico's per gevarencategorie
+RiskListsByDangerCategories                      = Lijst van de risico's per gevarencategorie
+DigiriskElementsRepartitionByDepth               = Verdeling van de structuur van de groeperingen van niveau %s
+RisksRepartitionByDangerCategoriesAndCriticality = Verdeling van de risico's per gevarencategorie en kriticiteit
+NumberOfRisks                                    = Aantal risico's
+DangerCategories                                 = Gevarencategorieën
+RisksRepartitionByDigiriskElement                = Verdeling van de risico's per groepering / werkeenheid %s
+
+
+
+#
+# RiskEnvironmentals - Milieurisico's
+#
+
+# Gegevens
+Environment                                    = Milieu
+Riskenvironmental                              = Milieurisico
+RiskEnvironmentals                             = Milieurisico's
+Riskenvironmentals                             = Milieurisico's
+RiskEnvironmentalsMin                          = milieurisico's
+AddRiskenvironmentalTitle                      = Toevoegen van het milieurisico
+DigiriskElementRiskenvironmentalsList          = Lijst van de milieurisico's
+DigiriskElementInheritedRiskenvironmentalsList = Lijst van de overgeërfde milieurisico's
+DigiriskElementSharedRiskenvironmentalsList    = Lijst van de gedeelde milieurisico's
+ImportSharedRiskenvironmentals                 = Gedeelde milieurisico's importeren
+SelectAllSharedRiskenvironmentalsOfElement     = Alle milieurisico's van dit element selecteren
+ConfirmImportSharedRiskenvironmentals          = Kies de te importeren gedeelde milieurisico's
+EnvironmentDescription                         = Planning - Acties om risico's en kansen aan te pakken
+
+#
+# ListingRisksEnvironmentalAction - Lijst van milieurisico's met corrigerende acties
+#
+
+# Recht
+ListingRisksEnvironmentalActionMin = Lijst van milieurisico's met corrigerende acties
+
+# Gegevens
+ListingRisksEnvironmentalAction            = Lijst van milieurisico's met corrigerende acties
+Listingrisksenvironmentalaction            = Lijst van milieurisico's met corrigerende acties
+ListingRisksEnvironmentalActionGenerated   = Genereren van de lijst van milieurisico's met corrigerende acties
+listingrisksenvironmentalaction.odt        = Lijst van milieurisico's met corrigerende acties
+listingrisksenvironmentalaction_custom.odt = Aangepaste lijst van milieurisico's met corrigerende acties
+
+#
+# ListingRisksEnvironmentalDocument - Lijst van milieurisico's met documenten
+#
+
+# Gegevens
+ListingRisksEnvironmentalDocument = Lijst van milieurisico's
+
+
+
+#
+# RiskAssessment - Beoordeling
+#
+
+# Gegevens
+RiskAssessment                              = Beoordeling
+Riskassessment                              = Beoordeling
+RiskAssessments                             = Beoordelingen
+RiskAssessmentCreated                       = Aanmaken van een beoordeling
+RiskAssessmentModified                      = Wijzigen van een beoordeling
+RiskAssessmentDeleted                       = Verwijderen van een beoordeling
+RiskAssessmentConfig                        = Instellingen van de gegevens van de beoordelingen
+TheRiskAssessment                           = De beoordeling
+LastRiskAssessment                          = Laatste beoordeling van het risico
+RiskAssessmentWellCreated                   = Beoordeling aangemaakt
+RiskAssessmentNotCreated                    = Fout bij het aanmaken van de beoordeling
+RiskAssessmentWellEdited                    = Beoordeling bewerkt
+RiskAssessmentNotEdited                     = Fout bij het bewerken van de beoordeling
+RiskAssessmentWellDeleted                   = Beoordeling verwijderd
+RiskAssessmentNotDeleted                    = Fout bij het verwijderen van de beoordeling
+EvaluationCreate                            = Toevoegen van de beoordeling
+EvaluationEdit                              = Bewerken van de beoordeling
+EvaluationMethod                            = Beoordelingsmethode
+lastEvaluationOn                            = Laatste beoordeling op
+DeleteEvaluation                            = Weet u zeker dat u de beoordeling wilt verwijderen?
+DigiriskRiskAssessmentData                  = Configureerbare gegevens van de beoordelingen
+MultipleRiskAssessmentMethodName            = Beoordelingsmethoden
+MultipleRiskAssessmentMethodDescription     = Het wisselen van beoordelingsmethode activeren
+AdvancedRiskAssessmentMethod                = Geavanceerde beoordelingsmethode
+AdvancedRiskAssessmentMethodDescription     = De geavanceerde beoordelingsmethode activeren
+RiskAssessmentList                          = Lijst van de beoordelingen van het risico
+EditRiskAssessment                          = De beoordeling bewerken
+ShowAllRiskAssessments                      = Alle beoordelingen bekijken
+ShowAllRiskAssessmentsDescription           = De volledige lijst van de risicobeoordelingen weergeven in de risicolijst
+ParentRisk                                  = Bovenliggend risico
+RiskAssessmentDate                          = Datum van de beoordeling
+SimpleEvaluation                            = Eenvoudige beoordeling
+AdvancedEvaluation                          = Geavanceerde beoordeling
+CalculatedEvaluation                        = Berekende beoordeling
+SelectEvaluation                            = Vink de vakjes aan om uw beoordeling te berekenen
+EvaluationList                              = Lijst van de beoordelingen van het risico
+HowToSetMultipleRiskAssessmentMethod        = Ga naar Module-instellingen - Risicoanalyse - Beoordeling om het meervoudig gebruik van de beoordelingsmethoden in te stellen
+NoFileLinked                                = Geen gekoppelde foto
+AddRiskAssessment                           = Een beoordeling van het risico toevoegen
+AddRiskAssessmentTask                       = Een taak aan het risico toevoegen
+ListRiskAssessmentTask                      = Lijst van de taken van het risico
+ShowRiskAssessmentDate                      = Datum van de beoordelingen
+ShowRiskAssessmentDateDescription           = Vervangt de aanmaakdatum door de begindatum van de beoordelingen in de fiche en de documenten
+RiskAssessmentHideDateInDocument            = De datum van de beoordeling verbergen in de documenten
+RiskAssessmentHideDateInDocumentDescription = De datum van de beoordeling verbergen in de kolom "Informatie over de beoordeling" in de documenten
+RiskTaskComplete                            = Taak %s voltooid
+
+# Statistieken
+TasksRepartition = Verdeling van de taken per gemelde werkelijke voortgang
+TaskAt0Percent   = Taak op 0
+TaskInProgress   = Lopende taak
+TaskAt100Percent = Taak op 100
+
+
+#
+# RiskSign - Signalering
+#
+
+# Rechten
+RiskSignsMin = signaleringen
+
+# Gegevens
+RiskSign                           = Signalering
+RiskSignCreated                    = Aanmaken van een signalering
+RiskSignModified                   = Wijzigen van een signalering
+RiskSignDeleted                    = Verwijderen van een signalering
+TheRiskSign                        = De signalering
+RiskSignConfig                     = Instellingen van de gegevens van de signaleringen
+RiskSignWellCreated                = Signalering aangemaakt
+RiskSignNotCreated                 = Fout bij het aanmaken van de signalering
+RiskSignWellEdited                 = Signalering bewerkt
+RiskSignNotEdited                  = Fout bij het bewerken van de signalering
+RiskSignWellDeleted                = Signalering verwijderd
+RiskSignNotDeleted                 = Fout bij het verwijderen van de signalering
+RiskSignCategory                   = Categorie
+RiskSignImport                     = Import van signaleringen
+RiskSignUnlink                     = Verwijderen van de gedeelde signalering
+AddRiskSignTitle                   = Toevoegen van een signalering
+AddRiskSignButton                  = De signalering toevoegen
+EditRiskSign                       = Bewerken van een signalering
+DeleteRiskSignMessage              = Verwijderen van de signalering
+DigiriskElementRiskSignList        = Lijst van de signaleringen
+RiskSigns                          = Signaleringen
+DigiriskElementSharedRiskSignsList = Lijst van de gedeelde signaleringen
+ImportSharedRiskSigns              = Gedeelde signaleringen importeren
+SelectAllSharedRiskSignsOfElement  = Alle signaleringen van dit element selecteren
+AlreadyImportedF                   = Al geïmporteerd
+ShowSharedRiskSigns                = Gedeelde signaleringen
+ShowSharedRiskSignsDescription     = De gedeelde signaleringen weergeven in de documenten en de lijsten
+DigiriskElementSharedRiskSign      = Gedeelde signaleringen
+SharedRiskSigns                    = Gedeelde signaleringen
+ShareRisksign                      = Het delen van de signaleringen activeren
+RISKSIGNSharing                    = Delen van de signaleringen
+RISKSIGNSharingDescription         = Selectie van de entiteiten die hun signaleringen met deze entiteit delen.
+UnlinkSharedRiskSign               = De gedeelde signalering ontkoppelen
+RiskSignWellUnlinkShared           = Signalering ontkoppeld
+RiskSignNotUnlinkShared            = Fout bij het ontkoppelen van de signalering
+HasBeenUnlinkSharedF               = is ontkoppeld
+HasNotBeenUnlinkSharedF            = is niet ontkoppeld
+RiskSignSharedTooltip              = Met deze optie kunt u de signaleringen delen. <br> INFO: als u de taken wilt kunnen weergeven, moet u de optie voor het delen van projecten activeren.
+ShowInheritedRiskSigns             = Overgeërfde signaleringen
+ShowInheritedRiskSignsDescription  = De overgeërfde signaleringen weergeven in de documenten en de lijsten
+DigiriskElementInheritedRiskSignsList = Lijst van de overgeërfde signaleringen
+ConfirmImportSharedRiskSigns       = Kies de te importeren gedeelde signaleringen
+RiskSignSharedWithEntityRefLabel   = Delen van de signalering %s met
+RiskSignUnlinkedFromEntityRefLabel = Ontkoppelen van de signalering %s van
+
+#
+# Tasks - Taak
+#
+
+# Gegevens
+ActionPlan                               = Actieplan
+Task                                     = Taak
+TaskCreatedEvent                         = Aanmaken van een taak
+TaskModifiedEvent                        = Wijzigen van een taak
+TaskDeletedEvent                         = Verwijderen van een taak
+TheTask                                  = De taak
+TaskConfig                               = Instellingen van de gegevens van de taken
+TaskWellCreated                          = Taak aangemaakt
+TaskNotCreated                           = Fout bij het aanmaken van de taak
+TaskWellEdited                           = Taak bewerkt
+TaskNotEdited                            = Fout bij het bewerken van de taak
+TaskWellDeleted                          = Taak verwijderd
+TaskNotDeleted                           = Fout bij het verwijderen van de taak
+TasksManagement                          = Beheer van de taken
+SelectProject                            = Keuze van het project
+DUProject                                = Aan de taken van de risico's gekoppeld project
+EnvironmentProject                       = Aan de taken van de milieurisico's gekoppeld project
+NoTaskLinked                             = Geen lopende taak
+TaskList                                 = Lijst van de taken van het risico
+TaskCreate                               = Toevoegen van de taak
+TaskEdit                                 = Bewerken van de taak
+HowToSetDUProject                        = Ga naar Module-instellingen - Risicoanalyse - Taak om de keuze van het project in te stellen
+DeleteTask                               = Weet u zeker dat u de taak wilt verwijderen?
+ListingHeaderTask                        = Lijst van de taken
+ListingHeaderTaskTooltip                 = Activeer het delen van projecten om de taken weer te geven
+TasksManagementDescription               = Het taakbeheer activeren
+TaskManagementNotActivated               = Activeer het taakbeheer in Module-instellingen / Risicoanalyse / Taak
+DigiriskProgress                         = Voortgang
+ShowTaskStartDate                        = Begindatum van de taken
+ShowTaskStartDateDescription             = Vervangt de aanmaakdatum door de begindatum van de taken in de fiche en de documenten
+ShowTaskEndDate                          = Einddatum van de taken
+ShowTaskEndDateDescription               = De einddatum van de taken weergeven
+ShowTasksDone                            = Voltooide taken
+ShowTasksDoneDescription                 = De op 100 voltooide taken weergeven
+ShowTasksDoneDescriptionExtend           = in de risicolijsten
+ShowTaskCalculatedProgress               = Voortgang van de taak
+ShowTaskCalculatedProgressDescription    = De berekende voortgang van de taak weergeven in plaats van de gemelde voortgang
+ShowAllTasks                             = Alle taken van een risico in de lijsten
+ShowAllTasksDescription                  = Alle taken weergeven in de takenlijst van een risico in de lijsten
+DeleteTaskTimeSpent                      = Weet u zeker dat u %s min bestede tijd van de taak wilt verwijderen?
+TaskTimeSpentEdit                        = Bewerken van de bestede tijd van de taak
+TheTaskTimeSpent                         = De bestede tijd
+TaskTimeSpentCreated                     = Aanmaken van bestede tijd
+TaskTimeSpentModified                    = Wijzigen van bestede tijd
+TaskTimeSpentDeleted                     = Verwijderen van bestede tijd
+TaskTimeSpentWellCreated                 = Bestede tijd aangemaakt
+TaskTimeSpentNotCreated                  = Fout bij het aanmaken van de bestede tijd
+TaskTimeSpentWellEdited                  = Bestede tijd bewerkt
+TaskTimeSpentNotEdited                   = Fout bij het bewerken van de bestede tijd
+TaskTimeSpentWellDeleted                 = Bestede tijd verwijderd
+TaskTimeSpentNotDeleted                  = Fout bij het verwijderen van de bestede tijd
+OnTheTask                                = op de taak
+TaskTimeSpentDuration                    = Duur van de bestede tijd
+TaskTimeSpentDurationDescription         = De bestede tijd die standaard aan elke taak wordt toegevoegd
+NoTaskShared                             = Geen gedeelde taken
+WarningTaskLabel                         = Let op, u hebt het maximaal toegestane aantal tekens (255) overschreden
+ErrorRecordHasSubTasks                   = De taak heeft onderliggende elementen
+TotalConsumedTime                        = Totale bestede tijd op het project
+TotalConsumedTimeAmount                  = Kosten van de bestede tijd
+NbTasks                                  = Aantal taken
+TotalProgress                            = Totale werkelijke voortgang van de taken
+TotalBudget                              = Som van het budget van de taken
+TaskTimeSpentDate                        = Datum van de bestede tijd
+StartDateCannotBeAfterEndDate            = De einddatum mag niet vóór de begindatum liggen
+TasksFromProject                         = De weergegeven taken komen uit het project dat is ingesteld als "Project risico-inventarisatie"
+TaskHideRefInDocument                    = De referentie verbergen
+TaskHideRefInDocumentDescription         = De referentie van de taak verbergen in de documenten
+TaskHideResponsibleInDocument            = De verantwoordelijke verbergen
+TaskHideResponsibleInDocumentDescription = De verantwoordelijke van de taak verbergen in de documenten
+TaskHideDateInDocument                   = De datum verbergen
+TaskHideDateInDocumentDescription        = De begin- en einddatum van de taak verbergen in de documenten
+TaskHideBudgetInDocument                 = Het budget verbergen
+TaskHideBudgetInDocumentDescription      = Het budget van de taak verbergen in de documenten
+
+#
+# DigiAI - DigiAI
+#
+
+# Gegevens
+WelcomeToDigiAI = Welkom bij DigiAI
+UploadAnImage = Een afbeelding uploaden
+OpenAIApiKey = OpenAI API-sleutel
+OpenAIApiKeyDescription = Om DigiAI te gebruiken hebt u een OpenAI API-sleutel nodig. U kunt er een verkrijgen door een account aan te maken op <a href="https://platform.openai.com/signup" target="_blank">https://platform.openai.com/signup</a>. Na registratie kunt u een API-sleutel genereren in het gedeelte "API Keys" van uw dashboard.
+
+#
+# Ticket - Openbare ticketinterface
+#
+
+# Rechten
+TicketTagsConfig                         = Wijzigen van de registers arbeidsveiligheid en -gezondheid
+
+# Gegevens
+Register                                 = Register
+Send                                     = Versturen
+TicketSent                               = Ticket verstuurd
+FilesLinked                              = Foto's / Bijlagen
+AddDocument                              = Document toevoegen
+LastnamePlaceholder                      = Voorbeeld: Jansen
+FirstnamePlaceholder                     = Voorbeeld: Jan
+PhonePlaceholder                         = 00.00.00.00.00
+LocationPlaceholder                      = Voorbeeld: Kantoor A
+ServicePlaceholder                       = Voorbeeld: Belader
+Location                                 = Plaats
+CategoriesCreated                        = Aanmaken van de ticketcategorieën
+ExtrafieldsCreated                       = Aanmaken van de extra velden voor tickets
+AnticipatedLeave                         = Vervroegd vertrek
+DGI                                      = Ernstig en onmiddellijk gevaar
+SST                                      = Veiligheid en gezondheid op het werk
+PresquAccident                           = Bijna-ongeval
+Accident                                 = Ongeval
+EnhancementSuggestion                    = Verbetervoorstel
+MaterialProblem                          = Materieel probleem
+HumanProblem                             = Menselijk probleem
+Others                                   = Overig
+AccidentWithoutDIAT                      = Licht ongeval
+AccidentWithDIAT                         = Arbeidsongeval
+Environment                              = Milieu
+Quality                                  = Kwaliteit
+NonCompliance                            = Non-conformiteit
+FirstName                                = Voornaam
+LastName                                 = Achternaam
+Phone                                    = Telefoon
+DeclarationDate                          = Melding
+DigiriskTicketPublicAccess               = Op de volgende URL is een openbare interface beschikbaar waarvoor geen identificatie nodig is
+TicketActivatePublicInterface            = De openbare interface activeren
+GenerateExtrafields                      = Genereren van de standaard extra velden voor tickets
+GenerateTicketCategories                 = Genereren van de standaard ticketcategorieën
+AlreadyGenerated                         = Al gegenereerd
+NotGenerated                             = Nog niet gegenereerd
+NotCreated                               = Nog niet aangemaakt
+ExtrafieldsGeneration                    = Met deze optie worden de standaard extra velden van de tickets gegenereerd. De aangemaakte velden zijn: <br> Achternaam, Voornaam, Telefoon, GP/UT, Plaats en Datum
+CategoriesGeneration                     = Met deze optie worden de standaardcategorieën van de tickets gegenereerd. De aangemaakte categorieën zijn: <br> - Register <br> - - Ongeval <br> - - - Bijna-ongeval, Licht ongeval, Arbeidsongeval <br> - - Veiligheid en gezondheid op het werk <br> - - - Vervroegd vertrek, Overige, Menselijk probleem, Materieel probleem <br> - - Ernstig en onmiddellijk gevaar <br> - - Kwaliteit <br> - - - Non-conformiteit, Verbetervoorstel <br> - - Milieu <br> - - - Non-conformiteit, Overige
+TicketSuccess                            = Uw registermelding is doorgestuurd naar de preventiedienst onder het nummer:
+TicketPublicAccess                       = Terugkoppeling naar de openbare ticketinterface:
+TicketShowCompanyLogo                    = Het logo van het bedrijf weergeven in de openbare interface
+TicketShowCompanyLogoHelp                = Activeer deze optie om het logo van het bedrijf te verbergen op de pagina's van de openbare interface
+YouMustNotifyYourHierarchy               = U bent <b>verplicht</b> uw leidinggevende op de hoogte te stellen
+GoBackToTicketCreation                   = Ga naar de pagina voor het volgen van tickets
+SendEmailOnTicketSubmit                  = E-mails versturen bij het aanmaken
+CatTicketsList                           = Lijst van de tags/categorieën van de tickets
+SendEmailTo                              = Te informeren e-mailadres
+SendEmailOnTicketSubmitHelp              = Het automatisch versturen van een e-mail bij het aanmaken van een ticket activeren
+MultipleEmailsSeparator                  = Scheid meerdere te informeren e-mailadressen met een ";". Bijvoorbeeld: "aaaa@bbb.cc;dddd@eee.ff"
+TicketCategories                         = Categorieën van de tickets
+TicketDocumentsConfig                    = Documenten van de tickets
+TicketExtrafields                        = Extra velden van de tickets
+MainCategorySetting                      = Met deze optie bepaalt u van welke categorie de subcategorieën in de openbare interface verschijnen
+TicketCategoriesInDocumentsSetting       = Met deze optie kiest u welke ticketcategorieën worden weergegeven in de ticketlijst van de documenten (Risico-inventarisatie, fiche van de groepering enz.). Als er geen categorie is geselecteerd, worden alle categorieën weergegeven
+ParentCategorySetting                    = Met deze optie bepaalt u de titel van de bovenliggende categorie voor de openbare ticketinterface
+ChildCategorySetting                     = Met deze optie bepaalt u de titel van de onderliggende categorie voor de openbare ticketinterface
+TicketManagement                         = Beheer van de tickets
+MainCategory                             = Keuze van de hoofdcategorie
+TicketCategoriesInDocuments              = Categorieën weergegeven in de documenten
+ParentCategoryLabel                      = Titel van de bovenliggende categorie
+ChildCategoryLabel                       = Titel van de onderliggende categorie
+TicketPublicInterfaceEnabled             = De openbare ticketinterface is geactiveerd
+TicketPublicInterfaceDisabled            = De openbare ticketinterface is gedeactiveerd
+TicketPublicInterface                    = Openbare interface
+EmailsToNotifySet                        = De te informeren e-mailadressen zijn opgeslagen
+MainCategorySet                          = De hoofdcategorie is ingesteld
+TicketCategoriesInDocumentsSet           = De in de documenten weergegeven categorieën zijn ingesteld
+ParentCategoryLabelSet                   = De titel van de bovenliggende categorie is ingesteld
+ChildCategoryLabelSet                    = De titel van de onderliggende categorie is ingesteld
+TicketPublicInterfaceConfigDocumentation = Raadpleeg de documentatie om de openbare ticketinterface in te stellen
+ParentCategory                           = Bovenliggende categorie
+TSProject                                = Aan de tickets gekoppeld project
+TicketDescription                        = Project van de tickets
+TicketProjectUpdated                     = Het standaardproject van de tickets is bijgewerkt
+QRCodeAlreadyGenerated                   = QR-code gegenereerd
+GenerateQRCode                           = De QR-code genereren
+CompanyQRCodeGeneration                  = Genereren van de QR-code van de entiteit
+QRCodeGeneration                         = Genereren van de QR-code
+MultiCompanyQRCodeGeneration             = Genereren van de QR-code voor meerdere entiteiten
+TicketCreationMailWellSent               = Bevestigingsmail voor het aanmaken van het ticket verstuurd
+TicketCreationMailSent                   = De e-mail voor het aanmaken van het ticket is verstuurd naar %s
+HowToSetupTicketCategories               = Klik op deze link om de ticketcategorieën in te stellen:
+ConfigTicketCategories                   = Instellingen van de ticketcategorieën
+NewTicketSubmitted                       = Er is een ticket ingediend via de openbare interface
+ANewTicketHasBeenSubmitted               = Nieuw veiligheidsregister aangemaakt voor %s
+TicketCreationSubject                    = Aanmaken van een ticket via de openbare interface van Digirisk
+TicketDocumentCustomDigiriskTemplate     = Aangepaste ODT van de ticketfiches
+HowToSetupDigiriskElement                = Klik op deze link om de Digirisk-elementen (groeperingen/werkeenheden) in te stellen:
+ConfigDigiriskElement                    = Instellingen van de Digirisk-elementen
+ErrorFieldEmail                          = Fout: het e-mailadres moet overeenkomen met het volgende formaat: <b>'aaa@aaa.fr'</b>
+ErrorFieldPhone                          = Fout: het telefoonnummer moet overeenkomen met het volgende formaat: <b>'0XXXXXXXXXXX'</b> of <b>'+33XXXXXXXXX'</b>
+TicketEmailRequired                      = E-mail verplicht om een ticket aan te maken
+TicketEmailRequiredHelp                  = Activeer deze optie om het invoeren van een e-mailadres verplicht te maken bij het aanmaken van een ticket in de openbare interface
+WelcomeToPublicTicketInterface           = Welkom bij de openbare ticketinterface
+PleaseSelectAnEntity                     = Selecteer een entiteit:
+ShowSelectorOnTicketPublicInterface      = De entiteitkiezer weergeven in de openbare ticketinterface in plaats van de lijst met entiteiten
+ShowSelectorOnTicketPublicInterfaceHelp  = De entiteitkiezer weergeven in de openbare ticketinterface in plaats van de lijst met entiteiten met hun logo
+MultiEntityPublicInterface               = Openbare ticketinterface voor meerdere bedrijven
+TicketCategoriesNotCreated               = U hebt geen ticketcategorieën aangemaakt
+TicketPublicInterfaceQRCode              = QR-code van de openbare ticketinterface
+MultiEntityTicketPublicInterfaceQRCode   = QR-code van de openbare ticketinterface voor meerdere bedrijven
+PublicInterfaceConfiguration             = Zichtbare / verplichte velden van de openbare interface
+TicketNumber                             = Ticketnr.
+FromAndDate                              = Herkomst en datum
+AuthorRequest                            = Aanvrager
+DateCloture                              = Afsluitdatum
+
+PublicInterfaceUseSignatory              = Handtekening verplicht om dit register te melden
+ValidateText                             = Te aanvaarden voorwaarden voor de ondertekening
+TicketPublicInterfaceShowCategory        = De beschrijving van de categorie weergeven
+EmailTemplate                            = E-mailsjabloon
+EmailTemplateDescription                 = E-mailsjabloon
+
+OpenInNewTab                             = In een nieuw tabblad openen
+TicketDigiriskElementRequired            = GP/UT verplicht om een ticket aan te maken
+TicketDigiriskElementRequiredHelp        = Activeer deze optie om het selecteren van een GP/UT verplicht te maken bij het aanmaken van een ticket in de openbare interface
+TicketDigiriskElementHideRef             = De referentie van de GP/UT verbergen in de afdelingskiezer van de openbare interface
+TicketDigiriskElementHideRefHelp         = Activeer deze optie om de referentie van een GP/UT te verbergen in de openbare interface
+TicketDigiriskelementVisible             = Het veld GP/UT weergeven om een ticket aan te maken
+TicketServiceVisible                     = Het veld GP/UT weergeven om een ticket aan te maken
+TicketDigiriskelementVisibleHelp         = Activeer deze optie om het veld GP/UT weer te geven in de openbare interface en het zo nodig verplicht te maken
+TicketServiceVisibleHelp                 = Activeer deze optie om het veld GP/UT weer te geven in de openbare interface en het zo nodig verplicht te maken
+TicketPhotoVisible                       = Het veld Foto weergeven om een ticket aan te maken
+TicketPhotoVisibleHelp                   = Activeer deze optie om het veld Foto weer te geven in de openbare interface
+TicketEmailVisible                       = Het veld E-mail weergeven om een ticket aan te maken
+TicketEmailVisibleHelp                   = Activeer deze optie om het veld E-mail weer te geven in de openbare interface en het zo nodig verplicht te maken
+TicketLastnameVisible                    = Het veld Achternaam weergeven om een ticket aan te maken
+TicketLastnameVisibleHelp                = Activeer deze optie om het veld Achternaam weer te geven in de openbare interface en het zo nodig verplicht te maken
+TicketFirstnameVisible                   = Het veld Voornaam weergeven om een ticket aan te maken
+TicketFirstnameVisibleHelp               = Activeer deze optie om het veld Voornaam weer te geven in de openbare interface en het zo nodig verplicht te maken
+TicketPhoneVisible                       = Het veld Telefoon weergeven om een ticket aan te maken
+TicketPhoneVisibleHelp                   = Activeer deze optie om het veld Telefoon weer te geven in de openbare interface en het zo nodig verplicht te maken
+TicketLocationVisible                    = Het veld Plaats weergeven om een ticket aan te maken
+TicketLocationVisibleHelp                = Activeer deze optie om het veld Plaats weer te geven in de openbare interface en het zo nodig verplicht te maken
+TicketDateVisible                        = Het veld Datum weergeven om een ticket aan te maken
+TicketDateVisibleHelp                    = Activeer deze optie om het veld Datum weer te geven in de openbare interface en het zo nodig verplicht te maken
+QRCodeGenerated                          = QR-code gegenereerd
+FkTicket                                 = Gekoppeld ticket
+PublicTicket                             = Openbare ticketinterface
+TicketPublicInterfaceForbidden           = Toegang tot de openbare ticketinterface geweigerd
+DefaultUserGroup                         = Standaardgroep
+DefaultUserGroupDescription              = Standaardgroep in de groepskiezers
+ConfigureDefaultUserGroup                = De standaardgroep instellen
+RegisterSigned                           = Register ondertekend
+
+#Openbare interface
+TicketPublicInterfaceShowCategoryDescription     = De beschrijving van de ticketcategorieën weergeven in de openbare interface
+TicketPublicInterfaceShowCategoryDescriptionHelp = Activeer deze optie om de beschrijving van de ticketcategorieën weer te geven in de openbare interface
+
+
+# Statistieken
+TicketStatistics    = Statistieken van de tickets
+ExportCSV           = CSV-export
+GenerateCSV         = Het CSV-bestand genereren
+SuccessGenerateCSV  = CSV-bestand %s met succes gegenereerd
+ErrorMissingData    = Fout: het CSV-bestand kon niet worden gegenereerd, de naar het bestand verstuurde gegevens zijn onjuist. <br> Controleer of er GP/UT aan tickets zijn toegewezen.
+CSVFileExport       = Export van de registers in CSV-formaat gekoppeld aan GP/UT
+ThirdPartyHelp      = Als het filter "Relatie" leeg is, wordt er geen relatie gebruikt voor de zoekopdracht
+GP/UTHelp           = Standaard neemt het filter alle GP/UT mee
+CategoryTicketHelp  = Standaard neemt het filter alle categorieën mee
+CreatedByHelp       = Als het filter "Aangemaakt door" leeg is, wordt er geen gebruiker gebruikt voor de zoekopdracht
+AssignedToHelp      = Als het filter "Toegewezen aan" leeg is, wordt er geen gebruiker gebruikt voor de zoekopdracht
+StatusHelp          = Standaard neemt het filter alle statussen mee<br>
+ConcernedTimePeriod = In aanmerking genomen periode
+LessThan            = Minder dan
+MoreThan            = Meer dan
+Comparator          = Vergelijker
+RangeNumber         = Hoeveelheid
+TimeRange           = Tijdseenheid
+RangeLabel          = Naam van de voorwaarde
+Inferior            = Kleiner dan
+Superior            = Groter dan
+TimeRangeAdded      = Voorwaarde toegevoegd
+TimeRangeDeleted    = Voorwaarde verwijderd
+
+NumberOfTicketsByMainCategorieAndDigiriskElement    = Aantal registers per categorie en per GP
+NumberOfTicketsByMainSubCategorieAndDigiriskElement = Aantal registers per subcategorie en per GP
+NumberOfTicketsByYear                           = Aantal tickets per jaar
+
+# Ticket Management Dashboard - Dashboard ticketbeheer
+TicketManagementDashboard                 = Dashboard ticketbeheer
+RunningTicket                             = Lopende tickets
+NbOfOpenedTicket                          = Aantal openstaande tickets
+OldestTicket                              = Oudste ticket
+OldestTicketDescription                   = Oudste ticket met de verstreken tijd sinds het aanmaken
+OldestMessageTicket                       = Oudste ticket met een bericht
+OldestMessageTicketDescription            = Oudste ticket met een bericht en de verstreken tijd sinds het aanmaken van het bericht
+MeanAnswerTime                            = Gemiddelde reactietijd
+MeanAnswerTimeDescription                 = Gemiddelde tijd tussen openen en afsluiten, uitsluitend berekend over de afgesloten tickets
+MeanFirstResponseTime                     = Gemiddelde tijd tot de eerste reactie
+MeanFirstResponseTimeDescription          = Gemiddelde tijd tussen het openen van het ticket en het eerste voor de melder zichtbare bericht. Interne notities tellen niet mee en tickets zonder openbaar bericht zijn uitgesloten van de berekening
+NbTicketPerUser                           = Gemiddeld aantal toegewezen tickets per persoon
+NbExchangePerTicket                       = Aantal uitwisselingen per ticket
+TicketRepartitionPerUserAndMeanAnswerTime = Verdeling van de tickets per gebruiker en gemiddelde reactietijd
+TopSocietyWithMostTickets                 = Top %s van de bedrijven met de meeste tickets
+TicketsCreatedVersusClosedByMonth         = Aangemaakte en afgesloten tickets in de laatste %s maanden
+TicketsCreated                            = Aangemaakt
+TicketsClosed                             = Afgesloten
+OpenTicketsByStatus                       = Verdeling van de openstaande tickets per status
+OpenTicketBacklogAge                      = Ouderdom van de openstaande tickets (sinds het aanmaken)
+BacklogAgeUnderDays                       = Minder dan %s dagen
+BacklogAgeBetweenDays                     = Van %s tot %s dagen
+BacklogAgeOverDays                        = Meer dan %s dagen
+ShowSelectedDateTypes                     = Selecteer het weer te geven datumtype
+
+# E-mail
+The                            = Op
+TicketMessage                  = Bericht van het register
+SeeTicketUrl                   = Het ticket bekijken
+AutoNotificationTicket         = E-mailmelding automatisch verstuurd door
+TicketPublicInterfaceOtherName = Beheerinterface van de registers arbeidsveiligheid en -gezondheid en ernstig en onmiddellijk gevaar
+
+
+
+# Ticketdocument
+
+# Gegevens
+TicketDocument                 = Fiche van het ticket
+Ticketdocument                 = Fiche van het ticket
+ticketdocument.odt             = Fiche van het ticket
+ticketdocument_custom.odt      = Aangepaste fiche van het ticket
+ticketdocument_events.odt      = Fiche van het ticket met gebeurtenissen
+ticketdocument_sign.odt        = Fiche van het ticket met handtekening
+ticketdocument_event_sign.odt  = Fiche van het ticket met gebeurtenis en handtekening
+TicketSuccessMessage           = Succesbericht van het ticket
+TicketSuccessMessageSet        = Het bericht is gewijzigd
+TicketDocumentPDF              = FT-A4-LIGGEND
+TicketDocumentPDFDescription   = De fiche van het ticket weergeven
+GeneratedTicketDocumentDate    = Exportdatum van dit ticket
+
+
+# Projectdocument
+
+# ODT-sjabloon
+DigiriskTemplateDocumentProject = Documentsjablonen van de projectfiches van Digirisk
+DocumentModelPapripactA3Paysage = Documentsjablonen van het prognoserapport over de projecttaken
+PapripactFullName               = Jaarprogramma voor de Preventie van Beroepsrisico's en de Verbetering van de Arbeidsomstandigheden
+
+# Registerdocument
+
+RegisterDocument     = Register van lichte arbeidsongevallen
+Registerdocument     = Register van lichte arbeidsongevallen
+RegisterDocumentsMin = registers van lichte arbeidsongevallen
+registerdocument.odt = Register van lichte arbeidsongevallen
+
+#
+# Tools - Hulpmiddelen
+#
+
+# Gegevens
+Tools                                        = Hulpmiddelen
+DigiriskDataMigration                        = Beheer van de migratiegegevens
+DataMigrationImport                          = Import van de structuurgegevens van Digirisk
+DataMigrationImportDescription               = Import van de structuurgegevens van Digirisk WordPress in ZIP-formaat
+DataMigrationImportRisks                     = Import van de risicogegevens van Digirisk
+DataMigrationImportRisksDescription          = Import van de risicogegevens van Digirisk WordPress in ZIP-formaat
+ErrorFileNotWellFormatted                    = Het bestand heeft niet het juiste formaat of is leeg. U moet een importbestand van Digirisk WordPress bijvoegen met de naam DATE_OBJET_export.json
+ErrorFileNotWellFormattedZIP                 = Het bestand heeft niet het juiste formaat of is leeg. U moet een importbestand van Digirisk WordPress bijvoegen met de naam DATE_OBJET_export.zip
+ErrorJsonBadFormatted                        = Het JSON-bestand is niet correct opgemaakt
+SuccessImport                                = Import van de gegevens geslaagd
+DataMigrationImportRiskSigns                 = Import van de signaleringsgegevens van Digirisk
+DataMigrationImportRiskSignsDescription      = Import van de signaleringsgegevens van Digirisk WordPress in ZIP-formaat
+DataMigrationImportGlobal                    = Import van de globale gegevens van Digirisk <br> (Structuur, risico's en signaleringen)
+DataMigrationImportGlobalDescription         = Import van de globale gegevens van Digirisk WordPress in ZIP-formaat <br> (Structuur, risico's en signaleringen)
+DataMigrationExportGlobal                    = Export van de globale gegevens van Digirisk <br> (Structuur, risico's en signaleringen)
+DataMigrationExportGlobalDescription         = Export van de globale gegevens van Digirisk Dolibarr in ZIP-formaat <br> (Structuur, risico's en signaleringen)
+DataMigrationExportTree                      = Export van de structuur van Digirisk <br> (Alleen de structuur)
+DataMigrationExportTreeDescription           = Export van de structuur van Digirisk Dolibarr in ZIP-formaat <br> (Voor de huidige entiteit zichtbare GP/UT, zonder de risico's en de signaleringen)
+DataMigrationImportGlobalDolibarrDescription = Import van de globale gegevens van Digirisk Dolibarr in ZIP-formaat <br> (Structuur, risico's en signaleringen)
+DataMigrationTreeAlreadyImported             = Import van de structuurgegevens al uitgevoerd
+DataMigrationRisksAlreadyImported            = Import van de risicogegevens al uitgevoerd
+DataMigrationRiskSignsAlreadyImported        = Import van de signaleringsgegevens al uitgevoerd
+DataMigrationGlobalAlreadyImported           = Import van de globale gegevens (Structuur, risico's en signaleringen) al uitgevoerd
+AdvancedImport                               = Geavanceerde import
+AdvancedImportDescription                    = Maakt het mogelijk elk element afzonderlijk te importeren (Structuur, risico's en signaleringen)
+DataMigrationWordPressToDolibarr             = Migratie van de gegevens van WordPress naar Dolibarr
+DataMigrationDolibarrToDolibarr              = Migratie van de gegevens van Dolibarr naar Dolibarr
+RepairRisks                                  = De risico's herstellen
+NumberOfRisksCorrupted                       = U hebt %s risico('s) waarvan de categorie beschadigd is, ga naar de pagina "Hulpmiddelen" om ze te herstellen
+NoRiskToRepair                               = Geen risico te herstellen
+DigiriskElementSuccessfullyRepaired          = Digirisk-elementen (GP/UT) met succes hersteld
+RiskSuccessfullyRepaired                     = Risico's met succes hersteld
+RiskAssessmentSuccessfullyRepaired           = Beoordelingen met succes hersteld
+CorruptedCategoryOnRiskList                  = Lijst van de risico's waarvan de categorie beschadigd is
+
+# Clean - Opschonen
+Clean                                          = Opschonen
+CleanObject                                    = De gegevens opschonen
+CleanDigiriskElementExistParentDigiriskElement = %d Digirisk-elementen (GP/UT) hebben een ongeldig bovenliggend element
+CleanDigiriskElement                           = De Digirisk-elementen (GP/UT) opschonen
+CleanRiskFkElement                             = %d risico's hebben een ongeldige GP/UT
+CleanRiskStatus                                = %d risico's hebben een ongeldige status
+CleanRiskExistFkElement                        = %d risico's zijn verweesd
+CleanRiskExistRiskAssessment                   = %d risico's hebben geen enkele beoordeling
+CleanRisk                                      = De risico's opschonen
+CleanRiskAssessmentStatus                      = %d beoordelingen hebben een ongeldige status
+CleanRiskAssessmentCotation                    = %d beoordelingen hebben een lege score
+CleanRiskAssessmentExistFkRisk                 = %d beoordelingen zijn verweesd
+CleanRiskAssessment                            = De beoordelingen opschonen
+NoDigiriskElementToClean                       = Geen Digirisk-element (GP/UT) om op te schonen
+NoRiskToClean                                  = Geen risico om op te schonen
+NoRiskAssessmentToClean                        = Geen beoordeling om op te schonen
+
+
+#
+# Overige
+#
+
+# Gegevens
+AT = tot
+
+LabourInspectorName                 = DREETS
+UrlLabourInspector                  = https://travail-emploi.gouv.fr/ministere/organisation/article/dreets-directions-regionales-de-l-economie-de-l-emploi-du-travail-et-des
+IDCCTooltip                         = Dit veld komt uit de module Digirisk voor Dolibarr <br> De nomenclatuur van de collectieve arbeidsovereenkomsten komt van travail-emploi.gouv.fr
+NoEmailContact                      = Geen e-mailadres bij dit contact
+AddMedia                            = Een mediabestand toevoegen
+NoMediaLinked                       = Geen gekoppeld mediabestand
+UserGroup                           = Gebruikersgroep
+ReaderGroup                         = Lezersgroep
+UserCreated                         = De gebruiker is aangemaakt
+GetAPI                              = Gebruik van de Digirisk API-routes met de GET-methode
+PostAPI                             = Gebruik van de Digirisk API-routes met de POST-methode
+MinimizeMenu                        = Het menu verkleinen
+ActionsLine                         = Acties
+PhotoWellSent                       = De foto is toegevoegd aan de mediabibliotheek
+PhotoNotSent                        = De foto is niet correct verstuurd
+PhotoWellSaved                      = Het mediabestand of de mediabestanden is/zijn toegevoegd
+PhotoNotSaved                       = Het mediabestand of de mediabestanden is/zijn niet toegevoegd
+UseCaptcha                          = Grafische code (CAPTCHA)
+UseCaptchaDescription               = Gebruik van de grafische code (CAPTCHA) op de pagina's van de openbare interface
+GP/UTParticipation                  = Deelname GP/UT
+LabourDoctorName                    = AMETRA
+LabourDoctorFirstName               = Bedrijfs-
+LabourDoctorLastName                = arts
+DashBoard                           = Dashboard
+Close                               = Sluiten
+DateRange                           = Datumbereik
+UseDateRange                        = Het datumbereik gebruiken
+SiretNumber                         = Fiscaal nr.
+Society                             = Bedrijf
+MulticompanyTransverseModeEnabled   = Het centrale beheer van gebruikers en groepen op de hoofdentiteit is geactiveerd.<br>U kunt daarom geen gebruiker of groep aanmaken op deze entiteit.<br>Ga naar de hoofdentiteit om dit toe te voegen.
+ManuelInputNBEmployees              = Het aantal medewerkers handmatig invoeren
+ManuelInputNBEmployeesDescription   = Als de optie is geactiveerd, kunt u het aantal medewerkers handmatig invoeren in de instellingen van het bedrijf.<br>Anders wordt het aantal medewerkers berekend.<br>Raadpleeg de documentatie voor meer informatie.
+ManuelInputNBWorkedHours            = Het aantal gewerkte uren handmatig invoeren
+ManuelInputNBWorkedHoursDescription = Als de optie is geactiveerd, kunt u het aantal gewerkte uren handmatig invoeren in de instellingen van het bedrijf.<br>Anders wordt het aantal gewerkte uren berekend.<br>Raadpleeg de documentatie voor meer informatie.
+ShowPatchNoteAgain                  = De releasenotitie weergeven
+ShowPatchNoteAgainDescription       = Als de optie is geactiveerd, verschijnt de releasenotitie van de huidige versie opnieuw op de startpagina van Digirisk.<br>(Vereist dat de optie «De releasenotities van GitHub weergeven» is geactiveerd om zichtbaar te zijn.)
+HowToConfigureSetupConf             = Ga naar Digirisk - Instellingen - Configuratie<br>om de aan Digirisk gekoppelde bedrijfsgegevens in te stellen
+LabourDoctorNameFull                = Artsenvereniging
+PermissionInheritedFromConfig       = De rechten worden overgeërfd van de algemene instellingen of van de bovenliggende instellingen
+CategorieManagement                 = Beheer van de categorieën
+ShowSelectedRiskTypes               = Selecteer de weer te geven risicotypes
+CharRemaining                       = Resterende tekens
+NumberOfLinkedFiles                 = Aantal bijlagen
+ChooseAnImage                       = Een afbeelding kiezen
+
+# Action Plan - Gantt / Kanban
+ActionPlanGantt                     = Gantt-diagram
+ActionPlanKanban                    = Kanban
+ActionPlanView                      = Actieplan
+ColumnDraft                         = Concept
+ColumnInProgress                    = Lopend
+ColumnInControl                     = Te controleren
+ColumnDone                          = Voltooid
+NoTasks                             = Geen corrigerende actie
+ActionPlanGlobalProgress            = Totale voortgang van het PAPRIPACT
+ActionPlanGlobalProgressInfo        = Gemiddelde voortgang van %s corrigerende actie(s)
+KanbanLoadMore                      = Meer weergeven (%s)
+KanbanDisplay                       = Weergave van het Kanban
+KanbanPageSize                      = Aantal kaarten per kolom
+KanbanPageSizeDesc                  = Aantal corrigerende acties dat meteen in elke kolom wordt weergegeven; de volgende worden geladen via de knop «Meer weergeven» (verbetert de prestaties bij grote hoeveelheden)
+KanbanDraftMax                      = Drempel kolom «Concept»
+KanbanDraftMaxDesc                  = Maximale voortgang (%) waarbij een actie in de kolom «Concept» blijft
+KanbanProgressMax                   = Drempel kolom «Lopend»
+KanbanProgressMaxDesc               = Maximale voortgang (%) voor de kolom «Lopend»
+KanbanControlMax                    = Drempel kolom «Te controleren»
+KanbanControlMaxDesc                = Maximale voortgang (%) voor de kolom «Te controleren»; daarboven gaat de actie naar «Voltooid»
+PlannedWorkload                     = Voorziene belasting
+TimeSpent                           = Bestede tijd
+LinkedRisk                          = Gekoppeld risico
+TaskMovedTo                         = Taak verplaatst naar %s
+
+AddCategory                        = Een categorie toevoegen
+SelectCategory                     = Een categorie kiezen
+DateEndBeforeStart                 = Einddatum vóór de begindatum
+InternalUsers                      = Interne gebruikers
+ExternalContacts                   = Externe contacten
+AddContributor                     = Een medewerker toevoegen
+RemoveContact                      = Het contact verwijderen
+ColumnWidth                        = Breedte
+ColumnGap                          = Tussenruimte
+ActionPlanExportCsv                = Het PAPRIPACT downloaden in CSV-formaat
+ActionPlanExportA3                 = Het PAPRIPACT downloaden als PDF A3 liggend
+ActionPlanExportGantt              = Het Gantt-diagram downloaden als PNG-afbeelding
+ActionPlanDisplayedProject         = Weergegeven project
+ActionPlanChangeProject            = Van project wisselen
+ActionPlanDefaultProject           = Risico-inventarisatie (standaard)
+ActionPlanNoProjectConfigured      = Geen project ingesteld
+
+# ActionPlan — Gebeurtenisregistratie
+ActionPlanLogging                  = Actieplan — Wijzigingsgeschiedenis
+ActionPlanLoggingDescription       = Het aanmaken van gebeurtenissen bij wijzigingen in het Kanban activeren
+ActionPlanLogLabel                 = Wijziging van de naam
+ActionPlanLogLabelDesc             = Een gebeurtenis aanmaken wanneer de naam van een taak wordt gewijzigd
+ActionPlanLogWorkload              = Wijziging van de belasting
+ActionPlanLogWorkloadDesc          = Een gebeurtenis aanmaken wanneer de voorziene belasting wordt gewijzigd
+ActionPlanLogBudget                = Wijziging van het budget
+ActionPlanLogBudgetDesc            = Een gebeurtenis aanmaken wanneer het budget wordt gewijzigd
+ActionPlanLogContributorAdd        = Toevoegen van een medewerker
+ActionPlanLogContributorAddDesc    = Een gebeurtenis aanmaken wanneer een medewerker wordt toegevoegd
+ActionPlanLogContributorRemove     = Verwijderen van een medewerker
+ActionPlanLogContributorRemoveDesc = Een gebeurtenis aanmaken wanneer een medewerker wordt verwijderd
+ActionPlanLogProgress              = Wijziging van de voortgang
+ActionPlanLogProgressDesc          = Een gebeurtenis aanmaken wanneer de voortgang wordt gewijzigd
+ActionPlanLogTag                   = Wijziging van de tags
+ActionPlanLogTagDesc               = Een gebeurtenis aanmaken wanneer een tag wordt toegevoegd of verwijderd
+ActionPlanLogDateStart             = Wijziging van de begindatum
+ActionPlanLogDateStartDesc         = Een gebeurtenis aanmaken wanneer de begindatum wordt gewijzigd
+ActionPlanLogDateEnd               = Wijziging van de einddatum
+ActionPlanLogDateEndDesc           = Een gebeurtenis aanmaken wanneer de einddatum wordt gewijzigd
+ActionPlanTaskLabelChanged         = Naam gewijzigd: "%s" → "%s"
+ActionPlanTaskWorkloadChanged      = Belasting gewijzigd: %s → %s
+ActionPlanTaskBudgetChanged        = Budget gewijzigd: %s → %s
+ActionPlanTaskContributorAdded     = Medewerker toegevoegd: %s
+ActionPlanTaskContributorRemoved   = Medewerker verwijderd: ID %s
+ActionPlanTaskProgressChanged      = Voortgang gewijzigd: %s%% → %s%%
+ActionPlanTaskTagAdded             = Tag toegevoegd: %s
+ActionPlanTaskTagRemoved           = Tag verwijderd: ID %s
+ActionPlanTaskDateStartChanged     = Begindatum gewijzigd: %s → %s
+ActionPlanTaskDateEndChanged       = Einddatum gewijzigd: %s → %s
+
+# ===========================================================================
+# Filters van het actieplan — issue #4907 (GP/UT, risiconiveau, tags)
+# ===========================================================================
+ActionPlanElement                    = GP/UT
+ActionPlanFilterElementChildren      = Met de subelementen
+ActionPlanFilterElementChildrenHelp  = De corrigerende acties van de onderliggende GP/UT van de geselecteerde GP/UT opnemen
+ActionPlanFilterScale                = Risiconiveau
+ActionPlanFilterAllScales            = Alle niveaus
+ActionPlanFilterTags                 = Tags
+ActionPlanFilterCount                = %s corrigerende actie(s) weergegeven van %s
+ActionPlanDictionaries               = Lijsten van het Kanban
+ActionPlanDictionariesDesc           = De waarden beheren die worden aangeboden in de lijsten van het actieplan en de Kanban
+ActionPlanTagDictionary              = Tags van de corrigerende acties
+ActionPlanTagDictionaryDesc          = Tags (taakcategorieën) die worden aangeboden op de kaarten en in het filter van het Kanban van het actieplan
+ActionPlanTicketDictionaries         = Woordenboeken van de ticket-Kanban
+ActionPlanTicketDictionariesDesc     = Types, groepen en ernstniveaus waaruit de kolommen van de ticket-Kanban bestaan
+ActionPlanManageDictionary           = Beheren
+
+# ===========================================================================
+# Ticketactiekaart — issue #4443 (1-klik-interface)
+# ===========================================================================
+TicketActionCard                     = Ticketactie
+TicketActionCardPickerIntro          = Selecteer een ticket om met 1 klik een snelle actie uit te voeren.
+TicketActionCardStatusSection        = Status
+TicketActionCardAssignSection        = Toewijzing
+TicketActionCardContentSection       = Inhoud
+TicketActionCardDangerSection        = Gevoelige zone
+TicketActionMarkRead                 = Als gelezen markeren
+TicketActionInProgress               = Op lopend zetten
+TicketActionWaiting                  = In de wacht zetten
+TicketActionClose                    = Afsluiten
+TicketActionCancel                   = Ticket annuleren
+TicketActionAssignSelf               = Aan mij toewijzen
+TicketActionAssignOther              = Toewijzen aan...
+TicketActionAddMessage               = Een bericht toevoegen
+TicketActionLinkAccident             = Een ongeval koppelen
+TicketActionOpenFull                 = Volledige details
+TicketActionMarkedRead               = Ticket als gelezen gemarkeerd
+TicketActionInProgressDone           = Ticket op lopend gezet
+TicketActionWaitingDone              = Ticket in de wacht gezet
+TicketActionClosedDone               = Ticket afgesloten
+TicketActionCancelledDone            = Ticket geannuleerd
+TicketActionAssignedSelfDone         = Ticket aan u toegewezen
+TicketActionAssignedOtherDone        = Ticket toegewezen
+TicketActionCloseConfirm             = Het afsluiten bevestigen
+TicketActionCancelConfirm            = De annulering bevestigen
+TicketActionCardRegistresSection      = Informatie registers
+TicketMessageTitle                    = Titel van het bericht
+TicketResponsibleAndProgress          = Verantwoordelijke en voortgang
+TicketActionCardClassificationSection = Classificatie
+TicketActionCardDatesSection          = Belangrijke data
+TicketActionCardIdentificationSection = Identificatie
+TicketActionCardOtherFieldsSection    = Overige informatie
+TicketActionCardEventsSection         = Recente gebeurtenissen
+TicketActionCardRelatedSection        = Gekoppelde objecten
+UnknownFieldToUpdate                  = Onbekend veld: %s
+Saved                                 = Opgeslagen
+SeeAll                                = Alles bekijken
+LayoutCustomize                       = Aanpassen
+LayoutDone                            = Klaar
+LayoutControls                        = Lay-outbediening
+LayoutWidthHalf                       = Halve kolom
+LayoutWidthFull                       = Hele kolom
+LayoutWidthSpan                       = Volledige breedte
+LayoutSaved                           = Lay-out opgeslagen
+LayoutReset                           = Herstellen
+LayoutResetTitle                      = De lay-out herstellen (terug naar de standaardwaarden)
+LayoutDensity                         = Weergavedichtheid
+LayoutDensityCompact                  = Compact
+LayoutDensityCozy                     = Comfortabel
+LayoutDensitySpacious                 = Ruim
+AddTag                                = Een tag toevoegen
+TagAdded                              = Tag toegevoegd
+TagRemoved                            = Tag verwijderd
+Preview                               = Voorbeeld
+OpenInNewTab                          = In een nieuw tabblad openen
+FileDeleted                           = Bestand verwijderd
+OtherTicket                           = ander ticket
+OtherTickets                          = andere tickets
+SeeOtherTicketsForThisCompany         = De ticketgeschiedenis van deze klant bekijken
+StatusTimeline                        = Tijdlijn van de status
+WatchTicket                           = Dit ticket volgen
+UnwatchTicket                         = Dit ticket niet meer volgen
+TicketWatched                         = Ticket gevolgd
+TicketUnwatched                       = Ticket niet meer gevolgd
+WatchedTicket                         = Gevolgd ticket
+WatchedOnly                           = Alleen de gevolgde
+AllTickets                            = Alle
+NoWatchedTicket                       = Geen gevolgd ticket
+FileUploaded                          = Bestand verstuurd
+UploadFile                            = Een bestand kiezen
+OrDropAnywhere                        = of sleep het naar de kaart
+Messages                              = Berichten
+TypeYourReply                         = Typ uw antwoord…
+PrivateMessage                        = Privébericht
+Send                                  = Versturen
+NoMessageYet                          = Nog geen bericht
+BeFirstToReply                        = Wees de eerste die reageert
+MessagePosted                         = Bericht verstuurd
+MessageEdited                         = Bericht gewijzigd
+MessageDeleted                        = Bericht verwijderd
+ConfirmDeleteMessage                  = Dit bericht verwijderen?
+ReplyByEmail                          = Per e-mail versturen
+SentByMail                            = Per e-mail verstuurd
+MailSentToNRecipients                 = e-mail verstuurd naar %d ontvanger(s)
+MailNotSent                           = versturen van de e-mail mislukt
+NoRecipientFound                      = geen ontvanger gevonden
+OriginalMessage                       = Oorspronkelijk bericht
+JustNow                               = zojuist
+NMinAgo                               = %d min geleden
+NHAgo                                 = %d u geleden
+NDAgo                                 = %d d geleden
+NAttachedFiles                        = %d bijlage(n)
+Quote                                 = Citeren
+NotAllowed                            = Actie niet toegestaan
+Private                               = Privé
+Unknown                               = Onbekend
+LayoutTagsMode                        = Weergave van de tags
+LayoutTagsModeChips                   = Volledige lijst (chips)
+LayoutTagsModeSelector                = Uitklapkiezer
+LayoutActionsMode                     = Weergave van de acties
+LayoutActionsModeBar                  = Actiebalk
+LayoutActionsModeMenu                 = Menu (⋮)
+Move                                  = Verplaatsen
+Hide                                  = Verbergen
+Show                                  = Weergeven
+
+# ===========================================================================
+# Ticket-kanban — instellingen van de gebeurtenisregistratie — issue #4753
+# ===========================================================================
+TicketKanban                           = Ticket-Kanban
+TicketKanbanLogging                    = Ticket-Kanban — Wijzigingsgeschiedenis
+TicketKanbanLoggingDescription         = Het aanmaken van gebeurtenissen bij wijzigingen in het kanban activeren
+TicketKanbanLogStatus                  = Wijziging van de status
+TicketKanbanLogStatusDesc              = Een gebeurtenis aanmaken wanneer de status van een ticket via het kanban wordt gewijzigd
+TicketKanbanLogAssignee                = Wijziging van de toegewezen persoon
+TicketKanbanLogAssigneeDesc            = Een gebeurtenis aanmaken wanneer de toegewezen persoon van een ticket via het kanban wordt gewijzigd
+TicketKanbanLogCategoryAdd             = Toevoegen van een tag
+TicketKanbanLogCategoryAddDesc         = Een gebeurtenis aanmaken wanneer een tag via het kanban aan een ticket wordt toegevoegd
+TicketKanbanLogCategoryRemove          = Verwijderen van een tag
+TicketKanbanLogCategoryRemoveDesc      = Een gebeurtenis aanmaken wanneer een tag via het kanban van een ticket wordt verwijderd
+TicketKanbanLogType                    = Wijziging van het type
+TicketKanbanLogTypeDesc                = Een gebeurtenis aanmaken wanneer het type van een ticket via het kanban wordt gewijzigd
+TicketKanbanLogGroup                   = Wijziging van de groep
+TicketKanbanLogGroupDesc               = Een gebeurtenis aanmaken wanneer de groep van een ticket via het kanban wordt gewijzigd
+TicketKanbanLogSeverity                = Wijziging van de ernst
+TicketKanbanLogSeverityDesc            = Een gebeurtenis aanmaken wanneer de ernst van een ticket via het kanban wordt gewijzigd
+TicketKanbanLogSubject                 = Wijziging van het onderwerp
+TicketKanbanLogSubjectDesc             = Een gebeurtenis aanmaken wanneer het onderwerp van een ticket via het kanban wordt gewijzigd
+TicketKanbanLogDeadline                = Wijziging van de uiterste datum
+TicketKanbanLogDeadlineDesc            = Een gebeurtenis aanmaken wanneer de uiterste datum van een ticket via het kanban wordt gewijzigd
+TicketKanbanClosedLimit                = Limiet gesloten tickets
+TicketKanbanClosedLimitDesc            = Maximaal aantal gesloten/geannuleerde tickets dat in het kanban wordt weergegeven (0 = onbeperkt)
+
+# ===========================================================================
+# Ticket — traceerbaarheid van de wijzigingen — issue #4885
+# ===========================================================================
+TicketLogModifications                 = Traceerbaarheid van de wijzigingen
+TicketLogModificationsDesc             = Een gebeurtenis aanmaken voor elke bewerking vanuit de ticketfiche (onderwerp, bericht, registers, toegewezen persoon, relatie, project, voortgang, status, taken, documenten)
+TicketMessageEdited                    = Bericht gewijzigd
+TicketMessageDeleted                   = Bericht verwijderd
+TicketTaskCreated                      = Taak aangemaakt: %s
+TicketDocumentGenerated                = Document gegenereerd
+TicketFileDeleted                      = Bestand verwijderd
+
+# Paneel voor het snel aanmaken van een ticket
+SelectNothing                          = — Selecteren —
+QuickCreateTicket                      = Snel een ticket aanmaken
+TicketSubjectPlaceholder               = Titel van het ticket...
+TicketInitialMessage                   = Eerste bericht
+OptionalDescription                    = Beschrijving (optioneel)...
+Unassigned                             = Niet toegewezen
+QuickCreateAttachments                 = Bijlagen
+QuickCreateDropzone                    = Sleep hierheen of klik om te selecteren
+QuickCreateDropzoneActive              = Hier neerzetten…
+QuickCreateAttachmentHint              = Toegestane formaten: afbeeldingen, PDF, documenten. Max. 10 MB per bestand.
+QuickCreateTicketSuccess               = Ticket %s met succes aangemaakt.
+
+# MeteoVigilance - Weerwaarschuwing Météo-France
+MeteoVigilance = Weerwaarschuwing Météo-France
+MeteoVigilancePanelTitle = Waarschuwing %s
+MeteoVigilanceAdvice2 = Wees oplettend
+MeteoVigilanceAdvice3 = Wees zeer waakzaam
+MeteoVigilanceAdvice4 = Uiterste waakzaamheid
+MeteoVigilanceUpdatedAt = Bijgewerkt %s
+MeteoVigilanceEnabled = De weerwaarschuwing activeren
+MeteoVigilanceEnabledDescription = Geeft de widget Weerwaarschuwing Météo-France weer op het dashboard (en de waarschuwingsbalk bij een oranje/rode waarschuwing).
+MeteoVigilanceLevel = Waarschuwingsniveau
+MeteoVigilanceActivePhenomena = Actieve verschijnselen
+MeteoVigilanceNoAlert = Geen bijzondere waarschuwing
+MeteoVigilanceSource = Bron
+MeteoVigilanceSeeOnMeteoFrance = Bekijken op vigilance.meteofrance.fr
+MeteoVigilanceNotConfigured = API-sleutel Météo-France niet ingesteld — klik om in te stellen
+MeteoVigilanceUnknownDepartment = Departement van het bedrijf niet bepaald
+MeteoVigilanceUnavailable = Waarschuwingsgegevens tijdelijk niet beschikbaar
+MeteoVigilanceBannerTitle = Waarschuwing %s van kracht in departement %s
+MeteoVigilanceLevel1 = Groen
+MeteoVigilanceLevel2 = Geel
+MeteoVigilanceLevel3 = Oranje
+MeteoVigilanceLevel4 = Rood
+MeteoVigilancePhenomenon1 = Zware wind
+MeteoVigilancePhenomenon2 = Regen en overstroming
+MeteoVigilancePhenomenon3 = Onweer
+MeteoVigilancePhenomenon4 = Hoogwater
+MeteoVigilancePhenomenon5 = Sneeuw en ijzel
+MeteoVigilancePhenomenon6 = Hittegolf
+MeteoVigilancePhenomenon7 = Extreme kou
+MeteoVigilancePhenomenon8 = Lawines
+MeteoVigilancePhenomenon9 = Golven en kustoverstroming
+MeteoVigilanceSetup = Instellingen van de weerwaarschuwing
+MeteoVigilanceApiKey = API-sleutel Météo-France
+MeteoVigilanceApiKeyDescription = API-sleutel van het portaal van Météo-France (maak een account en een applicatie «Bulletin Vigilance» aan op <a href="https://portail-api.meteofrance.fr" target="_blank">portail-api.meteofrance.fr</a> om de sleutel te genereren).
+MeteoVigilanceDepartment = Departementscode (overschrijving)
+MeteoVigilanceDepartmentDescription = Laat leeg om het departement automatisch af te leiden uit het adres van het bedrijf. Voer anders een code in (bijv. 35, 2A).
+MeteoVigilanceCacheTTL = Duur van de cache (seconden)
+MeteoVigilanceCacheTTLDescription = Periode waarin de gegevens van de API in de cache worden bewaard vóór een nieuwe aanroep (standaard 3600).
+MeteoVigilanceSettings = Instellingen van de weerwaarschuwing
+MeteoVigilanceRefreshNow = Nu vernieuwen
+MeteoVigilanceRefreshed = Gegevens vernieuwd: waarschuwing %s in departement %s
+
+# Conversatiesysteem van de tickets
+Conversation = Conversatie
+PublicMessage = Openbaar bericht
+ConvTo = Aan
+ConvCc = Cc
+
+SaveNote = De notitie opslaan
+
+AddRecipient = Een ontvanger toevoegen
+NoRecipientFound = Geen ontvanger
+
+AddFile = Een bestand toevoegen
+
+MentionAgents = Medewerkers vermelden
+YouWereMentionedOnTicket = U bent vermeld op ticket %s
+YouWereMentionedOnTicketBody = %s heeft u vermeld op ticket %s:
+
+Mentioned = Vermeld
+
+# Snel mobiel aanmaken van een preventieplan
+MobileQuickCreation = Snel mobiel aanmaken
+MobilePPInteriorCompany = Inlenend bedrijf (intern)
+MobilePPResponsibleAutoSign = Verantwoordelijke (ondertekent automatisch)
+MobilePPSignatureSaved = Handtekening opgeslagen
+MobilePPEditSignature = De handtekening wijzigen
+MobilePPDrawSignatureHint = Teken hieronder uw handtekening en sla deze op. Deze wordt hergebruikt voor uw volgende plannen.
+MobilePPClearSignature = Wissen
+MobilePPSaveSignature = Mijn handtekening opslaan
+MobilePPExteriorCompany = Externe onderneming
+MobileSirenOrSiret = SIREN / SIRET
+MobileSirenOrSiretPlaceholder = 9 of 14 cijfers
+MobilePPResponsibleToSign = Verantwoordelijke die moet ondertekenen
+MobilePPChooseExistingContact = Een bestaand contact kiezen
+MobilePPNewContact = Nieuw contact
+MobilePPEmailForSignatureHelp = Dit e-mailadres ontvangt het ondertekeningsverzoek.
+MobilePPPeriod = Interventieperiode
+MobilePPMaxOneYearHint = Maximaal 1 jaar tussen de begindatum en de einddatum.
+MobilePPSubmit = Het preventieplan aanmaken
+MobilePPErrorNoSignature = U moet uw handtekening opslaan voordat u het plan aanmaakt.
+MobilePPErrorEmptySignature = De handtekening is leeg.
+MobilePPErrorInvalidSiren = Ongeldige SIREN of SIRET (9 of 14 cijfers verwacht).
+MobilePPErrorEndBeforeStart = De einddatum moet na de begindatum liggen.
+MobilePPErrorMaxOneYear = De duur mag niet langer zijn dan 1 jaar.
+MobilePPErrorDatesRequired = Vul de begindatum en de einddatum in.
+MobilePPErrorStartRequired = De begindatum ontbreekt.
+MobilePPErrorEndRequired = De einddatum ontbreekt.
+MobilePPErrorNoProject = Er is geen standaardproject voor preventieplannen ingesteld.
+MobilePPCompanyFound = Bedrijf gevonden:
+MobilePPCompanyNotFound = Geen bedrijf gevonden in de database: er wordt een nieuw bedrijf aangemaakt.
+MobilePPWarningEmailNotSent = Het plan is aangemaakt, maar de e-mail voor de ondertekening kon niet worden verstuurd.
+MobilePPWarningEmailNotConfigured = Het plan is aangemaakt, maar de e-mail is niet ingesteld: ondertekeningsverzoek niet verstuurd.
+MobilePPCreated = Preventieplan %s aangemaakt.
+MobilePPUpdated = Preventieplan %s bijgewerkt.
+MobilePPSignatureEmailSubject = Verzoek tot ondertekening van het preventieplan %s
+MobilePPSignatureEmailContent = Goedendag,<br><br>U wordt uitgenodigd om het preventieplan voor %s te ondertekenen.<br><br><a href="%s">Klik hier om te ondertekenen</a><br><br>Met vriendelijke groet.
+MobilePPSuccessTitle = Preventieplan aangemaakt
+MobilePPSuccessText = De interne verantwoordelijke heeft automatisch ondertekend. Er is een ondertekeningsverzoek verstuurd naar de externe onderneming.
+MobilePPViewPlan = Het plan bekijken
+MobilePPCreateAnother = Een ander plan aanmaken
+MobileSuccessInteriorSigned = Interne verantwoordelijke: ondertekend
+MobileSuccessExteriorNotified = Externe onderneming: ondertekeningsverzoek verstuurd
+MobileSuccessExteriorNotSigned = Externe onderneming: handtekening nog te verkrijgen
+MobileSuccessExteriorNotNotified = Externe onderneming: ondertekeningsverzoek niet verstuurd
+MobileSuccessExteriorSigned = Externe onderneming: ondertekend
+MobileSuccessDocumentGenerated = Document van het plan gegenereerd
+MobilePPWarningEmailNotSentDetail = De e-mail voor de ondertekening kon niet worden verstuurd: %s
+MobilePPWarningNoRecipientEmail = geen geldig e-mailadres voor de externe verantwoordelijke
+MobilePPSignatureEmailSentTo = Ondertekeningsverzoek verstuurd naar %s
+MobilePPExtSignatureTitle = Handtekening van de externe onderneming
+MobilePPExtEmailSentOn = Verzoek verstuurd naar %s op %s
+MobilePPExtEmailNotSent = Ondertekeningsverzoek niet verstuurd: geef de link door of laat nu ondertekenen
+MobilePPSpreadDefaultsTitle = Openbare weergave van de verspreiding
+MobilePPSpreadShowCount = Het aantal ondertekenaars weergeven
+MobilePPSpreadShowName = De naam en voornaam weergeven
+MobilePPSpreadShowContact = Het telefoonnummer en het e-mailadres weergeven
+MobilePPSpreadHidePublicNote = De openbare notitie niet weergeven
+MobilePPExtAlreadySigned = Ondertekend op %s
+MobilePPExtSignNow = Nu laten ondertekenen
+MobilePPExtResendEmail = De e-mail opnieuw versturen
+MobilePPNoTagAvailable = Er is geen tag voor preventieplannen beschikbaar.
+MobilePPCreateTag = Een tag aanmaken
+MobileSpreadShareTitle = De verspreiding delen
+MobileSpreadShareText = Laat de betrokken personen deze code scannen. Zonder account en zonder inloggen vullen zij hun gegevens in, uploaden zij hun documenten en ondertekenen zij.
+MobileSpreadOpen = De verspreiding openen
+MobilePPRisks = Risico's
+MobilePPAddRisk = Een risico toevoegen
+MobilePPRiskModalTitle = Een risico kiezen
+MobilePPRiskComment = Opmerking
+MobilePPRiskDescriptionPlaceholder = Het risico op locatie beschrijven
+MobilePPNoRiskYet = Nog geen risico toegevoegd.
+MobilePPDeleteRiskTitle = Het risico verwijderen
+MobilePPDeleteRiskConfirm = «%s» wordt uit het plan verwijderd, samen met de beschrijving, de foto's en de beschermingsmiddelen.
+MobilePPUserCompany = Inlenend bedrijf
+MobilePPUserCompanyShort = EU
+MobilePPConcernedCompanies = Betreft
+MobilePPExteriorCompanyShort = EE
+MobilePPPriorFormalities = Voorafgaande formaliteiten
+MobilePPPriorVisitDone = Gezamenlijke voorinspectie uitgevoerd
+MobilePPPriorVisitTextPlaceholder = Wat tijdens de inspectie is vastgesteld
+MobileRiskCompanies = Bij de risico's betrokken bedrijven (mobiel)
+CertificationDictionary = Certificeringen en bevoegdheden
+MobilePPChooseExistingCompany = Een bestaande relatie kiezen
+MobilePPOrFillManually = of de gegevens invoeren
+MobilePPProtections = Beschermingsmiddelen
+MobilePPAddProtection = Een beschermingsmiddel toevoegen
+MobilePPProtectionModalTitle = Een beschermingsmiddel kiezen
+MobilePPMandatory = Verplicht
+MobileProtections = Beschermingsmiddelen (mobiel)
+MobilePPCertifications = Verplichte certificeringen
+MobilePPAddCertification = Een certificering toevoegen
+MobileCertifications = Certificeringen (mobiel)
+MobilePPUploadCertPhoto = Een foto versturen
+MobilePPErrorCreatingThirdparty = Fout bij het aanmaken van de relatie.
+MobilePPErrorCreatingContact = Fout bij het aanmaken van het contact.
+MobilePPErrorUpdatingPlan = Fout bij het bijwerken van het preventieplan.
+MobilePPErrorCreatingPlan = Fout bij het aanmaken van het preventieplan.
+MobileSuccessViewDocument = Het document bekijken
+MobileSuccessPlanSentByEmailOn = Preventieplan per e-mail verstuurd op %s
+MobileSuccessExteriorSignedOn = Verantwoordelijke van de Externe Onderneming (EE): Ondertekend op %s
+MobileSuccessExteriorPendingSignature = Verantwoordelijke van de Externe Onderneming (EE): In afwachting van ondertekening
+MobilePPDefaultsTitle = Standaardwaarden (mobiel aanmaken)
+MobilePPDefaultDateStartToday = Begindatum = datum van vandaag
+MobilePPDefaultDuration = Standaardduur van de periode (dagen)
+MobilePPEmailAutoSend = De e-mail voor de ondertekening automatisch versturen bij het aanmaken
+
+# Snel mobiel aanmaken van een vuurvergunning
+MobileFPPreventionPlanHelp = De externe onderneming en de periode van het geselecteerde plan worden automatisch overgenomen.
+MobileFPPeriod = Plaats en periode van de werkzaamheden
+MobileFPMaxOneMonthHint = Maximaal één maand tussen het begin en het einde van de werkzaamheden.
+MobileFPErrorMaxOneMonth = De duur mag niet langer zijn dan één maand.
+MobileFPErrorNoProject = Er is geen standaardproject voor vuurvergunningen ingesteld.
+MobileFPWorkTypes = Types werkzaamheden
+MobileFPAddWorkType = Een type werkzaamheden toevoegen
+MobileFPWorkTypeModalTitle = Een type werkzaamheden kiezen
+MobileFPSubmit = De vuurvergunning aanmaken
+MobileFPCreated = Vuurvergunning %s aangemaakt.
+MobileFPUpdated = Vuurvergunning %s bijgewerkt.
+MobileFPSignatureEmailSubject = Verzoek tot ondertekening van de vuurvergunning %s
+MobileFPSignatureEmailContent = Goedendag,<br><br>U wordt uitgenodigd om de vuurvergunning voor %s te ondertekenen.<br><br><a href="%s">Klik hier om te ondertekenen</a><br><br>Met vriendelijke groet.
+MobileFPSuccessTitle = Vuurvergunning aangemaakt
+MobileFPViewPermit = De vergunning bekijken
+MobileFPCreateAnother = Een andere vergunning aanmaken
+
+# Digirisk PWA
+PwaApplication = Mobiele app
+PwaNavHome = Start
+PwaNavPreventionPlans = Plannen
+PwaNavFirePermits = Vergunningen
+PwaNavMenu = Menu
+PwaNavFavoritesHint = Favorieten onderaan weergegeven (max. %s)
+PwaNavAddFavorite = Aan favorieten toevoegen
+PwaNavRemoveFavorite = Uit favorieten verwijderen
+PwaHello = Goedendag %s
+PwaResultCount = %s resulta(a)t(en)
+AllStatus = Alle statussen
+PwaTilePreventionPlanInProgress = Lopende plannen
+PwaTilePreventionPlanToSign = Te ondertekenen plannen
+PwaTileFirePermitInProgress = Lopende vergunningen
+PwaTileFirePermitToSign = Te ondertekenen vergunningen
+
+# Massa-acties op de taken
+MassValidateTasks = De taken valideren
+MassChangeTasksProject = Van project wisselen
+ConfirmMassValidateTasksQuestion = Weet u zeker dat u de %s geselecteerde ta(a)k(en) wilt valideren? Alleen taken met de status concept worden gevalideerd.
+ConfirmMassChangeTasksProjectQuestion = Weet u zeker dat u de %s geselecteerde ta(a)k(en) aan het gekozen project wilt koppelen?
+MassValidateTasksSuccess = %s ta(a)k(en) gevalideerd van %s geselecteerde
+MassChangeTasksProjectSuccess = %s ta(a)k(en) gekoppeld aan project %s
+
+# PDF van het preventieplan
+PreventionPlanLegalNotice = Het preventieplan is een verplicht document dat de risico's moet voorkomen die voortvloeien uit de wisselwerking tussen de activiteiten van meerdere bedrijven op dezelfde locatie, overeenkomstig artikel R4512-7 van het Franse arbeidswetboek.
+PreventionPlanUserCompany = Inlenend bedrijf - EU
+PreventionPlanExteriorCompany = Externe onderneming - EE
+PreventionPlanUserCompanyResponsible = Verantwoordelijke van het Inlenend Bedrijf (EU)
+PreventionPlanExteriorCompanyResponsible = Verantwoordelijke van de Externe Onderneming (EE)
+EmergencyNumbers = Alarmnummers
+Firefighters = Brandweer
+AnyEmergency = Elke noodsituatie
+PriorVisitIntro = Het inlenend bedrijf heeft, voorafgaand aan de uitvoering van de werkzaamheden, op %s een gezamenlijke voorinspectie uitgevoerd. Tijdens dit bezoek zijn de volgende punten door het inlenend bedrijf gepresenteerd (art. R. 4512-2 en R. 4512-3 van het Franse arbeidswetboek):
+PriorVisitCheckList = Werkplekken|Aldaar aanwezige installaties|Eventueel aan de externe ondernemingen ter beschikking gesteld materieel|Het interventiegebied van de externe ondernemingen afbakenen|De zones van dit gebied markeren die gevaren voor de werknemers kunnen opleveren|De verkeersroutes aangeven die de werknemers mogen gebruiken, evenals de voertuigen en machines van welke aard ook die toebehoren aan de externe ondernemingen|De toegangswegen van de werknemers tot de ruimten en installaties voor de EE vaststellen (met name de sanitaire voorzieningen, collectieve kleedruimten en kantines)
+PriorVisitComments = De volgende opmerkingen zijn genoteerd:
+InterventionPeriodSentence = Dit plan begint op %s en eindigt op %s. De werkzaamheden vinden plaats op de volgende tijden:
+RiskAnalysisIntro = U hebt %s werkzaamhe(i)d(en) voorzien voor dit preventieplan: hieronder de details van de geplande acties, de veroorzaakte risico's en de ingezette preventiemiddelen.
+PreventionPlanAttendants = Betrokkenen: Externe Onderneming (EE) en onderaannemers
+Morning = Ochtend
+Afternoon = Middag
+Signatures = Handtekeningen
+SignaturePending = In afwachting
+PreventionPlanRiskPhotos = Foto's van het risico
+InterventionPeriodOnly = Dit plan begint op %s en eindigt op %s.
+
+DigiRisk=DigiRisk
+DigiriskIdentification=BESCHRIJVING EN KENMERKEN
+DigiriskSecurity=VEILIGHEID
+DigiriskUserManual=VEREENVOUDIGDE GEBRUIKSAANWIJZING
+DigiriskQualification=KWALIFICATIE EN BEVOEGDHEID
+DigiriskHygiene=HYGIËNE EN REINIGING
+DigiriskMaintenance=ONDERHOUD EN CONTROLES
+DangerCategory=Risicofamilie
+SelectDangerCategory=Een risicofamilie kiezen
+DescribeRiskOnProduct=Het risico bij dit product beschrijven...
+ConfirmDeleteProductRisk=Dit risico verwijderen?
+AddProductRisk=Een productrisico toevoegen
+ClickToAddContent=Klik om inhoud toe te voegen...
+AddProtection=Een beschermingsmiddel toevoegen
+
+SelectProtection=Een PBM-beschermingsmiddel kiezen
+TechnicalSheet=Technische fiche
+DigiriskRisks=RISICO'S EN BESCHERMINGSMIDDELEN
+MobileSuccessInteriorSignedOn=Verantwoordelijke van het Inlenend Bedrijf (EU): Ondertekend op %s
+
+MobileSuccessPlanSentByEmailOn = Preventieplan per e-mail verstuurd op %s
+MobileSuccessExteriorSignedOn = Verantwoordelijke van de Externe Onderneming (EE): Ondertekend op %s
+MobileSuccessExteriorPendingSignature = Verantwoordelijke van de Externe Onderneming (EE): In afwachting van ondertekening
+
+MobilePPErrorInvalidEmail = Houd u aan het formaat van het e-mailadres.
+MobilePPErrorInvalidPhone = Houd u aan het formaat van het telefoonnummer.
+MobilePPExtSendEmail = De e-mail versturen
+MobilePPErrorMailServerNotConfigured = Uw mailserver is niet ingesteld, neem contact op met de beheerder.
+MobilePPDoliletterNotInstalled = De module Doliletter is niet geïnstalleerd. De verspreiding van de preventieplannen en vuurvergunningen is niet beschikbaar (neem contact op met uw beheerder)
+
+# Statussen en types voor de tooltips
+preventionplan = Preventieplan
+Locked = Vergrendeld
+InProgress = Lopend
+ValidatePendingSignature = In afwachting van ondertekening
+Archived = Gearchiveerd
+
+ProductFIChaptersManagement=Aanpassing van de hoofdstukken van de instructiefiche
+ProductFIChaptersManagementSub=Aanpassing van het tabblad "Instructiefiche" en het tabblad "Risico's" in de productfiche
+DefaultContent=Standaardinhoud
+CustomSvgUploaded=Aangepaste SVG
+DeleteCustomSvg=Verwijderen
+DefaultSvgUsed=Standaard-SVG
+
+PwaTilePreventionPlanLocked = Gevalideerde plannen
+PwaTileFirePermitLocked = Gevalideerde vergunningen
+
+# ===========================================================================
+# Woordenboek van de Kanban-kolommen van het actieplan — issue #5017
+# ===========================================================================
+ActionPlanColumnDictionary           = Kolommen van het Kanban van het actieplan
+ActionPlanColumnDictionaryDesc       = Kolommen die worden weergegeven in het Kanban van het PAPRIPACT wanneer de woordenboekmodus is geactiveerd: naam, voortgangsbereik, kleur en pictogram
+KanbanColumnSource                   = Bron van de kolommen
+KanbanColumnSourceDesc               = Het Kanban indelen met de onderstaande percentagedrempels (historische werking) of met het woordenboek van de kolommen
+KanbanColumnSourceThresholds         = Percentagedrempels (standaard)
+KanbanColumnSourceDictionary         = Woordenboek van de kolommen
+ActionPlanColumnProgressHelp         = Voortgangsgrenzen die door de kolom worden gedekt, van 0 tot 100
+ActionPlanColumnColorHelp            = Hexadecimale kleur van de kolom, bijvoorbeeld #3085d6
+ActionPlanColumnPictoHelp            = Naam van het Font Awesome-pictogram, bijvoorbeeld fa-check
+Progress_min                         = Voortgang min.
+Progress_max                         = Voortgang max.
+Picto                                = Pictogram
+
+# Registratie van de bestede tijd
+GenerateTimeSpentReport = De tijdregistratie genereren (PDF)
+TimeSpentReport = Registratie van de bestede tijd
+TimeSpentReportUsersHelp = Laat leeg om alle personen op te nemen die tijd op dit project hebben geboekt.
+TimeSpentReportSummary = Samenvatting per gebruiker
+TimeSpentReportGrandTotal = Eindtotaal
+TimeSpentReportGeneratedAt = Gegenereerd op
+TimeSpentReportWholePeriod = Sinds het begin van het project
+TimeSpentReportNoData = Geen bestede tijd komt overeen met de geselecteerde gebruikers en periode.
+TimeSpentDocumentPDFDescription = Bestede tijd op een project, gegroepeerd per gebruiker
+
+# Gelijkschakeling van de mobiele vuurvergunning met het preventieplan - issue #5042
+MobileProgress = Voortgang
+MobileStepDone = GEDAAN
+MobileStepInProgress = LOPEND
+MobileStepTodo = TE DOEN
+MobileStepSignedOn = ONDERTEKEND OP
+MobilePPStepCreated = PP aangemaakt
+MobileFPStepCreated = VV aangemaakt
+MobileStepUserCompanyResponsible = Verantw. EU
+MobileStepExteriorCompanyResponsible = Verantw. EE
+MobileStepLock = Vergrendelen
+MobileStepArchive = Archiveren
+MobileLock = Vergrendelen
+MobileResponsibleShort = Verantw.
+MobileMailSentTo = E-mail verstuurd naar
+MobilePPMotif = Reden van de werkzaamheden
+MobilePPSchedules = Werktijden
+MobilePPConfigHours = Stel hier uw werktijden in
+MobilePPCopyCompanyHours = De werktijden van het bedrijf kopiëren
+FirePermitUserCompany = Inlenend bedrijf - EU
+FirePermitExteriorCompany = Externe onderneming - EE
+MobileFPMotif = Reden van de werkzaamheden
+MobileFPMotifPlaceholder = Bijv.: lassen aan de dakconstructie
+MobileFPNoMotif = Geen reden ingevuld
+MobileFPSchedules = Werktijden van de werkzaamheden
+MobileFPWorkTypeDescriptionPlaceholder = De werkzaamheden op locatie beschrijven
+MobileFPNoWorkTypeYet = Nog geen type werkzaamheden toegevoegd.
+MobileFPDeleteWorkTypeTitle = Het type werkzaamheden verwijderen
+MobileFPDeleteWorkTypeConfirm = «%s» wordt uit de vergunning verwijderd, samen met de beschrijving, het materieel, de foto's en de beschermingsmiddelen.
+MobileFPNoTagAvailable = Er is geen tag voor vuurvergunningen beschikbaar.
+MobileFPErrorUpdatingPermit = Fout bij het bijwerken van de vuurvergunning.
+MobileFPErrorCreatingPermit = Fout bij het aanmaken van de vuurvergunning.
+MobileFPLockNeedsSignature = De vergunning moet ondertekend zijn voordat deze kan worden vergrendeld.
+MobileFPSpreadAvailableOnceSignedAndLocked = De verspreiding is beschikbaar zodra de vergunning door de verantwoordelijken is ondertekend en vergrendeld.
+MobileFPDefaultDateStartToday = Begindatum = datum van vandaag
+MobileFPDefaultDuration = Standaardduur van de periode (dagen)
+firepermit = Vuurvergunning
+ErrorRecordIsLocked = Deze registratie is vergrendeld en kan niet meer worden gewijzigd.
+MobilePPEmailTemplateExt = E-mailsjabloon voor de verantwoordelijke van de externe onderneming
+MobilePPEmailTemplateInt = E-mailsjabloon voor de medewerkers van de externe onderneming
+
+#
+# ListingRisksDocument PDF - Risicolijst in PDF-formaat
+#
+
+ListingRisksDocumentPDF            = Risicolijst PDF
+ListingRisksDocumentPDFDescription = Risicolijst als native PDF, geopend op de mini risico-inventarisatie van het element
+ListingRisksDocumentPDFTitle       = RISICO-INVENTARISATIE
+ListingRisksEstablishment          = Vestiging
+ListingRisksCoverContent           = Inhoud
+ListingRisksCoverHierarchy         = Hiërarchie
+ListingRisksCoverDuerpFollowUp     = Opvolging van de risico-inventarisatie
+ListingRisksCoverEmergencyNumbers  = Alarmnummers
+ListingRisksCoverReportIncident    = Een ongeval of een probleem melden
+ListingRisksCoverRegisters         = Registers arbeidsveiligheid en -gezondheid en ernstig en onmiddellijk gevaar
+ListingRisksCoverIllustration      = Illustratieafbeelding
+NoPreventionOfficerAssigned        = Geen preventiemedewerker aangewezen
+NoEmergencyNumberConfigured        = Geen alarmnummer ingesteld
+NoResponsibleAssigned              = Geen verantwoordelijke aangewezen
+ListingRisksLegalTitle             = Regelgevend kader
+RiskDefinitionTitle                = Definitie van een risico
+RiskDefinitionText                 = Risico: zn. Gevaar of nadeel waaraan men zich blootstelt. Iets op eigen risico doen, waarbij men de volledige verantwoordelijkheid voor de gevolgen draagt. Een berekend risico. Risico's nemen: zich aan een gevaar blootstellen.
+DangerDefinitionTitle              = Definitie van een gevaar
+DangerDefinitionText               = Gevaar: zn. (uit het volkslatijn dominiarium "macht", van dominus "meester"; oorspronkelijk het feit dat men aan iemand is overgeleverd). Wat de veiligheid of het leven van iemand bedreigt; wat een situatie, een onderneming enz. in gevaar kan brengen.
+SingleDocumentTitle                = De risico-inventarisatie
+SingleDocumentText                 = De risico-inventarisatie wordt geregeld door de artikelen R4121-1 tot en met 4 van het Franse arbeidswetboek. De algemene preventiebeginselen bepalen de volgorde waarin het risico wordt aangepakt.
+PreventionPrinciplesTitle          = De algemene preventiebeginselen - Artikel L4121-2
+PreventionPrinciplesIntro          = De werkgever voert de in artikel L. 4121-1 bedoelde maatregelen uit op basis van de volgende algemene preventiebeginselen:
+PreventionPrinciple1               = Risico's vermijden.
+PreventionPrinciple2               = De risico's beoordelen die niet kunnen worden vermeden.
+PreventionPrinciple3               = Risico's bij de bron bestrijden.
+PreventionPrinciple4               = Het werk aan de mens aanpassen, met name wat betreft het ontwerp van de werkplekken en de keuze van de arbeidsmiddelen en de werk- en productiemethoden, in het bijzonder om eentonig werk en tempogebonden werk te beperken en de gevolgen daarvan voor de gezondheid te verminderen.
+PreventionPrinciple5               = Rekening houden met de stand van de techniek.
+PreventionPrinciple6               = Vervangen wat gevaarlijk is door wat niet of minder gevaarlijk is.
+PreventionPrinciple7               = De preventie plannen door techniek, arbeidsorganisatie, arbeidsomstandigheden, sociale verhoudingen en de invloed van omgevingsfactoren tot een samenhangend geheel te verbinden, met name de risico's verbonden aan pesten en seksuele intimidatie, alsook die verbonden aan seksistisch gedrag.
+PreventionPrinciple8               = Collectieve beschermingsmaatregelen treffen en daaraan voorrang geven boven individuele beschermingsmaatregelen.
+PreventionPrinciple9               = De werknemers passende instructies geven.
+ListingRisksCotationMethodTitle    = Berekeningsmethode van de scores
+ListingRisksCotationMethodText     = De score van een risico is een cijfer van 0 tot 100 dat bij de beoordeling wordt toegekend. Het risiconiveau in de lijst volgt daar rechtstreeks uit, volgens onderstaande tabel.
+ListingRisksCotationLevel          = Niveau
+ListingRisksCotationRange          = Score
+ListingRisksCotationMeaning        = Betekenis
+ListingRisksCotationAction         = Te volgen handelwijze
+ListingRisksCotationAction1        = De aanwezige preventiemiddelen in stand houden.
+ListingRisksCotationAction2        = Een actie opnemen in het jaarlijkse preventieprogramma.
+ListingRisksCotationAction3        = Op korte termijn een preventieactie starten.
+ListingRisksCotationAction4        = Onmiddellijk handelen, de blootstelling moet stoppen.
+ListingRisksListTitle              = Lijst van risico's
+ListingRisksActionPlan             = Acties van het jaarlijkse preventieprogramma
+ListingRisksCotationColumn         = Sc.
+ListingRisksRiskColumn             = Risico
+ListingRisksAssessmentColumn       = Informatie over de beoordeling
+NoRiskAssessed                     = Geen risico beoordeeld binnen dit bereik

--- a/langs/nl_NL/index.php
+++ b/langs/nl_NL/index.php
@@ -1,0 +1,2 @@
+<?php
+//Silence is golden

--- a/langs/pl_PL/digiriskdolibarr.lang
+++ b/langs/pl_PL/digiriskdolibarr.lang
@@ -1,0 +1,2387 @@
+# Copyright (C) 2021-2023 EVARISK <technique@evarisk.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#
+# Ogólne
+#
+
+# Module label 'ModuleDigiriskdolibarrName'
+ModuleDigiriskdolibarrName = Digirisk
+
+# Module description 'ModuleDigiriskdolibarrDesc'
+ModuleDigiriskdolibarrDesc = Digirisk dla Dolibarr
+
+# Brak modułu Saturne
+SaturneModuleMissing = Moduł Saturne jest wymagany przez Digirisk. Pobierz go bezpłatnie z Dolistore (https://dolistore.com/en/modules/1906-Saturne.html) i zainstaluj przed aktywacją Digirisk.
+
+# Kolumna obrazów samouczka na stronach konfiguracji
+TutoImage = Obraz
+
+#
+# Strona administracyjna
+#
+
+# Dane
+DigiriskdolibarrSetup       = Konfiguracja modułu Digirisk
+DigiriskdolibarrSetupPage        = Strona konfiguracji modułu Digirisk
+AgendaModuleRequired        = Aby zapewnić identyfikowalność działań w Digirisk, upewnij się, że moduł Kalendarz jest włączony
+DigiriskDolibarrDescription = Digirisk dla Dolibarr
+HowToSetupOtherModules      = Aby uzyskać więcej funkcji w Digirisk, możesz włączyć wiele modułów (zarządzanie dostawcami, fakturami itp.) pod tym linkiem:
+ConfigMyModules             = Konfiguracja modułów
+AvoidLogoProblems              = Aby uniknąć problemów z logotypami w generowanych dokumentach, zapoznaj się z tymi wskazówkami konfiguracyjnymi:
+LogoHelpLink                = https://wiki.dolibarr.org/index.php?title=Premiers_paramétrages
+SecurityConfiguration       = Konfiguracja danych dotyczących bezpieczeństwa
+SocialConfiguration          = Konfiguracja danych socjalnych
+Uncompleted                     = Nieuzupełnione
+DigiriskData                 = Konfigurowalne dane Digirisk
+DigiriskManagement          = Przekierowanie po zalogowaniu
+DigiriskDescription          = Domyślne przekierowanie na stronę powitalną Digirisk zamiast na stronę Dolibarr.
+HowToSetupIHM                   = Aby uzyskać więcej możliwości wyświetlania Dolibarr (konfiguracja obrazu tła itp.), przejdź pod ten link:
+ConfigIHM                    = Konfiguracja wyświetlania
+ConfigDico                     = Przejdź do strony konfiguracji słowników
+LinkedProject               = Powiązany projekt
+DigiriskUpdate                  = Aktualizacja Digirisk:
+Security                       = Bezpieczeństwo
+HowToSharedElement          = Aby uzyskać więcej informacji o konfiguracji elementów współdzielonych, przejdź pod ten link:
+
+HowToSharedElementLink        = https://wiki.dolibarr.org/index.php?title=Module_Digirisk#Configuration
+ConfigSharedElement         = Konfiguracja elementów współdzielonych (ryzyka/oznakowania)
+DisabledSharedElement       = Opcja wyłączona, ponieważ Multi-company nie jest włączone lub nie przeprowadzono konfiguracji elementów współdzielonych (ryzyka/oznakowania)
+DigiriskEventAutoDesc       = Określ tutaj zdarzenia, dla których Digirisk automatycznie utworzy wpis w kalendarzu. Każde zdarzenie zawiera informacje o wykonanej czynności.
+DigiriskActionsEvents       = Zdarzenia, dla których Digirisk ma automatycznie wstawiać wpis do kalendarza.
+DigiriskDolibarr            = Digirisk
+Create                      = Utwórz
+
+# Ticket
+MultiCompanyTicketPublicInterfaceConfig = Konfiguracja publicznego interfejsu zgłoszeń dla wielu firm
+Subtitle                                = Podtytuł
+
+# DigiriskElement
+DigiriskElementDepthGraph            = Poziom szczegółowości na wykresach elementów Digirisk
+DigiriskElementDepthGraphDescription = Ta opcja pozwala wybrać poziom szczegółowości na wykresach elementów Digirisk <br> Domyślnie: poziom 1
+
+# WHSRegister = Rejestr BHP
+TicketsPublicInterfaceConfig         = Konfiguracja publicznego interfejsu zgłoszeń
+WHSRegister                          = Rejestr BHP
+CurrentTicketPublicInterfaceURL      = Adres URL publicznego interfejsu zgłoszeń
+MulticompanyTicketPublicInterfaceURL = Adres URL publicznego interfejsu zgłoszeń dla wielu firm
+OriginURL                            = Adres URL źródłowy
+ShortURL                             = Skrócony adres URL
+ExternalURL                          = Zewnętrzny adres URL
+AddExtraField                        = Utwórz pole dodatkowe
+IfEmptyVisibleAllCategories          = Jeśli puste, widoczne we wszystkich kategoriach
+
+# DigiQuali Sheet - Szablony
+LinkDigiriskdolibarr_digiriskstandard                 = Włącz powiązanie z jednostkami głównymi Digirisk Standard
+LinkDigiriskdolibarr_digiriskstandardDescription      = Umożliwia powiązanie jednostek standardowych Digirisk z szablonami
+LinkDigiriskdolibarr_digiriskelement                  = Włącz powiązanie ze zgrupowaniami i jednostkami pracy
+LinkDigiriskdolibarr_digiriskelementDescription       = Umożliwia powiązanie zgrupowań i jednostek pracy z szablonami
+LinkDigiriskdolibarr_risk                             = Włącz powiązanie z ryzykami
+LinkDigiriskdolibarr_riskDescription                  = Umożliwia powiązanie ryzyk z szablonami
+LinkDigiriskdolibarr_riskassessment                   = Włącz powiązanie z ocenami
+LinkDigiriskdolibarr_riskassessmentDescription        = Umożliwia powiązanie ocen z szablonami
+LinkDigiriskdolibarr_evaluator                        = Włącz powiązanie z oceniającymi
+LinkDigiriskdolibarr_evaluatorDescription             = Umożliwia powiązanie oceniających z szablonami
+LinkDigiriskdolibarr_risksign                         = Włącz powiązanie z oznakowaniami
+LinkDigiriskdolibarr_risksignDescription              = Umożliwia powiązanie oznakowań z szablonami
+LinkDigiriskdolibarr_preventionplan                   = Włącz powiązanie z planami prewencji
+LinkDigiriskdolibarr_preventionplanDescription        = Umożliwia powiązanie planów prewencji z szablonami
+LinkDigiriskdolibarr_firepermit                       = Włącz powiązanie z zezwoleniami na prace pożarowe
+LinkDigiriskdolibarr_firepermitDescription            = Umożliwia powiązanie zezwoleń na prace pożarowe z szablonami
+LinkDigiriskdolibarr_accident                         = Włącz powiązanie z wypadkami
+LinkDigiriskdolibarr_accidentDescription              = Umożliwia powiązanie wypadków z szablonami
+LinkDigiriskdolibarr_accidentinvestigation            = Włącz powiązanie z dochodzeniami powypadkowymi
+LinkDigiriskdolibarr_accidentinvestigationDescription = Umożliwia powiązanie dochodzeń z szablonami
+
+#
+# DigiriskDolibarr
+#
+
+# Uprawnienie
+LireDigirisk                 = Przeglądanie pulpitu Digirisk
+ReadDigirisk                 = Przeglądanie pulpitu Digirisk (odczyt)
+YouDontHaveTheRightToSeeThis = Nie masz uprawnień do przeglądania zgrupowań i jednostek pracy
+CanNotDoThis                 = Nie masz uprawnień do wykonania tej czynności
+EnableDigiriskdolibarr       = Włącz moduł DigiriskDolibarr, aby uzyskać dostęp do tej strony
+
+# Dane
+DigiriskMenu          = Dodaj informacje o swojej firmie/organizacji. Kliknij przycisk "Zapisz" na dole strony, aby je zachować
+DigiriskConfigSociety = Konfiguracja firmy
+PermissionDenied      = Odmowa dostępu
+AddUser               = Utwórz użytkownika
+StartDate             = Data początkowa
+EndDate               = Data końcowa
+NoPhoneNumber         = Brak numeru telefonu
+HasBeenCreatedF       = została utworzona
+HasBeenCreatedM       = został utworzony
+HasNotBeenCreatedF    = nie została utworzona
+HasNotBeenCreatedM    = nie został utworzony
+YourDocuments         = Dokumenty
+NoData                = Nd.
+HasBeenEditedF        = została zmodyfikowana
+HasBeenEditedM        = został zmodyfikowany
+HasNotBeenEditedF     = nie została zmodyfikowana
+HasNotBeenEditedM     = nie został zmodyfikowany
+
+HasBeenDeletedF    = została usunięta
+HasBeenDeletedM    = został usunięty
+HasNotBeenDeletedF = nie została usunięta
+HasNotBeenDeletedM = nie został usunięty
+
+DigiriskUserGroup                 = Digirisk - Użytkownicy
+DigiriskUserGroupDescription      = Grupa użytkowników DigiRisk ma uprawnienia do przeglądania i modyfikowania obiektów związanych z DigiRisk
+DigiriskAdminUserGroup            = DigiRisk - Administratorzy
+DigiriskAdminUserGroupDescription = Grupa administratorów ma wszystkie uprawnienia do DigiRisk i wymaganych modułów
+DigiriskReaderGroup               = DigiRisk - Czytelnicy
+DigiriskReaderGroupDescription    = Grupa czytelników ma wszystkie uprawnienia tylko do odczytu w DigiRisk i wymaganych modułach
+
+ContractType              = Rodzaj umowy
+Apprentice/Student        = Uczeń/Student
+Interim                   = Pracownik tymczasowy
+ProfessionalQualification = Kwalifikacje zawodowe
+DigiriskDocumentation     = Dokumentacja Digirisk
+
+SelectUser               = Wybierz użytkownika
+LabourInspectorFirstName = Inspektor
+LabourInspectorLastName  = pracy
+LabourInspector          = Inspektor pracy
+LabourInspectorSociety   = Kontrahent Inspektor pracy
+LabourInspectorAssigned  = Inspektor pracy
+
+SocieteSchedules = Godziny pracy firmy
+weekDayDefault   = Zobacz stronę internetową
+weekEndDefault   = Zamknięte Zamknięte
+
+#
+# DigriskDocuments - Dokumenty Digirisk
+#
+
+# Dane
+DigiriskDocuments              = Dokument Digirisk
+Responsible                    = Osoba odpowiedzialna
+ContactsAction                 = Kontakty działania
+PERCOTooltip                   = Jeśli Twoja firma posiada zbiorowy plan oszczędnościowy (PERCO), zaznacz to pole
+PEETooltip                     = Jeśli Twoja firma posiada pracowniczy plan oszczędnościowy (PEE), zaznacz to pole
+ShowPictoName                  = Pokaż nazwę piktogramu zagrożenia
+ShowPictoNameDescription       = Pokaż nazwę piktogramu zagrożenia ryzyka w dokumentach <br> Przydatne, jeśli chcesz przenieść tabelę do arkusza kalkulacyjnego
+RiskAssessmentColor            = Kolor ocen
+RiskAssessmentColorDescription = Wyświetla kolor ocen w dokumencie Papripact-A3-Poziomy
+
+#
+# LegalDisplay - Informacja ustawowa
+#
+
+# Uprawnienie
+LegalDisplaysMin = Informacje ustawowe
+
+# Dane
+LegalDisplay             = Informacja ustawowa
+Legaldisplay             = Informacja ustawowa
+HowToSetDataLegalDisplay = Aby skonfigurować dane informacji ustawowej, przejdź do Start - Konfiguracja - Firma/Organizacja - Bezpieczeństwo
+
+LegalDisplayDocumentGenerated       = Generowanie informacji ustawowej
+LabourDoctor                        = Lekarz medycyny pracy
+LabourInspector                     = Inspektor pracy
+FireBrigade                         = Straż pożarna
+AllEmergencies                      = Wszelkie zagrożenia
+RightsDefender                      = Rzecznik Praw Obywatelskich
+PoisonControlCenter                 = Centrum Toksykologii
+Police                              = Policja
+SafetyInstructions                  = Instrukcje bezpieczeństwa
+ResponsibleToNotify                 = Osoba odpowiedzialna do powiadomienia
+PreventionOfficers                  = Osoby odpowiedzialne za prewencję
+PreventionOfficer                   = Osoba odpowiedzialna za prewencję
+LocationOfDetailedInstructions      = Lokalizacja szczegółowej instrukcji
+LocationOfDetailedInstructionsValue = Brak szczegółowej instrukcji w tej lokalizacji
+FirstAid                            = Pierwsza pomoc
+FirstAidValue                       = <h2>Lista ratowników przedmedycznych obecnych na terenie zakładu (Nazwisko, Firma, Telefon)</h2><br><br>Każdy zespół musi być tak zorganizowany, aby w każdych okolicznościach można było udzielić pierwszej pomocy dowolnemu członkowi zespołu.<br />Ratownicy przedmedyczni muszą być wyraźnie oznaczeni i znani wszystkim.<h2>Postępowanie w razie wypadku</h2><br><br><h3>Lekki wypadek</h3><br><ul><li> - Pomoc udzielana przez ratowników przedmedycznych</li><br><li> - Obecność apteczki pierwszej pomocy</li></ul><br><br>Każda maszyna jest wyposażona w co najmniej jedną apteczkę umożliwiającą opatrzenie lekkich ran.<br><br><h3>Poważny wypadek</h3><br><ul><li> - Powiadomić ratownika obecnego na terenie zakładu</li><br><li> - Uruchomić procedurę awaryjną</li><br><li> - Poinformować osobę odpowiedzialną przedsiębiorstwa użytkującego, dyżur ruchowy całodobowy</li><br><li> - Skontaktować się w razie wypadku</li></ul><br><br>Przedsiębiorstwo użytkujące podaje w załączniku numery alarmowe. <br />
+AddPhoneNumber                      = Dodaj numer telefonu do użytkownika
+ConfigureLabourInspector            = Skonfiguruj inspektora pracy
+SocietyAdditionalDetails            = Informacje uzupełniające o firmie
+GeneralMeansAtDisposal              = Udostępnione środki ogólne
+GeneralMeansAtDisposalValue         = <h2>Udostępnione środki ratunkowe</h2><br><ul><li> - Punkt opatrunkowy</li><br><li> - Nasi ratownicy przedmedyczni są oznaczeni na kaskach i odzieży roboczej odznaką ratownika</li><br><li> - Apteczki na wypadek lekkich urazów dostępne w każdej lokalizacji</li></ul><br><br><h2>Instrukcje na wypadek lekkiego wypadku</h2><br><ul><li> - Skontaktować się z najbliższym ratownikiem</li><br><li> - Opatrzenie z użyciem udostępnionej apteczki</li><br><li> - Zgłoszenie na terenie zakładu:</li></ul><br><br><h2>Instrukcje na wypadek wypadku</h2><br><ul><li> - Straż pożarna: 18</li><br><li> - Pogotowie ratunkowe: 15</li><br><li> - Policja i żandarmeria: 17</li><br><li> - Europejski numer alarmowy: 112</li></ul><br><br><h2>Instrukcje na wypadek pożaru</h2><br>W razie pożaru postępuj w następującej kolejności:<br><ol><li> - Uruchom sygnał alarmowy.</li><br><li> - Zwalczaj ogień (jeśli nie jest zbyt duży) za pomocą gaśnicy.</li><br><li> - Jeśli ogień nie został ugaszony po użyciu jednej gaśnicy lub jest już zbyt duży, powiadom straż pożarną.</li><br><li> - Zamknij drzwi i okna przed opuszczeniem pomieszczeń.</li><br><li> - Poproś o pomoc przeszkolone zespoły.</li><br></ol>
+GeneralInstructions                 = Instrukcje ogólne
+GeneralInstructionsValue            = <h2>Wszystkie instalacje</h2><br><br><p>Surowo zabrania się palenia, rozniecania ognia oraz używania otwartego płomienia w obrębie instalacji i na nich.<br />Jeśli prace wymagają użycia otwartego płomienia (prace spawalnicze itp.), bezwzględnie należy wystawić zezwolenie na prace pożarowe (patrz przykład w załączniku 9.5).<br />Zasadniczo dostęp do instalacji jest zabroniony dla osób nieupoważnionych.<br />Każdy wykonawca musi posiadać przy sobie swoje uprawnienia i zaświadczenia o szkoleniu. Musi móc je okazać na terenie zakładu na żądanie przedsiębiorstwa użytkującego.</p><br><br><h2>Uprawnienia</h2><br>Każda osoba wykonująca prace musi dysponować kopią następujących uprawnień:<br><ul><li> - Uprawnienia elektryczne odpowiednie do wykonywanych prac</li><br><li> - Zaświadczenie o szkoleniu lub uprawnienia do prac na wysokości i ratownictwa wysokościowego</li></ul><br>Oraz móc je przedstawić na zwykłe żądanie przedsiębiorstwa użytkującego, kierownika prac lub dowolnego inspektora<br><br><h2>Środki ochrony indywidualnej</h2><br>Każda osoba wykonująca prace musi móc dysponować następującymi środkami ochrony indywidualnej, w zależności od rodzaju wykonywanych prac i środków ochrony określonych w analizie ryzyka.<br><br><h3>Prace różne</h3><br><ul><li> - Hełm przeznaczony do prac na wysokości (EN397) z paskiem podbródkowym i/lub spełniający wymagania izolacji elektrycznej (środowisko elektryczne)</li><br><li> - Obuwie ochronne</li><br><li> - Ochronniki słuchu, w razie potrzeby</li><br><li> - Inne (do określenia): w zależności od wykonywanych prac i związanych z nimi ryzyk.</li></ul><br><br><h3>Prace elektryczne</h3><br><ul><li> - Mata lub taboret izolacyjny</li><br><li> - Rękawice dostosowane do zakresu napięcia</li><br><li> - Hełmy do prac elektrycznych z osłoną twarzy (EN166)</li><br><li> - Wymagane ŚOI do prac przy średnim napięciu (UTE C 18-510)</li></ul><br><br><h3>Inne</h3><br>Uwaga: przedsiębiorstwa zewnętrzne muszą zapewnić swoim pracownikom wymienione wyżej ŚOI. Taboret i drążek ratowniczy znajdują się w stacjach transformatorowych.<br><br><h3>Prace na wysokości</h3><br><ul><li> - Wymagane ŚOI (szelki bezpieczeństwa, hełm, 2 linki z amortyzatorem lub podwójna linka Y, karabińczyki, urządzenie samohamowne itp.) z aktualnym przeglądem</li><br><li> - System automatycznej ewakuacji:</li><br><li> - Liczba: 1 zestaw ewakuacyjny (przewidziany dla 2 osób)</li><li>Lokalizacja: w koszu podnośnika</li><br><li> - Pamiętaj o dodatkowym zestawie ewakuacyjnym, jeśli w koszu znajdują się więcej niż dwie osoby</li><br><li> - Inne (do określenia): zastosowane urządzenie samohamowne: HACA o numerze referencyjnym 0529 7103 (zaczep mostkowy na szelkach)</li></ul><br><br>Urządzenia samohamowne muszą być zgodne ze sztywnym systemem asekuracji, w który wyposażone są maszyny. Urządzenia samohamowne muszą być zgodne z najnowszą normą i pomyślnie przejść badania uzupełniające (dodatkowe testy CNB/P/11.073 z 13.10.2010), które stały się obowiązkowe na mocy opinii francuskiego Ministerstwa Pracy z 28 września 2010 r., w celu zapewnienia zgodności z wymaganiami dyrektywy 89/686/EWG.
+RulesOfProcedure                    = Regulamin pracy
+RulesOfProcedureValue               = Dostępny na obowiązkowej tablicy informacyjnej w pomieszczeniu socjalnym
+CollectiveAgreement                 = Układy zbiorowe pracy
+CollectiveAgreementValue            = Dostępne na stronie rządowej:<br /><a href="https://www.service-public.fr/particuliers/vosdroits/F78" target="_blank">https://www.service-public.fr/particuliers/vosdroits/F78</a>
+legaldisplay.odt                    = Informacja ustawowa
+legaldisplay_custom.odt             = Niestandardowa informacja ustawowa
+
+#
+# InformationsSharing - Rozpowszechnianie informacji
+#
+
+# Uprawnienie
+InformationsSharingsMin = Rozpowszechnianie informacji
+
+# Dane
+InformationsSharing                  = Rozpowszechnianie informacji
+Informationssharing                  = Rozpowszechnianie informacji
+InformationsSharingDocumentGenerated = Generowanie rozpowszechniania informacji
+HowToSetDataInformationsSharing      = Aby skonfigurować dane rozpowszechniania informacji, przejdź do Start - Konfiguracja - Firma/Organizacja - Sprawy socjalne
+ConfigureSecurityAndSocialData       = Skonfiguruj dane firmy
+LastMainDoc                          = Ostatnio wygenerowany dokument
+
+ParticipationAgreement      = Umowy o udziale w zyskach
+ParticipationAgreementValue = Tak, wszyscy pracownicy posiadający obowiązującą umowę o pracę na czas nieokreślony lub określony z przedsiębiorstwem, niezależnie od jej rodzaju, mogą korzystać z udziału w zyskach.<br />Wymagany jest jednak warunek stażu pracy: 6 miesięcy w przedsiębiorstwie.<br />Przy ustalaniu wymaganego stażu uwzględnia się wszystkie umowy o pracę wykonane w okresie obliczeniowym oraz w ciągu poprzedzających go 12 miesięcy.<br />Staż pracy ocenia się na dzień zamknięcia danego roku obrotowego lub na dzień odejścia w przypadku rozwiązania umowy w trakcie roku obrotowego.
+TermsAndConditions          = Zasady
+
+ESC                  = Rada Społeczno-Ekonomiczna
+StaffRepresentatives = Przedstawiciele pracowników
+ElectionDate         = Data wyborów
+ElectionDateCSE      = Data wyborów Rady Społeczno-Ekonomicznej
+ElectionDateDP       = Data wyborów przedstawicieli pracowników
+
+Titulars                       = Członkowie
+Alternates                     = Zastępcy
+informationssharing.odt        = Rozpowszechnianie informacji
+informationssharing_custom.odt = Niestandardowe rozpowszechnianie informacji
+ActionOnUser                   = Użytkownik, którego dotyczy
+HarassmentOfficer              = Osoba odpowiedzialna ds. mobbingu
+HarassmentOfficerCSE           = Osoba odpowiedzialna ds. mobbingu w Radzie Społeczno-Ekonomicznej
+ExceptionsToWorkingHours       = Odstępstwa od czasu pracy
+PermanentDerogation            = Odstępstwo stałe
+PermanentDerogationValue       = Nie
+OccasionalDerogation           = Odstępstwo okazjonalne
+OccasionalDerogationValue      = Tak
+
+
+#
+# PreventionPlan - Plan prewencji
+#
+
+# Uprawnienie
+PreventionPlansMin = plany prewencji
+
+# Dane
+
+PreventionPlan                                        = Plan prewencji
+Preventionplan                                        = Plan prewencji
+ThePreventionplan                                     = plan prewencji
+PreventionPlanDocument                                = Plan prewencji
+Preventionplandocument                                = Plan prewencji
+PreventionPlanDocumentGenerated                       = Generowanie planu prewencji
+PreventionPlanList                                    = Lista planów prewencji
+PreventionPlanLine                                    = ryzyko(a)
+PreventionPlanLineCreated                             = Utworzenie ryzyka w planie prewencji
+PreventionPlanLineModified                            = Modyfikacja ryzyka w planie prewencji
+PreventionPlanLineDeleted                             = Usunięcie ryzyka z planu prewencji
+NewPreventionPlan                                     = Nowy plan prewencji
+PriorVisit                                            = Wspólna kontrola wstępna
+PriorVisitYesNo                                       = Wizyta wstępna przeprowadzona
+PriorVisitText                                        = Notatka z kontroli
+CSSCTIntervention                                     = Udział CSSCT
+CSSCTInterventionText                                 = Udział CSSCT?
+MasterWorker                                          = Osoba odpowiedzialna przedsiębiorstwa użytkującego
+MasterWorker                                          = Osoba odpowiedzialna przedsiębiorstwa użytkującego
+ExtSociety                                            = Przedsiębiorstwo zewnętrzne
+ExtSocietyResponsible                                 = Osoba odpowiedzialna przedsiębiorstwa zewnętrznego
+ExtSocietyResponsible                                 = Osoba odpowiedzialna przedsiębiorstwa zewnętrznego
+ExtSocietyAttendant                                   = Pracownik przedsiębiorstwa zewnętrznego
+ActionsDescription                                    = Opis czynności
+INRSRisk                                              = Ryzyko (INRS)
+PreventionMethod                                      = Środki prewencji
+PreventionplanSchedules                               = Godziny planu prewencji
+Attendants                                            = Uczestnicy
+ModifyPreventionPlan                                  = Zmodyfikuj plan prewencji
+ActionsDescriptionTooltip                             = Opis czynności wykonywanych przez pracownika
+INRSRiskTooltip                                       = Lista kategorii ryzyk proponowanych w wytycznych INRS
+PreventionMethodTooltip                               = Środek prewencji do wdrożenia w celu ograniczenia ryzyka
+LockPreventionPlan                                    = Zablokuj plan prewencji
+ConfirmLockPreventionPlan                             = Czy na pewno chcesz zablokować plan prewencji?<br>Blokada utrwala dane i generowanie dokumentu.
+AllSignatoriesMustHaveSigned                          = Wszyscy uczestnicy muszą podpisać, aby zablokować obiekt
+ValidatePreventionPlan                                = Zatwierdź plan prewencji
+ConfirmValidatePreventionPlan                         = Czy na pewno chcesz zatwierdzić plan prewencji? <br> Zatwierdzenie umożliwia uczestnikom podpisanie dokumentu, ale <b> uniemożliwia dodawanie nowych uczestników oraz modyfikację planu prewencji </b>.
+ReOpenPreventionPlan                                  = Otwórz ponownie plan prewencji
+ConfirmReOpenPreventionPlan                           = Czy na pewno chcesz ponownie otworzyć plan prewencji? Ponowne otwarcie umożliwia modyfikację planu prewencji i dodawanie nowych uczestników, ale <b>wszystkie podpisy na dokumencie zostaną utracone</b>.
+PreventionPlanRiskList                                = Lista ryzyk planu prewencji
+ActionsPreventionPlanRisk                             = Działania
+PreventionPlanDescription                             = Projekt planów prewencji
+PriorVisitDate                                        = Data wspólnej kontroli wstępnej
+AddPreventionPlanLine                                 = Dodanie ryzyka
+UpdatePreventionPlanLine                              = Aktualizacja ryzyka
+DeletePreventionPlanLine                              = Usunięcie ryzyka
+PreventionPlanDet                                     = Ryzyko planu prewencji
+Preventionplandet                                     = Ryzyko planu prewencji
+PreventionPlanMessage                                 = do planu prewencji
+PreventionPlanMustBeValidated                         = Plan prewencji musi być zatwierdzony, aby można go było ponownie otworzyć
+PreventionPlanMustBeInProgress                        = Plan prewencji musi być w trakcie realizacji, aby uzyskać dostęp do tej funkcji
+PreventionPlanMustBeInProgressToValidate              = Plan prewencji jest już zatwierdzony
+CSEMustBeAlerted3DaysBeforeVisit                      = Rada Społeczno-Ekonomiczna musi zostać powiadomiona 3 dni przed wspólną kontrolą wstępną (art. R. 4514-1 1°, R. 4514-3 i R. 4514-9 francuskiego kodeksu pracy)
+PreventionPlanData                                    = Dane planu prewencji
+MasterWorkerDescription                               = Użytkownik używany domyślnie jako osoba odpowiedzialna przedsiębiorstwa użytkującego
+NoPreventionPlanRisk                                  = Brak ryzyka w planie prewencji
+NoPreventionPlanLinked                                = Brak powiązanego planu prewencji
+PreventionPlanLinked                                  = Powiązany plan prewencji
+PreventionPlanManagement                              = Zarządzanie planami prewencji
+PPRProject                                            = Projekt powiązany z planami prewencji
+NewLabelForClonePreventionPlan                        = Nazwa nowego planu prewencji
+ClonePreventionPlanRisk                               = Sklonuj ryzyka planu prewencji
+CloneAttendantsPreventionPlan                         = Sklonuj uczestników planu prewencji
+CloneSchedulePreventionPlan                           = Sklonuj godziny planu prewencji
+ConfirmClonePreventionPlan                            = Czy na pewno chcesz sklonować plan prewencji <b> %s </b>?
+preventionplandocument.odt                            = Plan prewencji
+preventionplandocument_custom.odt                     = Niestandardowy plan prewencji
+ErrorThirdPartyHasAtLeastOneChildOfTypePreventionPlan = Kontrahent jest powiązany z co najmniej jednym elementem podrzędnym typu plan prewencji:
+ErrorContactHasAtLeastOneChildOfTypePreventionPlan    = Kontakt jest powiązany z co najmniej jednym elementem podrzędnym typu plan prewencji:
+ConfirmDeletePreventionPlan                           = Czy na pewno chcesz usunąć ten plan prewencji?
+PreventionPlanRole                                    = Role planu prewencji
+
+# E-mail
+PreventionPlanLabel   = Podsumowanie planu prewencji
+PreventionPlanSubject = E-mail plan prewencji
+PreventionPlanContent = W załączeniu znajduje się dokument ODT planu prewencji.
+
+# Wyzwalacze
+PreventionPlanCreated          = Utworzenie planu prewencji
+PreventionPlanModified         = Modyfikacja planu prewencji
+PreventionPlanDeleted          = Usunięcie planu prewencji
+PreventionPlanInProgress       = Ponowne otwarcie planu prewencji
+PreventionPlanPendingSignature = Skierowanie planu prewencji do podpisu
+PreventionPlanLocked           = Zablokowanie planu prewencji
+PreventionPlanArchived         = Archiwizacja planu prewencji
+PreventionPlanSentByMail       = Wysłanie planu prewencji e-mailem
+
+#
+# FirePermit - Zezwolenie na prace pożarowe
+#
+
+# Uprawnienie
+FirePermitMin  = zezwolenie na prace pożarowe
+FirePermitsMin = zezwolenia na prace pożarowe
+
+# Dane
+NewFirePermit                                     = Nowe zezwolenie na prace pożarowe
+ModifyFirePermit                                  = Zmodyfikuj zezwolenie na prace pożarowe
+FirePermitList                                    = Lista zezwoleń na prace pożarowe
+FirePermit                                        = Zezwolenie na prace pożarowe
+Firepermit                                        = Zezwolenie na prace pożarowe
+TheFirepermit                                     = zezwolenie na prace pożarowe
+FirePermitDocument                                = Zezwolenie na prace pożarowe
+Firepermitdocument                                = Zezwolenie na prace pożarowe
+FirePermitDocumentGenerated                       = Generowanie zezwolenia na prace pożarowe
+FirePermitCreated                                 = Utworzenie zezwolenia na prace pożarowe
+FirePermitModified                                = Modyfikacja zezwolenia na prace pożarowe
+FirePermitDeleted                                 = Usunięcie zezwolenia na prace pożarowe
+FirePermitInProgress                              = Ponowne otwarcie zezwolenia na prace pożarowe
+FirePermitPendingSignature                        = Skierowanie zezwolenia na prace pożarowe do podpisu
+FirePermitLocked                                  = Zablokowanie zezwolenia na prace pożarowe
+FirePermitArchived                                = Archiwizacja zezwolenia na prace pożarowe
+FirePermitSignatureAddAttendant                   = Dodanie uczestnika do zezwolenia na prace pożarowe
+FirePermitSentByMail                              = Wysłanie zezwolenia na prace pożarowe e-mailem
+FirePermitLine                                    = ryzyko(a)
+FirePermitDet                                     = Ryzyko zezwolenia na prace pożarowe
+Firepermitdet                                     = Ryzyko zezwolenia na prace pożarowe
+FirePermitLineCreated                             = Utworzenie ryzyka w zezwoleniu na prace pożarowe
+FirePermitLineModified                            = Modyfikacja ryzyka w zezwoleniu na prace pożarowe
+FirePermitLineDeleted                             = Usunięcie ryzyka z zezwolenia na prace pożarowe
+FirePermitRiskList                                = Lista ryzyk zezwolenia na prace pożarowe
+AddFirePermitLine                                 = Dodanie ryzyka
+UpdateFirePermitLine                              = Aktualizacja ryzyka
+DeleteFirePermitLine                              = Usunięcie ryzyka
+FirePermitMessage                                 = do zezwolenia na prace pożarowe
+UsedMaterialTooltip                               = Sprzęt do zastosowania w celu ograniczenia ryzyka
+ActionsFirePermitRisk                             = Działania
+ConfirmValidateFirePermit                         = Czy na pewno chcesz zatwierdzić zezwolenie na prace pożarowe? <br> Zatwierdzenie umożliwia uczestnikom podpisanie dokumentu, ale <b> uniemożliwia dodawanie nowych uczestników oraz modyfikację zezwolenia na prace pożarowe </b>.
+ConfirmReOpenFirePermit                           = Czy na pewno chcesz ponownie otworzyć zezwolenie na prace pożarowe? Ponowne otwarcie umożliwia modyfikację zezwolenia na prace pożarowe i dodawanie nowych uczestników, ale <b>wszystkie podpisy na dokumencie zostaną utracone</b>.
+ConfirmLockFirePermit                             = Czy na pewno chcesz zablokować zezwolenie na prace pożarowe?<br>Blokada utrwala dane i generowanie dokumentu.
+FirePermitMustBeInProgress                        = Zezwolenie na prace pożarowe musi być w trakcie realizacji, aby uzyskać dostęp do tej funkcji
+NewLabelForCloneFirePermit                        = Nazwa nowego zezwolenia na prace pożarowe
+CloneFirePermitRisk                               = Sklonuj ryzyka zezwolenia na prace pożarowe
+CloneAttendantsFirePermit                         = Sklonuj uczestników zezwolenia na prace pożarowe
+CloneScheduleFirePermit                           = Sklonuj godziny zezwolenia na prace pożarowe
+ConfirmCloneFirePermit                            = Czy na pewno chcesz sklonować zezwolenie na prace pożarowe <b> %s </b>?
+FirePermitDescription                             = Projekt zezwoleń na prace pożarowe
+FirePermitData                                    = Dane zezwolenia na prace pożarowe
+FirePermitManagement                              = Zarządzanie zezwoleniami na prace pożarowe
+FPRProject                                        = Projekt powiązany z zezwoleniami na prace pożarowe
+firepermitdocument.odt                            = Zezwolenie na prace pożarowe
+firepermitdocument_custom.odt                     = Niestandardowe zezwolenie na prace pożarowe
+UsedEquipment                                     = Użyty sprzęt
+ErrorThirdPartyHasAtLeastOneChildOfTypeFirePermit = Kontrahent jest powiązany z co najmniej jednym elementem podrzędnym typu zezwolenie na prace pożarowe:
+ErrorContactHasAtLeastOneChildOfTypeFirePermit    = Kontakt jest powiązany z co najmniej jednym elementem podrzędnym typu zezwolenie na prace pożarowe:
+ConfirmDeleteFirePermit                           = Czy na pewno chcesz usunąć to zezwolenie na prace pożarowe?
+FirePermitRole                                    = Role zezwolenia na prace pożarowe
+FirepermitSchedules                               = Godziny zezwolenia na prace pożarowe
+
+# E-mail
+FirePermitLabel   = Podsumowanie zezwolenia na prace pożarowe
+FirePermitSubject = E-mail zezwolenie na prace pożarowe
+FirePermitContent = W załączeniu znajduje się dokument ODT zezwolenia na prace pożarowe.
+
+
+#
+# Accident - Wypadek
+#
+
+# Uprawnienie
+AccidentsMin = wypadki
+
+# Wyzwalacz
+AccidentCreateTrigger         = Wypadek %s został utworzony
+ActionsOnAccident             = Zdarzenia powiązane z wypadkiem
+AccidentGeneratedWithDolibarr = Wypadek wygenerowany w Dolibarr
+AccidentWorkStopCreateTrigger = Zwolnienie lekarskie %s dodane do wypadku
+AccidentWorkStopModifyTrigger = Zwolnienie lekarskie %s zmodyfikowane przy wypadku
+AccidentWorkStopDeleteTrigger = Zwolnienie lekarskie %s usunięte z wypadku
+AccidentModifyTrigger         = Wypadek %s zmodyfikowany
+AccidentDeleteTrigger         = Wypadek %s usunięty
+AccidentMetaDataCreateTrigger = Zapis danych uzupełniających wypadku
+AccidentLesionCreateTrigger   = Uraz %s dodany do wypadku
+AccidentLesionModifyTrigger   = Uraz %s zmodyfikowany przy wypadku
+AccidentLesionDeleteTrigger   = Uraz %s usunięty z wypadku
+ACC_USER_EMPLOYERSigned       = Podpis osoby odpowiedzialnej firmy
+VictimAndCaregivers           = Poszkodowany i osoba udzielająca pomocy
+Victim                        = Poszkodowany
+Caregiver                     = Osoba udzielająca pomocy
+
+# Model numeracji
+DigiriskAccidentNumberingModule         = Model numeracji wypadków Digirisk
+DigiriskAccidentStandardModel           = Zwraca numer w postaci ACCn, gdzie n to licznik sekwencyjny bez przerw i bez zerowania.
+DigiriskAccidentWorkStopNumberingModule = Model numeracji zwolnień lekarskich powiązanych z wypadkiem
+DigiriskAccidentWorkStopStandardModel   = Zwraca numer w postaci ACCWn, gdzie n to licznik sekwencyjny bez przerw i bez zerowania.
+DigiriskAccidentLesionNumberingModule   = Model numeracji urazów powiązanych z wypadkiem
+DigiriskAccidentLesionStandardModel     = Zwraca numer w postaci ACCLn, gdzie n to licznik sekwencyjny bez przerw i bez zerowania.
+DigiriskAccidentDocumentNumberingModule = Model numeracji kart wypadku Digirisk
+DigiriskAccidentDocumentStandardModel   = Zwraca numer w postaci ACCDn, gdzie n to licznik sekwencyjny bez przerw i bez zerowania.
+
+# Szablon ODT
+DigiriskTemplateDocumentAccident       = Szablony dokumentów wypadków Digirisk
+AccidentDocumentCustomDigiriskTemplate = Niestandardowy ODT wypadków
+AccidentDocumentDigiriskTemplate       = Domyślny ODT wypadków
+AccidentDocument                       = Karta wypadku
+AccidentDocumentGeneratedWithDolibarr  = Wypadek wygenerowany w Dolibarr
+
+# Dane
+NewAccident                              = Nowy wypadek
+ModifyAccident                           = Zmodyfikuj wypadek
+AccidentList                             = Lista wypadków
+Accident                                 = Wypadek
+AccidentCreated                          = Utworzenie wypadku
+DeleteAccident                           = Usunąć wypadek?
+AccidentModified                         = Modyfikacja wypadku
+AccidentDeleted                          = Usunięcie wypadku
+AccidentLine                             = ryzyko(a)
+AccidentDate                             = Data wypadku
+AccidentSchedule                         = Godziny wypadku
+AccidentRiskList                         = Lista informacji uzupełniających o wypadku
+Accidentworkstop                         = Zwolnienie lekarskie
+AccidentWorkStopCreated                  = Utworzenie zwolnienia lekarskiego
+AccidentWorkStopModified                 = Modyfikacja zwolnienia lekarskiego
+AccidentWorkStopDeleted                  = Usunięcie zwolnienia lekarskiego
+AddAccidentWorkStop                      = Dodanie zwolnienia lekarskiego do wypadku
+UpdateAccidentWorkStop                   = Aktualizacja zwolnienia lekarskiego przy wypadku
+DeleteAccidentWorkStop                   = Usunięcie zwolnienia lekarskiego z wypadku
+Accidentlesion                           = Uraz
+AccidentLesionCreated                    = Utworzenie urazu
+AccidentLesionModified                   = Modyfikacja urazu
+AccidentLesionDeleted                    = Usunięcie urazu
+AddAccidentLesion                        = Dodanie urazu do wypadku
+UpdateAccidentLesion                     = Aktualizacja urazu przy wypadku
+DeleteAccidentLesion                     = Usunięcie urazu z wypadku
+AccidentDescription                      = Projekt wypadków
+AccidentManagement                       = Zarządzanie wypadkami
+AccidentWorkstopManagement               = Zarządzanie zwolnieniami lekarskimi
+AccidentLesionManagement                 = Zarządzanie urazami
+AccidentInvestigationManagement          = Zarządzanie dochodzeniami powypadkowymi
+ACCProject                               = Projekt powiązany z wypadkami
+UserVictim                               = Poszkodowany w wypadku
+AccidentType                             = Rodzaj wypadku
+WorkAccidentStatement                    = Wypadek przy pracy
+CommutingAccident                        = Wypadek w drodze do pracy
+AccidentMetaData                         = Dane uzupełniające
+RelativeLocation                         = Dodatkowe informacje o miejscu wypadku
+VictimActivity                           = Czynność poszkodowanego w chwili wypadku
+AccidentNature                           = Charakter wypadku
+AccidentObject                           = Przedmiot, którego kontakt spowodował uraz poszkodowanego
+AccidentNatureDoubt                      = Ewentualne uzasadnione zastrzeżenia (w razie potrzeby dołącz pismo przewodnie)
+AccidentNatureDoubtLink                  = Link do pisma przewodniego
+VictimTransportedTo                      = Poszkodowany został przewieziony do
+VictimWorkHours                          = Godziny pracy poszkodowanego w dniu wypadku
+WorkHoursMorningDateStart                = Początek godzin pracy poszkodowanego (rano)
+WorkHoursMorningDateEnd                  = Koniec godzin pracy poszkodowanego (rano)
+WorkHoursAfternoonDateStart              = Początek godzin pracy poszkodowanego (po południu)
+WorkHoursAfternoonDateEnd                = Koniec godzin pracy poszkodowanego (po południu)
+AccidentNoticed                          = Informacja o wypadku
+Found                                    = Stwierdzony
+Known                                    = Znany
+AccidentNoticeDate                       = Data powzięcia wiadomości o wypadku
+AccidentNoticeBy                         = Osoba, która poinformowała o wypadku
+ByEmployer                               = Przez pracodawcę
+ByEmployees                              = Przez jego pracowników
+AccidentDescribedByVictim                = Wypadek został opisany przez poszkodowanego
+RegisteredInAccidentRegister             = Wypadek jest wpisany do rejestru lekkich wypadków przy pracy
+RegisterDate                             = Data wpisu do rejestru lekkich wypadków przy pracy
+RegisterNumber                           = Numer wpisu do rejestru lekkich wypadków przy pracy
+Consequence                              = Skutki
+WithoutWorkStop                          = Bez zwolnienia lekarskiego
+LessThanFourDays                         = Mniej niż 4 dni
+LessThanTwentyOneDays                    = Mniej niż 21 dni
+LessThanThreeMonth                       = Mniej niż 3 miesiące
+LessThanSixMonths                        = Mniej niż 6 miesięcy
+LongTimeWorkStop                         = Więcej niż 6 miesięcy
+WithWorkStop                             = Ze zwolnieniem lekarskim
+Fatal                                    = Zgon
+PoliceReport                             = Raport policyjny
+PoliceReportBy                           = Osoba, która sporządziła raport policyjny
+FirstPersonNoticedIsWitness              = Osoba powiadomiona
+Witness                                  = Świadek
+FirstPersonNoticed                       = Pierwsza powiadomiona osoba
+ThirdPartyResponsability                 = Czy wypadek został spowodowany przez osobę trzecią?
+FkSocResponsible                         = Firma odpowiedzialnej osoby trzeciej
+FkSocResponsibleInsuranceSociety         = Towarzystwo ubezpieczeniowe osoby trzeciej
+LesionLocalization                       = Umiejscowienie urazów
+LesionNature                             = Charakter urazów
+AccidentInvestigation                    = Dochodzenie powypadkowe
+Accidentinvestigation                    = Dochodzenie powypadkowe
+AccidentInvestigationLink                = Link do dochodzenia powypadkowego
+AccidentLocation                         = Miejsce wypadku
+DigiriskDolibarrActionTrigger            = Wyzwalacz zdarzeń Digirisk
+CollateralVictim                         = Poszkodowany pośrednio
+FromDigirisk                             = Od
+At                                       = Do
+AndFrom                                  = Oraz od
+ExternalAccident                         = Czy wypadek miał miejsce w zakładzie innym niż macierzysty zakład poszkodowanego?
+AccidentAttendants                       = Wypadek - Uczestnicy
+UserEmployer                             = Osoba odpowiedzialna firmy
+SignatureUserEmployer                    = Podpis osoby odpowiedzialnej firmy
+CerfaLink                                = Link do formularza Cerfa
+WorkStopDays                             = Liczba dni zwolnienia lekarskiego
+AccidentLesionList                       = Lista urazów powiązanych z wypadkiem
+DocumentsMetaData                        = Dodatkowe załączniki
+WorkStopDocument                         = Zgłoszenie zwolnienia lekarskiego
+AccidentMetaDataSave                     = Dane uzupełniające wypadku zostały zapisane
+ErrorFieldNotEmpty                       = Błąd: pole <b>'%s'</b> nie może być puste
+ErrorFieldMustBeGreaterOrEqualZero       = Błąd: pole <b>'%s'</b> musi być większe lub równe 0
+ConfirmDeleteAccidentWorkStop            = Czy na pewno chcesz usunąć zwolnienie lekarskie <b>%s</b> przy wypadku?
+AccidentMetaDataLesion                   = Dane uzupełniające urazów
+TotalWorkStopDays                        = Łączna liczba dni zwolnienia lekarskiego
+RegisterAccident                         = Lekki wypadek
+AccidentsLinked                          = Powiązany(e) wypadek(ki)
+GaugeCounter                             = To pole jest używane w liczniku wskaźnika
+DateStartWorkStop                        = Data początku zwolnienia lekarskiego
+DateEndWorkStop                          = Data końca zwolnienia lekarskiego
+ReturnWorkDate                           = Data powrotu do pracy
+DayWithoutAccident                       = Dni bez wypadków
+AccidentRepartition                      = Rozkład wypadków według rodzaju
+AccidentByYear                           = Rozkład wypadków według roku
+NbAccidentsByEmployees                   = Liczba wypadków na pracownika
+AccidentRegister                         = Wypadek według rejestru
+AccidentWithoutRegister                  = Wypadki bez rejestru
+AccidentWithRegister                     = Wypadki z rejestrem
+WorkStopDurationDistribution             = Rozkład czasu według zwolnienia lekarskiego
+WorkStopDurationDistributionDigiriskElem = Rozkład czasu zwolnienia lekarskiego według GP/UT
+WorkStopDuration                         = Czas trwania zwolnienia lekarskiego
+NoAbsence                                = Brak zwolnienia
+UpTo4Days                                = Do 4 dni
+UpTo21Days                               = Do 21 dni
+UpTo3Months                              = Do 3 miesięcy
+UpTo6Months                              = Do 6 miesięcy
+MoreThan6Months                          = Więcej niż 6 miesięcy
+FrequencyIndex                           = Wskaźnik częstości
+FrequencyRate                            = Współczynnik częstości
+GravityIndex                             = Wskaźnik ciężkości
+GravityRate                              = Współczynnik ciężkości
+AccidentRateIndicator                    = Współczynniki i wskaźniki mierników skuteczności dotyczących wypadków
+NbPresquAccidents                        = Liczba zdarzeń potencjalnie wypadkowych
+NbAccidentInvestigations                 = Liczba dochodzeń powypadkowych
+AccidentInvestigationsMin                = dochodzenia powypadkowe
+NbWorkedHours                            = Liczba przepracowanych godzin
+ConfirmDeleteAccident                    = Czy na pewno chcesz usunąć wypadek?
+TheAccident                              = wypadek
+AccidentInvestigation                    = Dochodzenie powypadkowe
+Accident_investigation                   = Dochodzenie powypadkowe
+AccidentInvestigationDocument            = Dokument dochodzenia powypadkowego
+Accidentinvestigationdocument            = Dokument dochodzenia powypadkowego
+accidentinvestigationdocument.odt        = Dochodzenie powypadkowe
+NewAccidentInvestigation                 = Nowe dochodzenie powypadkowe
+UpdateAccidentInvestigation              = Zmodyfikuj dochodzenie powypadkowe
+AccidentInvestigationList                = Lista dochodzeń powypadkowych
+TheAccidentinvestigation                 = dochodzenie powypadkowe
+SeniorityInPosition                      = Staż na stanowisku
+VictimSkills                             = Kompetencje poszkodowanego
+CollectiveEquipment                      = Środki ochrony zbiorowej (ŚOZ)
+IndividualEquipment                      = Środki ochrony indywidualnej (ŚOI)
+Circumstances                            = Okoliczności
+CurativeAction                           = Działania doraźne
+CorrectiveAction                         = Działania korygujące
+PreventiveAction                         = Działania zapobiegawcze
+DigiriskActionType                       = Rodzaj działania Digirisk
+Actions                                  = Działania
+ActionsTab                               = Działania
+CurativeActions                          = Działania doraźne
+PreventiveActions                        = Działania zapobiegawcze
+TotalPlannedBudget                       = Przewidziany budżet
+AccidentInvestigationDocumentPDF         = EA-A4-PIONOWO
+PreventionPlanDocumentPDF                = PP-A4-PIONOWO
+PreventionPlanDocumentPDFDescription     = Wygeneruj plan prewencji w formacie PDF
+AccidentInvestigationDocumentPDFDescription = Wygeneruj dochodzenie powypadkowe w formacie PDF
+AccidentInvestigationDocumentGeneratedAt = Wygenerowano
+CorrectiveActions                        = Działania korygujące
+AddCurativeAction                        = Dodaj działanie doraźne
+AddCorrectiveAction                      = Dodaj działanie korygujące
+InvestigationNotValidatedYet             = Najpierw zatwierdź dochodzenie powypadkowe, aby móc tworzyć działania
+ActionLabel                              = Nazwa działania
+ActionDeadline                           = Termin
+ActionAssignedTo                         = Przypisane do
+ActionProgress                           = Postęp
+MarkAsDone                               = Oznacz jako zakończone
+XActionsOfY                              = %s / %s zakończonych
+NoActionsYet                             = Brak działań
+ActionAdded                              = Działanie zostało utworzone
+ActionClosed                             = Działanie zostało zamknięte
+ActionsAreProjectTasks                   = Działania są podzadaniami projektu Dolibarr
+SeeProjectTasksView                      = Zobacz zadanie nadrzędne
+OpenTask                                 = Otwórz zadanie
+AccidentInvestigationValidated           = Dochodzenie powypadkowe zostało zatwierdzone
+AccidentInvestigationReOpened            = Dochodzenie powypadkowe zostało ponownie otwarte
+AccidentInvestigationTaskCreated         = Zadania dochodzenia powypadkowego zostały utworzone
+AccidentInvestigationTaskDeleted         = Zadania dochodzenia powypadkowego zostały usunięte
+CausalityTree                            = Drzewo przyczyn
+TaskWillBeCreatedAfterValidation         = Zadania zostaną utworzone po zatwierdzeniu dochodzenia powypadkowego
+AccidentInvestigationCreated             = Utworzenie dochodzenia powypadkowego
+AccidentInvestigationModified            = Modyfikacja dochodzenia powypadkowego
+AccidentInvestigationDeleted             = Usunięcie dochodzenia powypadkowego
+AccidentInvestigationValidate            = Zatwierdzenie dochodzenia powypadkowego
+AccidentInvestigationUnValidate          = Ponowne otwarcie dochodzenia powypadkowego
+AccidentInvestigationLock                = Zablokowanie dochodzenia powypadkowego
+AccidentInvestigationSigned              = Podpisanie dochodzenia powypadkowego
+CloneWorkStop                            = Sklonować zwolnienia lekarskie?
+CloneMetadata                            = Sklonować dane uzupełniające?
+CloneLesion                              = Sklonować dane uzupełniające urazów?
+CloneFrom                                = Klon
+AccidentInvestigationRole                = Role dochodzenia powypadkowego
+LesionsOrWorkStop                        = urazy lub zwolnienia lekarskie
+AccidentsCategoriesArea                  = Obszar tagów/kategorii wypadków
+AddAccidentIntoCategory                  = Przypisz tę kategorię do wypadku
+PreventionplansCategoriesArea            = Obszar tagów/kategorii planów prewencji
+AddPreventionplanIntoCategory            = Przypisz tę kategorię do planu prewencji
+FirepermitsCategoriesArea                = Obszar tagów/kategorii zezwoleń na prace pożarowe
+AddFirepermitIntoCategory                = Przypisz tę kategorię do zezwolenia na prace pożarowe
+RisksCategoriesArea                      = Obszar tagów/kategorii ryzyk
+AddRiskIntoCategory                      = Przypisz tę kategorię do ryzyka
+AddTicketIntoCategory                    = Przypisz tę kategorię do zgłoszenia
+StartDateInvestigate                     = Data rozpoczęcia dochodzenia
+EndDateInvestigate                       = Data zakończenia dochodzenia
+YearType                                 = Rodzaj roku
+AllYears                                 = Wszystkie lata
+FiscalYear                               = Rok obrotowy
+CalendarYear                             = Rok kalendarzowy
+
+# AccidentTooltip - Podpowiedzi dotyczące wypadków
+VictimActivityTooltip              = Podaj czynność lub zadanie poszkodowanego w chwili wypadku, to znaczy co poszkodowany robił
+AccidentNatureTooltip              = Opisz zdarzenie, które doprowadziło do wypadku, w jaki sposób doszło do wypadku (problem elektryczny, wyciek gazu, pęknięcie sprzętu, poślizgnięcie, upadek, wysiłek fizyczny, agresja...), lub w jaki sposób poszkodowany odniósł uraz (uderzenie, zderzenie, zgniecenie, ukłucie, utonięcie, kontakt z substancją...)
+AccidentObjectTooltip              = To znaczy czym poszkodowany odniósł uraz: materiał, odpad, narzędzie (śrubokręt, nóż, wiertarka...), maszyna, pojazd, wózek transportowy, substancja chemiczna, element budowlany (drzwi, ściana...), podłoże...
+AccidentNatureDoubtTooltip         = W stosownych przypadkach wskaż uzasadnione zastrzeżenia, które mogą być uwzględnione wyłącznie wtedy, gdy dotyczą okoliczności czasu i miejsca wypadku lub istnienia przyczyny całkowicie niezwiązanej z pracą (art. R. 441-11 francuskiego kodeksu zabezpieczenia społecznego)
+VictimWorkHoursTooltip             = Podaj godziny pracy przepracowane przez Twojego pracownika lub godziny planowane w dniu wypadku
+ConsequenceTooltip                 = Jeśli poszkodowany przerwał pracę na zalecenie lekarza, masz OBOWIĄZEK wypełnić i przesłać formularz «attestation de salaire accident du travail ou maladie professionnelle» - numer S6202, do kasy chorych właściwej dla miejsca zwykłego pobytu poszkodowanego. <br> Następnie, w przypadku kolejnego zwolnienia po okresie leczenia lub powrocie do pracy, w innym miesiącu, będziesz musiał również dopełnić tej samej formalności
+FirstPersonNoticedIsWitnessTooltip = Podaj nazwisko, imię i adres świadka. <br> W przypadku braku świadka podaj pierwszą osobę w przedsiębiorstwie, która została powiadomiona o wypadku
+ThirdPartyResponsabilityTooltip    = Jeżeli wiesz o udziale osoby trzeciej, niezależnie od jej stopnia odpowiedzialności, w wypadku przy pracy lub w drodze do pracy, informacja ta musi być bezwzględnie zamieszczona w tej części
+FrequencyIndexTooltip              = Liczba wypadków na pracownika x 1 000
+FrequencyRateTooltip               = Liczba wypadków na przepracowane godziny x 1 000 000
+GravityRateTooltip                 = Liczba dni zwolnienia lekarskiego na przepracowane godziny x 1 000
+NbWorkedHoursTooltip               = Liczba przepracowanych godzin została wprowadzona ręcznie
+DocumentGeneratedWithVersioning    = Dokument wygenerowany podczas wersjonowania
+
+# Słownik
+UsualWorkplace                  = Zwykłe miejsce pracy
+OccasionalWorkplace             = Okazjonalne miejsce pracy
+LocationOfTheMeal               = Miejsce posiłku
+OnTheWayBetweenHomeAndWorkplace = Podczas drogi między domem a miejscem pracy
+OnTheWayBetweenMealAndWorkplace = Podczas drogi między pracą a miejscem posiłku
+DuringATripForTheEmployer       = Podczas wyjazdu służbowego na polecenie pracodawcy
+
+Trunk             = Tułów
+Hand              = Ręka
+LowerLimbs        = Kończyny dolne
+UpperLimbs        = Kończyny górne
+MultipleLocations = Wiele lokalizacji
+Foot              = Stopa
+Head              = Głowa
+Eyes              = Oczy
+InternalSeating   = Lokalizacje wewnętrzne
+Neck              = Szyja
+Back              = Plecy
+WholeBody         = Całe ciało
+NotSpecified      = Nieokreślone
+
+PainEffortLumbago           = Ból wysiłkowy, postrzał
+Contusion                   = Stłuczenie
+Wounds                      = Rany
+Sprain                      = Skręcenie
+FracturePitting             = Złamanie lub pęknięcie
+MultipleInjuries            = Urazy o różnym charakterze
+MuscleOrTendonTear          = Naderwanie mięśnia lub ścięgna
+PresenceOfForeignBody       = Obecność ciała obcego
+Burns                       = Oparzenie
+UnspecifiedAndMiscellaneous = Nieokreślone i różne
+Other                       = Inne
+CutOff                      = Skaleczenie
+
+Investigator = Prowadzący dochodzenie
+Rescuer      = Ratownik
+
+#
+# ListingRisksDocument - Zestawienie ryzyk z dokumentami
+#
+
+# Uprawnienie
+ListingRisksDocumentMin = zestawienia ryzyk z dokumentami
+
+# Dane
+ListingRisksDocument            = Zestawienie ryzyk
+Listingrisksdocument            = Zestawienie ryzyk
+ListingRisksHeader              = Ryzyka - %s
+ListingRisksDocumentGenerated   = Generowanie zestawienia ryzyk z dokumentami
+listingrisksdocument.odt        = Zestawienie ryzyk z dokumentami
+listingrisksdocument_custom.odt = Niestandardowe zestawienie ryzyk z dokumentami
+
+#
+# ListingRisksPhoto - Zestawienie ryzyk ze zdjęciami
+#
+
+# Uprawnienie
+ListingRisksPhotosMin = zestawienia ryzyk ze zdjęciami
+
+# Dane
+ListingRisksPhoto            = Zestawienie ryzyk ze zdjęciami
+Listingrisksphoto            = Zestawienie ryzyk ze zdjęciami
+ListingRisksPhotoGenerated   = Generowanie zestawienia ryzyk ze zdjęciami
+listingrisksphoto.odt        = Zestawienie ryzyk ze zdjęciami
+listingrisksphoto_custom.odt = Niestandardowe zestawienie ryzyk ze zdjęciami
+
+
+#
+# ListingRisksAction - Zestawienie ryzyk z działaniami korygującymi
+#
+
+# Uprawnienie
+ListingRisksActionsMin = zestawienia ryzyk z działaniami korygującymi
+
+# Dane
+ListingRisksAction                        = Zestawienie ryzyk z działaniami korygującymi
+Listingrisksaction                        = Zestawienie ryzyk z działaniami korygującymi
+ListingRisksActionGenerated               = Generowanie zestawienia ryzyk z działaniami korygującymi
+listingrisksaction.odt                    = Zestawienie ryzyk z działaniami korygującymi
+listingrisksaction_custom.odt             = Niestandardowe zestawienie ryzyk z działaniami korygującymi
+DigiriskListingRisksActionData            = Konfigurowalne dane zestawień ryzyk z działaniami korygującymi
+ShowTaskDoneListingRisksActionDescription = Umożliwia wyświetlanie lub ukrywanie zakończonych zadań w zestawieniu ryzyk z działaniami korygującymi
+
+
+#
+# RiskAssessmentDocument - Ocena ryzyka zawodowego
+#
+
+# Uprawnienie
+
+RiskAssessmentDocumentsMin = Oceny ryzyka zawodowego
+
+# Dane
+RiskAssessmentDocument                                    = Ocena ryzyka zawodowego
+Riskassessmentdocument                                    = Ocena ryzyka zawodowego
+RiskAssessmentDocumentGenerated                           = Generowanie oceny ryzyka zawodowego
+AuditStartDate                                            = Data rozpoczęcia audytu
+AuditEndDate                                              = Data zakończenia audytu
+Recipient                                                 = Odbiorca
+ImportantNote                                             = Ważna uwaga
+SitePlans                                                 = Lokalizacja planów
+SetStartEndDateBeforeSendEmail                            = Ustaw na tej stronie datę rozpoczęcia i zakończenia audytu, aby wysłać e-mail
+NoSitePlans                                               = Nie wprowadzono żadnego planu firmy
+riskassessmentdocument.odt                                = Ocena ryzyka zawodowego
+riskassessmentdocument_custom.odt                         = Niestandardowa ocena ryzyka zawodowego
+DigiriskRiskAssessmentDocumentData                        = Konfigurowalne dane oceny ryzyka zawodowego
+ActionPreventionCompletedTaskDone                         = Zakończone działania nie są wyświetlane
+AppliedOn                                                 = Aktywne w:
+RiskAssessmentDocumentMethod                              = * Etap 1: Zebranie informacji<br />- Wizytacja pomieszczeń<br />- Zebranie danych o personelu<br /><br />* Etap 2: Określenie metodyki i dokumentu<br />- Zatwierdzenie standardowych kart jednostek pracy<br />- Zatwierdzenie struktury jednostek<br /><br />* Etap 3: Przeprowadzenie badania ryzyk<br />- Uświadamianie personelu o ryzykach i zagrożeniach<br />- Utworzenie jednostek pracy wraz z personelem i osobą (osobami) odpowiedzialną(-ymi)<br />- Ocena ryzyk według jednostek pracy wraz z personelem<br /><br />* Etap 4<br />- Opracowanie i redakcja oceny ryzyka zawodowego
+RiskAssessmentDocumentSources                             = Uświadamianie o ryzykach jest opisane w ED840 wydanym przez INRS.<br />W tym dokumencie znajdziesz:<br />- Definicję ryzyka i zagrożenia wraz ze schematem wyjaśniającym<br />- Wyjaśnienia dotyczące różnych metod oceny
+RiskAssessmentDocumentImportantNote                       = Ważne uwagi:<br />Dokumentację DigiRisk możesz przeczytać tutaj<br /><a href="https://wiki.dolibarr.org/index.php?title=Module_Digirisk" target="_blank">https://wiki.dolibarr.org/index.php?title=Module_Digirisk</a><br />Projekt możesz śledzić tutaj:<br /><a href="https://github.com/Evarisk/Digirisk/projects?type=classic" target="_blank">https://github.com/Evarisk/Digirisk/projects?type=classic</a><br />Zgłoś błąd tutaj<br /><a href="https://github.com/Evarisk/Digirisk/issues" target="_blank">https://github.com/Evarisk/Digirisk/issues</a>
+GenerateZipArchiveWithDigiriskElementDocuments            = Generowanie archiwum ZIP z oceną ryzyka zawodowego
+GenerateZipArchiveWithDigiriskElementDocumentsDescription = Automatyczne generowanie archiwum ZIP zawierającego ocenę ryzyka zawodowego oraz wszystkie karty stanowisk podczas generowania oceny ryzyka zawodowego
+RiskAssessmentDocumentDescription                         = Plan działania oceny ryzyka zawodowego
+ErrorFailToFetchDigiriskElements                          = Błąd: nie udało się pobrać zgrupowań i jednostek pracy, które mają zostać ujęte w archiwum ZIP
+ErrorNoDocumentModelFound                                 = Błąd: brak dostępnego szablonu dokumentu dla <b>%s</b>
+ErrorFailToGenerateDigiriskElementDocument                = Błąd: generowanie dokumentu dla <b>%s</b> nie powiodło się, brakuje go w archiwum ZIP
+
+# Boxes - Widget
+NextGenerateDate  = Następne generowanie
+LastGenerateDate  = Ostatnie generowanie
+DelayGenerateDate = Pozostałe dni
+NoDelay           = Brak opóźnienia
+
+# E-mail
+RiskAssessmentDocumentLabel   = Podsumowanie oceny ryzyka zawodowego
+RiskAssessmentDocumentSubject = E-mail ocena ryzyka zawodowego
+RiskAssessmentDocumentContent = W załączeniu znajduje się archiwum ZIP oraz dokument ODT oceny ryzyka zawodowego.
+
+
+
+#
+# AuditReportDocument - Raport z audytu
+#
+
+# Dane
+AuditReportDocument     = Raport z audytu
+Auditreportdocument     = Raport z audytu
+AuditReportDocumentsMin = raporty z audytu
+auditreportdocument.odt = Raport z audytu
+
+
+
+#
+# GroupmentDocument - Karta zgrupowania
+#
+
+# Uprawnienie
+
+# Dane
+GroupmentDocument                        = Karta zgrupowania
+Groupmentdocument                        = Karta zgrupowania
+DocumentModelStandardPDF                 = Standardowy szablon PDF
+GroupmentDocumentGenerated               = Generowanie karty zgrupowania
+groupmentdocument.odt                    = Karta zgrupowania
+groupmentdocument_custom.odt             = Niestandardowa karta zgrupowania
+groupmentdocumentinherited.odt           = Karta zgrupowania - Ryzyka odziedziczone
+groupmentdocumentinherited_custom.odt    = Niestandardowa karta zgrupowania - Ryzyka odziedziczone
+groupmentdocumentshared.odt              = Karta zgrupowania - Ryzyka współdzielone
+groupmentdocumentshared_custom.odt       = Niestandardowa karta zgrupowania - Ryzyka współdzielone
+DigiriskGroupmentDocumentData            = Konfigurowalne dane kart zgrupowań
+ShowTaskDoneGroupmentDocumentDescription = Umożliwia wyświetlanie lub ukrywanie zakończonych zadań w karcie zgrupowania
+
+#
+# WorkUnitDocumment - Karta jednostki pracy
+#
+
+# Uprawnienie
+
+# Dane
+WorkUnitDocument                        = Karta jednostki pracy
+Workunitdocument                        = Karta jednostki pracy
+WorkUnitDocumentGenerated               = Generowanie karty jednostki pracy
+workunitdocument.odt                    = Karta jednostki pracy
+workunitdocument_custom.odt             = Niestandardowa karta jednostki pracy
+workunitdocumentinherited.odt           = Karta jednostki pracy - Ryzyka odziedziczone
+workunitdocumentinherited_custom.odt    = Niestandardowa karta jednostki pracy - Ryzyka odziedziczone
+workunitdocumentshared.odt              = Karta jednostki pracy - Ryzyka współdzielone
+workunitdocumentshared_custom.odt       = Niestandardowa karta jednostki pracy - Ryzyka współdzielone
+workunitdocumentcomplete.odt            = Karta jednostki pracy - Wszystkie ryzyka (własne, odziedziczone, współdzielone)
+workunitdocumentcomplete_custom.odt     = Niestandardowa karta jednostki pracy - Wszystkie ryzyka
+DigiriskWorkUnitDocumentData            = Konfigurowalne dane kart jednostek pracy
+ShowTaskDoneWorkUnitDocumentDescription = Umożliwia wyświetlanie lub ukrywanie zakończonych zadań w karcie jednostki pracy
+
+
+#
+# DigiriskElement - Element Digirisk
+#
+
+# Uprawnienia
+DigiriskElementsMin = elementy Digirisk (zgrupowanie i jednostka pracy)
+
+# Dane
+NewDigiriskElement                  = Nowy element Digirisk
+Digiriskelement                     = Zgrupowanie / Jednostka pracy
+GPUTOrganization                    = Organizacja GP/UT
+DigiriskElement                     = Element Digirisk
+HiddenElements                      = Kosz
+DigiriskElementCreated              = Utworzenie elementu Digirisk
+DigiriskElementModified             = Modyfikacja elementu Digirisk
+DigiriskElementDeleted              = Usunięcie elementu Digirisk
+ElementType                         = Rodzaj elementu
+ParentElement                       = Element nadrzędny
+OrganizationSaved                   = Organizacja zgrupowań i jednostek pracy została zapisana
+OrganizationNotSaved                = Nie udało się zapisać organizacji zgrupowań i jednostek pracy
+UnsavedChanges                      = Niezapisane zmiany
+SavingInProgress                    = Trwa zapisywanie...
+Saved                               = Zapisano
+ErrorSaving                         = Błąd podczas zapisywania
+DigiriskElementOrganization         = Organizacja struktury
+ShareDigiriskelement                = Włącz współdzielenie zgrupowań i jednostek pracy
+DIGIRISKELEMENTSharing              = Współdzielenie zgrupowań i jednostek pracy
+DIGIRISKELEMENTSharingDescription   = Wybór jednostek, które będą współdzielić swoje zgrupowania i jednostki pracy z tą jednostką.
+DigiriskElementSharedTooltip        = Ta opcja umożliwia współdzielenie zgrupowań i jednostek pracy. <br> INFORMACJA: jeśli chcesz wyświetlać zadania, musisz włączyć opcję współdzielenia projektów.
+PleaseSelectADigiriskElement        = Wybierz zgrupowanie lub jednostkę pracy...
+Registers                           = Rejestry
+ShowInSelectOnPublicTicketInterface = Musi pojawiać się na liście elementów publicznego interfejsu zgłoszeń
+Organization                        = Organizacja GP/UT
+YouDontHaveOrganization             = Nie utworzono zgrupowań ani jednostek pracy, przejdź do "Ocena ryzyka zawodowego" lub kliknij <b> tutaj </b>, aby je utworzyć.
+
+
+#
+# Groupment - Zgrupowanie
+#
+
+# Dane
+Groupment                  = Zgrupowanie
+GroupmentManagement        = Zarządzanie danymi zgrupowań
+NewGroupment               = Nowe zgrupowanie
+ModifyGroupment            = Zmodyfikuj zgrupowanie
+TrashGroupment             = Zgrupowanie w koszu
+DeletedElements            = Kosz
+DeletedDigiriskElement     = Zgrupowania / Jednostki pracy przeniesione do kosza
+ShowDeletedDigiriskElement = Pokaż zgrupowania / jednostki pracy znajdujące się w koszu
+
+#
+# WorkUnit - Jednostka pracy
+#
+
+# Dane
+WorkUnit           = Jednostka pracy
+Workunit           = Jednostka pracy
+WorkUnitManagement = Zarządzanie danymi jednostek pracy
+NewWorkUnit        = Nowa jednostka pracy
+ModifyWorkUnit     = Zmodyfikuj jednostkę pracy
+
+
+#
+# Evaluator - Oceniający
+#
+
+# Uprawnienia
+EvaluatorsMin = oceniający
+
+# Dane
+Evaluator                    = Oceniający
+Evaluators                   = Oceniający
+EvaluatorCreated             = Utworzenie oceniającego
+EvaluatorModified            = Modyfikacja oceniającego
+EvaluatorDeleted             = Usunięcie oceniającego
+TheEvaluator                 = Oceniający
+EvaluatorWellCreated         = Oceniający został utworzony
+EvaluatorNotCreated          = Błąd podczas tworzenia oceniającego
+EvaluatorList                = Lista oceniających
+AssignmentDate               = Data przydziału
+EvaluationDuration           = Czas trwania
+UserAssigned                 = Przypisany użytkownik
+AddEvaluatorTitle            = Dodanie oceniającego
+AddEvaluatorButton           = Dodaj oceniającego
+EvaluatorConfig              = Konfiguracja danych oceniających
+DeleteEvaluatorMessage       = Usunięcie oceniającego
+DigiriskEvaluatorData        = Konfigurowalne dane oceniających
+EvaluatorDuration            = Czas trwania oceny przez oceniającego
+EvaluatorDurationDescription = Czas, jaki oceniający potrzebuje na przeprowadzenie oceny ryzyka
+NbEmployeesInvolved          = Zaangażowani pracownicy
+NbEmployees                  = Pracownicy
+NbEmployeesInvolvedTooltip   = Unikalni pracownicy (oceniający)
+NbEmployeesTooltip           = Jeśli scentralizowane zarządzanie użytkownikami i grupami w jednostce głównej jest włączone.<br>Liczba pracowników odpowiada liczbie użytkowników współdzielonych/przypisanych do grupy, a także liczbie administratorów jednostki głównej
+NbEmployeesConfTooltip       = Liczba pracowników została wprowadzona ręcznie
+
+
+#
+# DigiriskStandard - Standard Digirisk
+#
+
+# Dane
+DigiriskStandardInformation = Informacja
+Digiriskstandard            = Standard Digirisk
+DigiriskStandardMin         = standardy Digirisk
+TheDigiriskstandard         = standard Digirisk
+
+
+#
+# RisksAnalysis - Analiza ryzyk
+#
+
+# Dane
+RiskAnalysis = Analiza ryzyk
+UpdateData   = Aktualizuj
+
+#
+# Risks - Ryzyka
+#
+
+# Uprawnienia
+RisksMin = ryzyka
+
+# Dane
+Risks                                    = Ryzyka
+Risk                                     = Ryzyko
+Riskprofessionals                        = Ryzyka zawodowe
+RiskCreated                              = Utworzenie ryzyka
+RiskModified                             = Modyfikacja ryzyka
+RiskDeleted                              = Usunięcie ryzyka
+RiskConfig                               = Konfiguracja danych ryzyk
+TheRisk                                  = Ryzyko
+RiskWellCreated                          = Ryzyko zostało utworzone
+RiskNotCreated                           = Błąd podczas tworzenia ryzyka
+RiskWellEdited                           = Ryzyko zostało zmodyfikowane
+RiskNotEdited                            = Błąd podczas modyfikacji ryzyka
+RiskList                                 = Zestawienie ryzyk
+AddRiskTitle                             = Dodanie ryzyka
+AddRiskButton                            = Dodaj ryzyko
+EditRisk                                 = Modyfikacja ryzyka
+LinkedRisk                               = Powiązane ryzyko
+RiskCategory                             = Kat.
+RiskCategoryEdit                         = Kategoria ryzyka
+RiskCategoryEditDescription              = Włącz modyfikację kategorii istniejącego ryzyka
+HowToEditRiskCategory                    = Aby zmienić kategorię ryzyka, kliknij piktogram kategorii
+DigiriskElementRisksList                 = Lista ryzyk
+DigiriskElementRisk                      = Ryzyka
+RiskDescriptionNotEnabled                = Pole opisu ryzyka nie jest włączone
+HowToEnableRiskDescription               = Aby włączyć pole opisu ryzyka, przejdź do "Konfiguracja modułu -> Ocena ryzyka zawodowego"
+HowToEnableRiskCategoryEdit              = Aby włączyć modyfikację kategorii ryzyka, przejdź do "Konfiguracja modułu -> Ocena ryzyka zawodowego"
+SortRisksListingsByEvaluation            = Sortuj ryzyka według oceny
+SortRisksListingsByEvaluationDescription = Włącz automatyczne sortowanie ryzyk według oceny w zestawieniach
+ListingHeaderEvaluation                  = Lista ocen
+RiskDescription                          = Opis ryzyka
+RiskDescriptionDescription               = Włącz pole opisu ryzyka
+RiskDescriptionNotActivated              = Włącz pole opisu ryzyka w Konfiguracja modułu / Analiza ryzyk / Ryzyka
+AddRisk                                  = Dodaj ryzyko
+MoveRisk                                 = Przenieś ryzyko
+MoveRisks                                = Przenieś ryzyka
+MoveRisksDescription                     = Umożliwia przenoszenie ryzyk z jednego zgrupowania lub jednostki pracy do innego
+SetConfToMoveRisk                        = Najpierw musisz zezwolić na przenoszenie ryzyk w "Konfiguracja modułu -> Ocena ryzyka zawodowego"
+RiskDescriptionPrefill                   = Wstępnie wypełnij opis
+RiskDescriptionPrefillDescription        = Wstępnie wypełnij opis ryzyka nazwą kategorii
+DigiriskElementSharedRisksList           = Lista ryzyk współdzielonych
+ImportSharedRisks                        = Importuj ryzyka współdzielone
+SelectAllSharedRisksOfElement            = Zaznacz wszystkie ryzyka tego elementu
+AlreadyImported                          = Już zaimportowane
+ShowSharedRisks                          = Ryzyka współdzielone
+ShareRisk                                = Włącz współdzielenie ryzyk
+RISKSharing                              = Współdzielenie ryzyk
+RISKSharingDescription                   = Wybór jednostek, które będą współdzielić swoje ryzyka z tą jednostką.
+ShowSharedRisksDescription               = Pokaż ryzyka współdzielone w dokumentach i zestawieniach
+UnlinkSharedRisk                         = Odłącz ryzyko współdzielone
+RiskWellUnlinkShared                     = Ryzyko zostało odłączone
+RiskNotUnlinkShared                      = Błąd podczas odłączania ryzyka
+HasBeenUnlinkSharedM                     = został odłączony
+HasNotBeenUnlinkSharedM                  = nie został odłączony
+RiskSharedTooltip                        = Ta opcja umożliwia współdzielenie ryzyk. <br> INFORMACJA: jeśli chcesz wyświetlać zadania, musisz włączyć opcję współdzielenia projektów.
+ShowInheritedRisksInListings             = Ryzyka odziedziczone - Zestawienia <br> (pochodzące z wyższych poziomów)
+ShowInheritedRisksInListingsDescription  = Ryzyka odziedziczone to ryzyka określone na wyższym poziomie (np. zakład lub GP) i automatycznie stosowane do GP/UT. <br> Włącz tę opcję, aby wyświetlać je w zestawieniach
+ShowInheritedRisksInDocuments            = Ryzyka odziedziczone - Dokumenty <br> (pochodzące z wyższych poziomów)
+ShowInheritedRisksInDocumentsDescription = Ryzyka odziedziczone to ryzyka określone na wyższym poziomie (np. zakład lub GP) i automatycznie stosowane do GP/UT. <br> Włącz tę opcję, aby wyświetlać je w dokumentach
+DigiriskElementInheritedRisksList        = Lista ryzyk odziedziczonych
+ConfirmImportSharedRisks                 = Wybierz ryzyka współdzielone do zaimportowania
+RisksRepartition                         = Rozkład ryzyk według oceny
+ShowRiskOrigin                           = Pokaż pochodzenie ryzyka
+ShowRiskOriginDescription                = Pokaż pochodzenie ryzyk w dokumentach (Ocena ryzyka zawodowego, Zgrupowanie, Jednostki pracy, Zestawienie ryzyk z działaniami i ze zdjęciami itp.).
+SharedRiskImportWithSuccess              = Ryzyko zaimportowane pomyślnie
+RiskImport                               = Import ryzyk
+RiskUnlink                               = Usunięcie ryzyka współdzielonego
+RiskDeleted                              = Ryzyko %s zostało usunięte
+RiskSharedWithEntityRefLabel             = Współdzielenie ryzyka %s z
+RiskUnlinkedFromEntityRefLabel           = Odłączenie ryzyka %s od
+TheDigiriskelement                       = element Digirisk
+DefaultProjectContactType                = Rola przypisywana domyślnie do projektu oceny ryzyka zawodowego
+DefaultTaskContactType                   = Rola przypisywana domyślnie do zadań projektu oceny ryzyka zawodowego
+RiskListParentView                       = Pokaż wszystkie elementy nadrzędne
+RiskListParentViewDescription            = Pokaż wszystkie elementy nadrzędne ryzyka na liście ryzyk i w dokumentach
+CategoryOnRisk                           = Pokaż tagi/kategorie na ryzykach
+CategoryOnRiskDescription                = Umożliwia przypisywanie tagów/kategorii do ryzyk i ich wyświetlanie - używać ostrożnie
+AddPsychosocialRisk                      = Dodaj ryzyko psychospołeczne
+AddPsychosocialRiskTitle                 = Dodanie ryzyka psychospołecznego
+AddPsychosocialRiskButton                = Dodaj ryzyko psychospołeczne
+AddSelectedPsychosocialRisks             = Dodaj wybrane ryzyka psychospołeczne
+SocialRelationsAtWork                    = Relacje społeczne w pracy
+WorkIntensityAndTime                     = Intensywność i czas pracy
+EmotionalRequirements                    = Wymagania emocjonalne
+Autonomy                                 = Autonomia
+MeaningOfWork                            = Sens pracy
+WorkSituationInsecurity                  = Niepewność sytuacji zawodowej
+PreventionContextInCompany               = Kontekst prewencji w przedsiębiorstwie
+RPSImpactOnCompanyAndEmployees           = Wpływ ryzyk psychospołecznych na przedsiębiorstwo i pracowników
+PsychosocialRisksFactors                 = Czynniki ryzyk psychospołecznych
+CompanyPreventionInformations            = Informacje o prewencji w przedsiębiorstwie
+Weak                                     = Niski
+Moderate                                 = Umiarkowany
+High                                     = Wysoki
+Extreme                                  = Ekstremalny
+HereIsTheWorkStationDescription          = Oto opis stanowiska pracy
+ImageAnalysis                            = Analiza obrazu
+TextAnalysis                             = Analiza tekstu
+AnalyzeText                              = Analizuj tekst
+EnterTextForAnalysis                     = Wprowadź tekst do analizy
+AIRiskAnalysis                           = Analiza ryzyk przez SI
+AnalysisInProgress                       = Trwa analiza...
+
+# Statystyki
+GreyRisk                                         = Ryzyko niskie
+OrangeRisk                                       = Ryzyko do zaplanowania
+RedRisk                                          = Ryzyko do obsłużenia
+BlackRisk                                        = Ryzyko niedopuszczalne
+RisksNotAssessed                                 = Ryzyka nieocenione
+RisksRepartitionByDangerCategories               = Rozkład ryzyk według kategorii zagrożenia
+RiskListsByDangerCategories                      = Lista ryzyk według kategorii zagrożenia
+DigiriskElementsRepartitionByDepth               = Rozkład struktury zgrupowań poziomu %s
+RisksRepartitionByDangerCategoriesAndCriticality = Rozkład ryzyk według kategorii zagrożenia i krytyczności
+NumberOfRisks                                    = Liczba ryzyk
+DangerCategories                                 = Kategorie zagrożenia
+RisksRepartitionByDigiriskElement                = Rozkład ryzyk według zgrupowania / jednostki pracy %s
+
+
+
+#
+# RiskEnvironmentals - Ryzyka środowiskowe
+#
+
+# Dane
+Environment                                    = Środowisko
+Riskenvironmental                              = Ryzyko środowiskowe
+RiskEnvironmentals                             = Ryzyka środowiskowe
+Riskenvironmentals                             = Ryzyka środowiskowe
+RiskEnvironmentalsMin                          = ryzyka środowiskowe
+AddRiskenvironmentalTitle                      = Dodanie ryzyka środowiskowego
+DigiriskElementRiskenvironmentalsList          = Lista ryzyk środowiskowych
+DigiriskElementInheritedRiskenvironmentalsList = Lista odziedziczonych ryzyk środowiskowych
+DigiriskElementSharedRiskenvironmentalsList    = Lista współdzielonych ryzyk środowiskowych
+ImportSharedRiskenvironmentals                 = Importuj współdzielone ryzyka środowiskowe
+SelectAllSharedRiskenvironmentalsOfElement     = Zaznacz wszystkie ryzyka środowiskowe tego elementu
+ConfirmImportSharedRiskenvironmentals          = Wybierz współdzielone ryzyka środowiskowe do zaimportowania
+EnvironmentDescription                         = Planowanie - Działania do wdrożenia wobec ryzyk i szans
+
+#
+# ListingRisksEnvironmentalAction - Zestawienie ryzyk środowiskowych z działaniami korygującymi
+#
+
+# Uprawnienie
+ListingRisksEnvironmentalActionMin = Zestawienie ryzyk środowiskowych z działaniami korygującymi
+
+# Dane
+ListingRisksEnvironmentalAction            = Zestawienie ryzyk środowiskowych z działaniami korygującymi
+Listingrisksenvironmentalaction            = Zestawienie ryzyk środowiskowych z działaniami korygującymi
+ListingRisksEnvironmentalActionGenerated   = Generowanie zestawienia ryzyk środowiskowych z działaniami korygującymi
+listingrisksenvironmentalaction.odt        = Zestawienie ryzyk środowiskowych z działaniami korygującymi
+listingrisksenvironmentalaction_custom.odt = Niestandardowe zestawienie ryzyk środowiskowych z działaniami korygującymi
+
+#
+# ListingRisksEnvironmentalDocument - Zestawienie ryzyk środowiskowych z dokumentami
+#
+
+# Dane
+ListingRisksEnvironmentalDocument = Zestawienie ryzyk środowiskowych
+
+
+
+#
+# RiskAssessment - Ocena
+#
+
+# Dane
+RiskAssessment                              = Ocena
+Riskassessment                              = Ocena
+RiskAssessments                             = Oceny
+RiskAssessmentCreated                       = Utworzenie oceny
+RiskAssessmentModified                      = Modyfikacja oceny
+RiskAssessmentDeleted                       = Usunięcie oceny
+RiskAssessmentConfig                        = Konfiguracja danych ocen
+TheRiskAssessment                           = Ocena
+LastRiskAssessment                          = Ostatnia ocena ryzyka
+RiskAssessmentWellCreated                   = Ocena została utworzona
+RiskAssessmentNotCreated                    = Błąd podczas tworzenia oceny
+RiskAssessmentWellEdited                    = Ocena została zmodyfikowana
+RiskAssessmentNotEdited                     = Błąd podczas modyfikacji oceny
+RiskAssessmentWellDeleted                   = Ocena została usunięta
+RiskAssessmentNotDeleted                    = Błąd podczas usuwania oceny
+EvaluationCreate                            = Dodanie oceny
+EvaluationEdit                              = Modyfikacja oceny
+EvaluationMethod                            = Metoda oceny
+lastEvaluationOn                            = Ostatnia ocena dnia
+DeleteEvaluation                            = Czy na pewno chcesz usunąć ocenę?
+DigiriskRiskAssessmentData                  = Konfigurowalne dane ocen
+MultipleRiskAssessmentMethodName            = Metody oceny
+MultipleRiskAssessmentMethodDescription     = Włącz zmianę metody oceny
+AdvancedRiskAssessmentMethod                = Zaawansowana metoda oceny
+AdvancedRiskAssessmentMethodDescription     = Włącz zaawansowaną metodę oceny
+RiskAssessmentList                          = Lista ocen ryzyka
+EditRiskAssessment                          = Modyfikuj ocenę
+ShowAllRiskAssessments                      = Zobacz wszystkie oceny
+ShowAllRiskAssessmentsDescription           = Pokaż pełną listę ocen ryzyk na liście ryzyk
+ParentRisk                                  = Ryzyko nadrzędne
+RiskAssessmentDate                          = Data oceny
+SimpleEvaluation                            = Ocena prosta
+AdvancedEvaluation                          = Ocena zaawansowana
+CalculatedEvaluation                        = Ocena obliczona
+SelectEvaluation                            = Zaznacz pola, aby obliczyć swoją ocenę
+EvaluationList                              = Lista ocen ryzyka
+HowToSetMultipleRiskAssessmentMethod        = Aby skonfigurować wielokrotne wykorzystanie metod oceny, przejdź do Konfiguracja modułu - Analiza ryzyk - Ocena
+NoFileLinked                                = Brak powiązanego zdjęcia
+AddRiskAssessment                           = Dodaj ocenę ryzyka
+AddRiskAssessmentTask                       = Dodaj zadanie do ryzyka
+ListRiskAssessmentTask                      = Lista zadań ryzyka
+ShowRiskAssessmentDate                      = Data ocen
+ShowRiskAssessmentDateDescription           = Zastępuje datę utworzenia datą rozpoczęcia ocen w karcie i w dokumentach
+RiskAssessmentHideDateInDocument            = Ukryj datę oceny w dokumentach
+RiskAssessmentHideDateInDocumentDescription = Ukryj datę oceny w kolumnie "Informacje o ocenie" w dokumentach
+RiskTaskComplete                            = Zadanie %s ukończone
+
+# Statystyki
+TasksRepartition = Rozkład zadań według zadeklarowanego rzeczywistego postępu
+TaskAt0Percent   = Zadanie na 0
+TaskInProgress   = Zadanie w toku
+TaskAt100Percent = Zadanie na 100
+
+
+#
+# RiskSign - Oznakowanie
+#
+
+# Uprawnienia
+RiskSignsMin = oznakowania
+
+# Dane
+RiskSign                           = Oznakowanie
+RiskSignCreated                    = Utworzenie oznakowania
+RiskSignModified                   = Modyfikacja oznakowania
+RiskSignDeleted                    = Usunięcie oznakowania
+TheRiskSign                        = Oznakowanie
+RiskSignConfig                     = Konfiguracja danych oznakowań
+RiskSignWellCreated                = Oznakowanie zostało utworzone
+RiskSignNotCreated                 = Błąd podczas tworzenia oznakowania
+RiskSignWellEdited                 = Oznakowanie zostało zmodyfikowane
+RiskSignNotEdited                  = Błąd podczas modyfikacji oznakowania
+RiskSignWellDeleted                = Oznakowanie zostało usunięte
+RiskSignNotDeleted                 = Błąd podczas usuwania oznakowania
+RiskSignCategory                   = Kategoria
+RiskSignImport                     = Import oznakowań
+RiskSignUnlink                     = Usunięcie oznakowania współdzielonego
+AddRiskSignTitle                   = Dodanie oznakowania
+AddRiskSignButton                  = Dodaj oznakowanie
+EditRiskSign                       = Modyfikacja oznakowania
+DeleteRiskSignMessage              = Usunięcie oznakowania
+DigiriskElementRiskSignList        = Lista oznakowań
+RiskSigns                          = Oznakowania
+DigiriskElementSharedRiskSignsList = Lista oznakowań współdzielonych
+ImportSharedRiskSigns              = Importuj oznakowania współdzielone
+SelectAllSharedRiskSignsOfElement  = Zaznacz wszystkie oznakowania tego elementu
+AlreadyImportedF                   = Już zaimportowane
+ShowSharedRiskSigns                = Oznakowania współdzielone
+ShowSharedRiskSignsDescription     = Pokaż oznakowania współdzielone w dokumentach i zestawieniach
+DigiriskElementSharedRiskSign      = Oznakowania współdzielone
+SharedRiskSigns                    = Oznakowania współdzielone
+ShareRisksign                      = Włącz współdzielenie oznakowań
+RISKSIGNSharing                    = Współdzielenie oznakowań
+RISKSIGNSharingDescription         = Wybór jednostek, które będą współdzielić swoje oznakowania z tą jednostką.
+UnlinkSharedRiskSign               = Odłącz oznakowanie współdzielone
+RiskSignWellUnlinkShared           = Oznakowanie zostało odłączone
+RiskSignNotUnlinkShared            = Błąd podczas odłączania oznakowania
+HasBeenUnlinkSharedF               = została odłączona
+HasNotBeenUnlinkSharedF            = nie została odłączona
+RiskSignSharedTooltip              = Ta opcja umożliwia współdzielenie oznakowań. <br> INFORMACJA: jeśli chcesz wyświetlać zadania, musisz włączyć opcję współdzielenia projektów.
+ShowInheritedRiskSigns             = Oznakowania odziedziczone
+ShowInheritedRiskSignsDescription  = Pokaż oznakowania odziedziczone w dokumentach i zestawieniach
+DigiriskElementInheritedRiskSignsList = Lista oznakowań odziedziczonych
+ConfirmImportSharedRiskSigns       = Wybierz oznakowania współdzielone do zaimportowania
+RiskSignSharedWithEntityRefLabel   = Współdzielenie oznakowania %s z
+RiskSignUnlinkedFromEntityRefLabel = Odłączenie oznakowania %s od
+
+#
+# Tasks - Zadanie
+#
+
+# Dane
+ActionPlan                               = Plan działania
+Task                                     = Zadanie
+TaskCreatedEvent                         = Utworzenie zadania
+TaskModifiedEvent                        = Modyfikacja zadania
+TaskDeletedEvent                         = Usunięcie zadania
+TheTask                                  = Zadanie
+TaskConfig                               = Konfiguracja danych zadań
+TaskWellCreated                          = Zadanie zostało utworzone
+TaskNotCreated                           = Błąd podczas tworzenia zadania
+TaskWellEdited                           = Zadanie zostało zmodyfikowane
+TaskNotEdited                            = Błąd podczas modyfikacji zadania
+TaskWellDeleted                          = Zadanie zostało usunięte
+TaskNotDeleted                           = Błąd podczas usuwania zadania
+TasksManagement                          = Zarządzanie zadaniami
+SelectProject                            = Wybór projektu
+DUProject                                = Projekt powiązany z zadaniami ryzyk
+EnvironmentProject                       = Projekt powiązany z zadaniami ryzyk środowiskowych
+NoTaskLinked                             = Brak zadań w toku
+TaskList                                 = Lista zadań ryzyka
+TaskCreate                               = Dodanie zadania
+TaskEdit                                 = Modyfikacja zadania
+HowToSetDUProject                        = Aby skonfigurować wybór projektu, przejdź do Konfiguracja modułu - Analiza ryzyk - Zadanie
+DeleteTask                               = Czy na pewno chcesz usunąć zadanie?
+ListingHeaderTask                        = Lista zadań
+ListingHeaderTaskTooltip                 = Włącz współdzielenie projektów, aby wyświetlać zadania
+TasksManagementDescription               = Włącz zarządzanie zadaniami
+TaskManagementNotActivated               = Włącz zarządzanie zadaniami w Konfiguracja modułu / Analiza ryzyk / Zadanie
+DigiriskProgress                         = Postęp
+ShowTaskStartDate                        = Data rozpoczęcia zadań
+ShowTaskStartDateDescription             = Zastępuje datę utworzenia datą rozpoczęcia zadań w karcie i w dokumentach
+ShowTaskEndDate                          = Data zakończenia zadań
+ShowTaskEndDateDescription               = Pokaż datę zakończenia zadań
+ShowTasksDone                            = Zadania ukończone
+ShowTasksDoneDescription                 = Pokaż zadania ukończone w 100
+ShowTasksDoneDescriptionExtend           = na listach ryzyk
+ShowTaskCalculatedProgress               = Postęp zadania
+ShowTaskCalculatedProgressDescription    = Pokaż obliczony postęp zadania zamiast postępu zadeklarowanego
+ShowAllTasks                             = Wszystkie zadania ryzyka w zestawieniach
+ShowAllTasksDescription                  = Pokaż wszystkie zadania na liście zadań ryzyka w zestawieniach
+DeleteTaskTimeSpent                      = Czy na pewno chcesz usunąć %s min poświęconego czasu z zadania?
+TaskTimeSpentEdit                        = Modyfikacja poświęconego czasu zadania
+TheTaskTimeSpent                         = Poświęcony czas
+TaskTimeSpentCreated                     = Utworzenie poświęconego czasu
+TaskTimeSpentModified                    = Modyfikacja poświęconego czasu
+TaskTimeSpentDeleted                     = Usunięcie poświęconego czasu
+TaskTimeSpentWellCreated                 = Poświęcony czas został utworzony
+TaskTimeSpentNotCreated                  = Błąd podczas tworzenia poświęconego czasu
+TaskTimeSpentWellEdited                  = Poświęcony czas został zmodyfikowany
+TaskTimeSpentNotEdited                   = Błąd podczas modyfikacji poświęconego czasu
+TaskTimeSpentWellDeleted                 = Poświęcony czas został usunięty
+TaskTimeSpentNotDeleted                  = Błąd podczas usuwania poświęconego czasu
+OnTheTask                                = w zadaniu
+TaskTimeSpentDuration                    = Czas trwania poświęconego czasu
+TaskTimeSpentDurationDescription         = Poświęcony czas dodawany domyślnie do każdego zadania
+NoTaskShared                             = Brak współdzielonych zadań
+WarningTaskLabel                         = Uwaga, przekroczono maksymalną dozwoloną liczbę znaków (255)
+ErrorRecordHasSubTasks                   = Zadanie ma elementy podrzędne
+TotalConsumedTime                        = Łączny poświęcony czas w projekcie
+TotalConsumedTimeAmount                  = Koszt poświęconego czasu
+NbTasks                                  = Liczba zadań
+TotalProgress                            = Całkowity rzeczywisty postęp zadań
+TotalBudget                              = Suma budżetu zadań
+TaskTimeSpentDate                        = Data poświęconego czasu
+StartDateCannotBeAfterEndDate            = Data zakończenia nie może być wcześniejsza niż data rozpoczęcia
+TasksFromProject                         = Wyświetlane zadania pochodzą z projektu określonego jako "Projekt oceny ryzyka zawodowego"
+TaskHideRefInDocument                    = Ukryj numer referencyjny
+TaskHideRefInDocumentDescription         = Ukryj numer referencyjny zadania w dokumentach
+TaskHideResponsibleInDocument            = Ukryj osobę odpowiedzialną
+TaskHideResponsibleInDocumentDescription = Ukryj osobę odpowiedzialną za zadanie w dokumentach
+TaskHideDateInDocument                   = Ukryj datę
+TaskHideDateInDocumentDescription        = Ukryj datę rozpoczęcia i zakończenia zadania w dokumentach
+TaskHideBudgetInDocument                 = Ukryj budżet
+TaskHideBudgetInDocumentDescription      = Ukryj budżet zadania w dokumentach
+
+#
+# DigiAI - DigiAI
+#
+
+# Dane
+WelcomeToDigiAI = Witamy w DigiAI
+UploadAnImage = Prześlij obraz
+OpenAIApiKey = Klucz API OpenAI
+OpenAIApiKeyDescription = Aby korzystać z DigiAI, musisz posiadać klucz API OpenAI. Możesz go uzyskać, zakładając konto na <a href="https://platform.openai.com/signup" target="_blank">https://platform.openai.com/signup</a>. Po rejestracji będziesz mógł wygenerować klucz API w sekcji "API Keys" swojego pulpitu.
+
+#
+# Ticket - Publiczny interfejs zgłoszeń
+#
+
+# Uprawnienia
+TicketTagsConfig                         = Modyfikacja rejestrów BHP
+
+# Dane
+Register                                 = Rejestr
+Send                                     = Wyślij
+TicketSent                               = Zgłoszenie wysłane
+FilesLinked                              = Zdjęcia / Załączniki
+AddDocument                              = Dodaj dokument
+LastnamePlaceholder                      = Przykład: Kowalski
+FirstnamePlaceholder                     = Przykład: Jan
+PhonePlaceholder                         = 00.00.00.00.00
+LocationPlaceholder                      = Przykład: Biuro A
+ServicePlaceholder                       = Przykład: Ładowacz
+Location                                 = Miejsce
+CategoriesCreated                        = Utworzenie kategorii zgłoszeń
+ExtrafieldsCreated                       = Utworzenie pól dodatkowych zgłoszeń
+AnticipatedLeave                         = Wcześniejsze wyjście
+DGI                                      = Poważne i bezpośrednie zagrożenie
+SST                                      = Bezpieczeństwo i higiena pracy
+PresquAccident                           = Zdarzenie potencjalnie wypadkowe
+Accident                                 = Wypadek
+EnhancementSuggestion                    = Propozycja usprawnienia
+MaterialProblem                          = Problem sprzętowy
+HumanProblem                             = Problem ludzki
+Others                                   = Inne
+AccidentWithoutDIAT                      = Lekki wypadek
+AccidentWithDIAT                         = Wypadek przy pracy
+Environment                              = Środowisko
+Quality                                  = Jakość
+NonCompliance                            = Niezgodność
+FirstName                                = Imię
+LastName                                 = Nazwisko
+Phone                                    = Telefon
+DeclarationDate                          = Zgłoszenie
+DigiriskTicketPublicAccess               = Publiczny interfejs niewymagający logowania jest dostępny pod następującym adresem URL
+TicketActivatePublicInterface            = Włącz publiczny interfejs
+GenerateExtrafields                      = Generowanie domyślnych pól dodatkowych zgłoszeń
+GenerateTicketCategories                 = Generowanie domyślnych kategorii zgłoszeń
+AlreadyGenerated                         = Już wygenerowane
+NotGenerated                             = Jeszcze niewygenerowane
+NotCreated                               = Jeszcze nieutworzone
+ExtrafieldsGeneration                    = Ta opcja umożliwia wygenerowanie domyślnych pól dodatkowych zgłoszeń. Utworzone zostaną pola: <br> Nazwisko, Imię, Telefon, GP/UT, Miejsce i Data
+CategoriesGeneration                     = Ta opcja umożliwia wygenerowanie domyślnych kategorii zgłoszeń. Utworzone zostaną kategorie: <br> - Rejestr <br> - - Wypadek <br> - - - Zdarzenie potencjalnie wypadkowe, Lekki wypadek, Wypadek przy pracy <br> - - Bezpieczeństwo i higiena pracy <br> - - - Wcześniejsze wyjście, Inne, Problem ludzki, Problem sprzętowy <br> - - Poważne i bezpośrednie zagrożenie <br> - - Jakość <br> - - - Niezgodność, Propozycja usprawnienia <br> - - Środowisko <br> - - - Niezgodność, Inne
+TicketSuccess                            = Twoje zgłoszenie zostało przekazane do działu prewencji pod numerem:
+TicketPublicAccess                       = Link powrotny do publicznego interfejsu zgłoszeń:
+TicketShowCompanyLogo                    = Pokaż logo firmy w publicznym interfejsie
+TicketShowCompanyLogoHelp                = Włącz tę opcję, aby ukryć logo firmy na stronach publicznego interfejsu
+YouMustNotifyYourHierarchy               = Masz <b>obowiązek</b> powiadomić swojego przełożonego
+GoBackToTicketCreation                   = Przejdź do strony śledzenia zgłoszeń
+SendEmailOnTicketSubmit                  = Wysyłaj e-maile przy tworzeniu
+CatTicketsList                           = Lista tagów/kategorii zgłoszeń
+SendEmailTo                              = Adres e-mail do powiadomienia
+SendEmailOnTicketSubmitHelp              = Włącz automatyczne wysyłanie e-maila przy tworzeniu zgłoszenia
+MultipleEmailsSeparator                  = Aby przypisać kilka adresów e-mail do powiadomienia, oddziel je znakiem ";". Na przykład: "aaaa@bbb.cc;dddd@eee.ff"
+TicketCategories                         = Kategorie zgłoszeń
+TicketDocumentsConfig                    = Dokumenty zgłoszeń
+TicketExtrafields                        = Pola dodatkowe zgłoszeń
+MainCategorySetting                      = Ta opcja umożliwia określenie kategorii, której podkategorie pojawią się w publicznym interfejsie
+TicketCategoriesInDocumentsSetting       = Ta opcja umożliwia wybór kategorii zgłoszeń wyświetlanych na liście zgłoszeń w dokumentach (Ocena ryzyka zawodowego, karta zgrupowania itp.). Jeśli nie wybrano żadnej kategorii, wyświetlane są wszystkie kategorie
+ParentCategorySetting                    = Ta opcja umożliwia określenie tytułu kategorii nadrzędnej dla publicznego interfejsu zgłoszeń
+ChildCategorySetting                     = Ta opcja umożliwia określenie tytułu kategorii podrzędnej dla publicznego interfejsu zgłoszeń
+TicketManagement                         = Zarządzanie zgłoszeniami
+MainCategory                             = Wybór kategorii głównej
+TicketCategoriesInDocuments              = Kategorie wyświetlane w dokumentach
+ParentCategoryLabel                      = Tytuł kategorii nadrzędnej
+ChildCategoryLabel                       = Tytuł kategorii podrzędnej
+TicketPublicInterfaceEnabled             = Publiczny interfejs zgłoszeń został włączony
+TicketPublicInterfaceDisabled            = Publiczny interfejs zgłoszeń został wyłączony
+TicketPublicInterface                    = Publiczny interfejs
+EmailsToNotifySet                        = Adresy e-mail do powiadomienia zostały zapisane
+MainCategorySet                          = Kategoria główna została określona
+TicketCategoriesInDocumentsSet           = Kategorie wyświetlane w dokumentach zostały określone
+ParentCategoryLabelSet                   = Tytuł kategorii nadrzędnej został określony
+ChildCategoryLabelSet                    = Tytuł kategorii podrzędnej został określony
+TicketPublicInterfaceConfigDocumentation = Aby skonfigurować publiczny interfejs zgłoszeń, zapoznaj się z dokumentacją
+ParentCategory                           = Kategoria nadrzędna
+TSProject                                = Projekt powiązany ze zgłoszeniami
+TicketDescription                        = Projekt zgłoszeń
+TicketProjectUpdated                     = Domyślny projekt zgłoszeń został zaktualizowany
+QRCodeAlreadyGenerated                   = Kod QR wygenerowany
+GenerateQRCode                           = Wygeneruj kod QR
+CompanyQRCodeGeneration                  = Generowanie kodu QR jednostki
+QRCodeGeneration                         = Generowanie kodu QR
+MultiCompanyQRCodeGeneration             = Generowanie kodu QR dla wielu jednostek
+TicketCreationMailWellSent               = E-mail potwierdzający utworzenie zgłoszenia został wysłany
+TicketCreationMailSent                   = E-mail o utworzeniu zgłoszenia został wysłany do %s
+HowToSetupTicketCategories               = Aby skonfigurować kategorie zgłoszeń, kliknij ten link:
+ConfigTicketCategories                   = Konfiguracja kategorii zgłoszeń
+NewTicketSubmitted                       = Zgłoszenie zostało przesłane przez publiczny interfejs
+ANewTicketHasBeenSubmitted               = Nowy rejestr bezpieczeństwa utworzony dla %s
+TicketCreationSubject                    = Utworzenie zgłoszenia przez publiczny interfejs Digirisk
+TicketDocumentCustomDigiriskTemplate     = Niestandardowy ODT kart zgłoszeń
+HowToSetupDigiriskElement                = Aby skonfigurować elementy Digirisk (zgrupowania/jednostki pracy), kliknij ten link:
+ConfigDigiriskElement                    = Konfiguracja elementów Digirisk
+ErrorFieldEmail                          = Błąd: adres e-mail musi być zgodny z następującym formatem: <b>'aaa@aaa.fr'</b>
+ErrorFieldPhone                          = Błąd: numer telefonu musi być zgodny z następującym formatem: <b>'0XXXXXXXXXXX'</b> lub <b>'+33XXXXXXXXX'</b>
+TicketEmailRequired                      = E-mail wymagany do utworzenia zgłoszenia
+TicketEmailRequiredHelp                  = Włącz tę opcję, aby podanie adresu e-mail było obowiązkowe przy tworzeniu zgłoszenia w publicznym interfejsie
+WelcomeToPublicTicketInterface           = Witamy w publicznym interfejsie zgłoszeń
+PleaseSelectAnEntity                     = Wybierz jednostkę:
+ShowSelectorOnTicketPublicInterface      = Pokaż selektor wielu jednostek w publicznym interfejsie zgłoszeń zamiast listy jednostek
+ShowSelectorOnTicketPublicInterfaceHelp  = Pokaż selektor wielu jednostek w publicznym interfejsie zgłoszeń zamiast listy jednostek z ich logo
+MultiEntityPublicInterface               = Publiczny interfejs zgłoszeń dla wielu firm
+TicketCategoriesNotCreated               = Nie utworzono kategorii zgłoszeń
+TicketPublicInterfaceQRCode              = Kod QR publicznego interfejsu zgłoszeń
+MultiEntityTicketPublicInterfaceQRCode   = Kod QR publicznego interfejsu zgłoszeń dla wielu firm
+PublicInterfaceConfiguration             = Widoczne / wymagane pola publicznego interfejsu
+TicketNumber                             = Nr zgłoszenia
+FromAndDate                              = Pochodzenie i data
+AuthorRequest                            = Zgłaszający
+DateCloture                              = Data zamknięcia
+
+PublicInterfaceUseSignatory              = Podpis wymagany do zgłoszenia tego rejestru
+ValidateText                             = Warunki do zaakceptowania przy podpisie
+TicketPublicInterfaceShowCategory        = Pokaż opis kategorii
+EmailTemplate                            = Szablon e-maila
+EmailTemplateDescription                 = Szablon e-maila
+
+OpenInNewTab                             = Otwórz w nowej karcie
+TicketDigiriskElementRequired            = GP/UT wymagane do utworzenia zgłoszenia
+TicketDigiriskElementRequiredHelp        = Włącz tę opcję, aby wybór GP/UT był obowiązkowy przy tworzeniu zgłoszenia w publicznym interfejsie
+TicketDigiriskElementHideRef             = Ukryj numer referencyjny GP/UT w selektorze działu publicznego interfejsu
+TicketDigiriskElementHideRefHelp         = Włącz tę opcję, aby ukryć numer referencyjny GP/UT w publicznym interfejsie
+TicketDigiriskelementVisible             = Pokaż pole GP/UT przy tworzeniu zgłoszenia
+TicketServiceVisible                     = Pokaż pole GP/UT przy tworzeniu zgłoszenia
+TicketDigiriskelementVisibleHelp         = Włącz tę opcję, aby pokazać pole GP/UT w publicznym interfejsie i w razie potrzeby uczynić je obowiązkowym
+TicketServiceVisibleHelp                 = Włącz tę opcję, aby pokazać pole GP/UT w publicznym interfejsie i w razie potrzeby uczynić je obowiązkowym
+TicketPhotoVisible                       = Pokaż pole Zdjęcie przy tworzeniu zgłoszenia
+TicketPhotoVisibleHelp                   = Włącz tę opcję, aby pokazać pole Zdjęcie w publicznym interfejsie
+TicketEmailVisible                       = Pokaż pole E-mail przy tworzeniu zgłoszenia
+TicketEmailVisibleHelp                   = Włącz tę opcję, aby pokazać pole E-mail w publicznym interfejsie i w razie potrzeby uczynić je obowiązkowym
+TicketLastnameVisible                    = Pokaż pole Nazwisko przy tworzeniu zgłoszenia
+TicketLastnameVisibleHelp                = Włącz tę opcję, aby pokazać pole Nazwisko w publicznym interfejsie i w razie potrzeby uczynić je obowiązkowym
+TicketFirstnameVisible                   = Pokaż pole Imię przy tworzeniu zgłoszenia
+TicketFirstnameVisibleHelp               = Włącz tę opcję, aby pokazać pole Imię w publicznym interfejsie i w razie potrzeby uczynić je obowiązkowym
+TicketPhoneVisible                       = Pokaż pole Telefon przy tworzeniu zgłoszenia
+TicketPhoneVisibleHelp                   = Włącz tę opcję, aby pokazać pole Telefon w publicznym interfejsie i w razie potrzeby uczynić je obowiązkowym
+TicketLocationVisible                    = Pokaż pole Miejsce przy tworzeniu zgłoszenia
+TicketLocationVisibleHelp                = Włącz tę opcję, aby pokazać pole Miejsce w publicznym interfejsie i w razie potrzeby uczynić je obowiązkowym
+TicketDateVisible                        = Pokaż pole Data przy tworzeniu zgłoszenia
+TicketDateVisibleHelp                    = Włącz tę opcję, aby pokazać pole Data w publicznym interfejsie i w razie potrzeby uczynić je obowiązkowym
+QRCodeGenerated                          = Kod QR wygenerowany
+FkTicket                                 = Powiązane zgłoszenie
+PublicTicket                             = Publiczny interfejs zgłoszeń
+TicketPublicInterfaceForbidden           = Dostęp do publicznego interfejsu zgłoszeń zabroniony
+DefaultUserGroup                         = Grupa domyślna
+DefaultUserGroupDescription              = Grupa domyślna w selektorach grup
+ConfigureDefaultUserGroup                = Skonfiguruj grupę domyślną
+RegisterSigned                           = Rejestr podpisany
+
+#Publiczny interfejs
+TicketPublicInterfaceShowCategoryDescription     = Pokaż opis kategorii zgłoszeń w publicznym interfejsie
+TicketPublicInterfaceShowCategoryDescriptionHelp = Włącz tę opcję, aby pokazać opis kategorii zgłoszeń w publicznym interfejsie
+
+
+# Statystyki
+TicketStatistics    = Statystyki zgłoszeń
+ExportCSV           = Eksport CSV
+GenerateCSV         = Wygeneruj plik CSV
+SuccessGenerateCSV  = Plik CSV %s został wygenerowany pomyślnie
+ErrorMissingData    = Błąd: nie udało się wygenerować pliku CSV, dane przesłane do pliku są nieprawidłowe. <br> Sprawdź, czy masz GP/UT przypisane do zgłoszeń.
+CSVFileExport       = Eksport rejestrów w formacie CSV powiązanych z GP/UT
+ThirdPartyHelp      = Jeśli filtr "Kontrahent" jest pusty, żaden kontrahent nie jest używany do wyszukiwania
+GP/UTHelp           = Domyślnie filtr uwzględnia wszystkie GP/UT
+CategoryTicketHelp  = Domyślnie filtr uwzględnia wszystkie kategorie
+CreatedByHelp       = Jeśli filtr "Utworzone przez" jest pusty, żaden użytkownik nie jest używany do wyszukiwania
+AssignedToHelp      = Jeśli filtr "Przypisane do" jest pusty, żaden użytkownik nie jest używany do wyszukiwania
+StatusHelp          = Domyślnie filtr uwzględnia wszystkie statusy<br>
+ConcernedTimePeriod = Uwzględniany okres
+LessThan            = Mniej niż
+MoreThan            = Więcej niż
+Comparator          = Operator porównania
+RangeNumber         = Ilość
+TimeRange           = Jednostka czasu
+RangeLabel          = Nazwa warunku
+Inferior            = Mniejsze niż
+Superior            = Większe niż
+TimeRangeAdded      = Warunek dodany
+TimeRangeDeleted    = Warunek usunięty
+
+NumberOfTicketsByMainCategorieAndDigiriskElement    = Liczba rejestrów według kategorii i według GP
+NumberOfTicketsByMainSubCategorieAndDigiriskElement = Liczba rejestrów według podkategorii i według GP
+NumberOfTicketsByYear                           = Liczba zgłoszeń według roku
+
+# Ticket Management Dashboard - Pulpit zarządzania zgłoszeniami
+TicketManagementDashboard                 = Pulpit zarządzania zgłoszeniami
+RunningTicket                             = Zgłoszenia w toku
+NbOfOpenedTicket                          = Liczba otwartych zgłoszeń
+OldestTicket                              = Najstarsze zgłoszenie
+OldestTicketDescription                   = Najstarsze zgłoszenie wraz z czasem od jego utworzenia
+OldestMessageTicket                       = Najstarsze zgłoszenie z wiadomością
+OldestMessageTicketDescription            = Najstarsze zgłoszenie z wiadomością wraz z czasem od utworzenia wiadomości
+MeanAnswerTime                            = Średni czas odpowiedzi
+MeanAnswerTimeDescription                 = Średni czas między otwarciem a zamknięciem, obliczany wyłącznie na zamkniętych zgłoszeniach
+MeanFirstResponseTime                     = Średni czas pierwszej odpowiedzi
+MeanFirstResponseTimeDescription          = Średni czas między otwarciem zgłoszenia a pierwszą wiadomością widoczną dla zgłaszającego. Notatki wewnętrzne nie są liczone, a zgłoszenia bez wiadomości publicznej są wykluczone z obliczeń
+NbTicketPerUser                           = Średnia liczba zgłoszeń przypisanych na osobę
+NbExchangePerTicket                       = Liczba wymian na zgłoszenie
+TicketRepartitionPerUserAndMeanAnswerTime = Rozkład zgłoszeń według użytkownika i średni czas odpowiedzi
+TopSocietyWithMostTickets                 = Top %s firm z największą liczbą zgłoszeń
+TicketsCreatedVersusClosedByMonth         = Zgłoszenia utworzone i zamknięte w ostatnich %s miesiącach
+TicketsCreated                            = Utworzone
+TicketsClosed                             = Zamknięte
+OpenTicketsByStatus                       = Rozkład otwartych zgłoszeń według statusu
+OpenTicketBacklogAge                      = Wiek otwartych zgłoszeń (od utworzenia)
+BacklogAgeUnderDays                       = Mniej niż %s dni
+BacklogAgeBetweenDays                     = Od %s do %s dni
+BacklogAgeOverDays                        = Więcej niż %s dni
+ShowSelectedDateTypes                     = Wybierz rodzaj daty do wyświetlenia
+
+# E-mail
+The                            = Dnia
+TicketMessage                  = Wiadomość rejestru
+SeeTicketUrl                   = Zobacz zgłoszenie
+AutoNotificationTicket         = Powiadomienie e-mail wysłane automatycznie przez
+TicketPublicInterfaceOtherName = Interfejs zarządzania rejestrami BHP oraz poważnych i bezpośrednich zagrożeń
+
+
+
+# Dokument zgłoszenia
+
+# Dane
+TicketDocument                 = Karta zgłoszenia
+Ticketdocument                 = Karta zgłoszenia
+ticketdocument.odt             = Karta zgłoszenia
+ticketdocument_custom.odt      = Niestandardowa karta zgłoszenia
+ticketdocument_events.odt      = Karta zgłoszenia ze zdarzeniami
+ticketdocument_sign.odt        = Karta zgłoszenia z podpisem
+ticketdocument_event_sign.odt  = Karta zgłoszenia ze zdarzeniem i podpisem
+TicketSuccessMessage           = Komunikat o powodzeniu zgłoszenia
+TicketSuccessMessageSet        = Komunikat został zmodyfikowany
+TicketDocumentPDF              = FT-A4-POZIOMO
+TicketDocumentPDFDescription   = Pokaż kartę zgłoszenia
+GeneratedTicketDocumentDate    = Data eksportu tego zgłoszenia
+
+
+# Dokument projektu
+
+# Szablon ODT
+DigiriskTemplateDocumentProject = Szablony dokumentów kart projektów Digirisk
+DocumentModelPapripactA3Paysage = Szablony dokumentu raportu prognostycznego dotyczącego zadań projektów
+PapripactFullName               = Roczny Program Zapobiegania Ryzykom Zawodowym i Poprawy Warunków Pracy
+
+# Dokument rejestru
+
+RegisterDocument     = Rejestr lekkich wypadków przy pracy
+Registerdocument     = Rejestr lekkich wypadków przy pracy
+RegisterDocumentsMin = rejestry lekkich wypadków przy pracy
+registerdocument.odt = Rejestr lekkich wypadków przy pracy
+
+#
+# Tools - Narzędzia
+#
+
+# Dane
+Tools                                        = Narzędzia
+DigiriskDataMigration                        = Zarządzanie danymi migracji
+DataMigrationImport                          = Import danych struktury Digirisk
+DataMigrationImportDescription               = Import danych struktury Digirisk WordPress w formacie ZIP
+DataMigrationImportRisks                     = Import danych ryzyk Digirisk
+DataMigrationImportRisksDescription          = Import danych ryzyk Digirisk WordPress w formacie ZIP
+ErrorFileNotWellFormatted                    = Plik ma nieprawidłowy format lub jest pusty. Musisz dołączyć plik importu pochodzący z Digirisk WordPress o nazwie DATE_OBJET_export.json
+ErrorFileNotWellFormattedZIP                 = Plik ma nieprawidłowy format lub jest pusty. Musisz dołączyć plik importu pochodzący z Digirisk WordPress o nazwie DATE_OBJET_export.zip
+ErrorJsonBadFormatted                        = Plik JSON nie jest poprawnie sformatowany
+SuccessImport                                = Import danych zakończony pomyślnie
+DataMigrationImportRiskSigns                 = Import danych oznakowań Digirisk
+DataMigrationImportRiskSignsDescription      = Import danych oznakowań Digirisk WordPress w formacie ZIP
+DataMigrationImportGlobal                    = Import danych globalnych Digirisk <br> (Struktura, ryzyka i oznakowania)
+DataMigrationImportGlobalDescription         = Import danych globalnych Digirisk WordPress w formacie ZIP <br> (Struktura, ryzyka i oznakowania)
+DataMigrationExportGlobal                    = Eksport danych globalnych Digirisk <br> (Struktura, ryzyka i oznakowania)
+DataMigrationExportGlobalDescription         = Eksport danych globalnych Digirisk Dolibarr w formacie ZIP <br> (Struktura, ryzyka i oznakowania)
+DataMigrationExportTree                      = Eksport struktury Digirisk <br> (Tylko struktura)
+DataMigrationExportTreeDescription           = Eksport struktury Digirisk Dolibarr w formacie ZIP <br> (GP/UT widoczne dla bieżącej jednostki, bez ryzyk i oznakowań)
+DataMigrationImportGlobalDolibarrDescription = Import danych globalnych Digirisk Dolibarr w formacie ZIP <br> (Struktura, ryzyka i oznakowania)
+DataMigrationTreeAlreadyImported             = Import danych struktury został już wykonany
+DataMigrationRisksAlreadyImported            = Import danych ryzyk został już wykonany
+DataMigrationRiskSignsAlreadyImported        = Import danych oznakowań został już wykonany
+DataMigrationGlobalAlreadyImported           = Import danych globalnych (Struktura, ryzyka i oznakowania) został już wykonany
+AdvancedImport                               = Import zaawansowany
+AdvancedImportDescription                    = Umożliwia zaimportowanie każdego elementu niezależnie (Struktura, ryzyka i oznakowania)
+DataMigrationWordPressToDolibarr             = Migracja danych z WordPress do Dolibarr
+DataMigrationDolibarrToDolibarr              = Migracja danych z Dolibarr do Dolibarr
+RepairRisks                                  = Napraw ryzyka
+NumberOfRisksCorrupted                       = Masz %s ryzyko(a) z uszkodzoną kategorią, przejdź na stronę "Narzędzia", aby je naprawić
+NoRiskToRepair                               = Brak ryzyk do naprawy
+DigiriskElementSuccessfullyRepaired          = Elementy Digirisk (GP/UT) zostały naprawione pomyślnie
+RiskSuccessfullyRepaired                     = Ryzyka zostały naprawione pomyślnie
+RiskAssessmentSuccessfullyRepaired           = Oceny zostały naprawione pomyślnie
+CorruptedCategoryOnRiskList                  = Lista ryzyk z uszkodzoną kategorią
+
+# Clean - Czyszczenie
+Clean                                          = Czyszczenie
+CleanObject                                    = Wyczyść dane
+CleanDigiriskElementExistParentDigiriskElement = %d elementów Digirisk (GP/UT) ma nieprawidłowy element nadrzędny
+CleanDigiriskElement                           = Wyczyść elementy Digirisk (GP/UT)
+CleanRiskFkElement                             = %d ryzyk ma nieprawidłowe GP/UT
+CleanRiskStatus                                = %d ryzyk ma nieprawidłowy status
+CleanRiskExistFkElement                        = %d ryzyk jest osieroconych
+CleanRiskExistRiskAssessment                   = %d ryzyk nie ma żadnej oceny
+CleanRisk                                      = Wyczyść ryzyka
+CleanRiskAssessmentStatus                      = %d ocen ma nieprawidłowy status
+CleanRiskAssessmentCotation                    = %d ocen ma pustą wartość
+CleanRiskAssessmentExistFkRisk                 = %d ocen jest osieroconych
+CleanRiskAssessment                            = Wyczyść oceny
+NoDigiriskElementToClean                       = Brak elementów Digirisk (GP/UT) do wyczyszczenia
+NoRiskToClean                                  = Brak ryzyk do wyczyszczenia
+NoRiskAssessmentToClean                        = Brak ocen do wyczyszczenia
+
+
+#
+# Inne
+#
+
+# Dane
+AT = do
+
+LabourInspectorName                 = DREETS
+UrlLabourInspector                  = https://travail-emploi.gouv.fr/ministere/organisation/article/dreets-directions-regionales-de-l-economie-de-l-emploi-du-travail-et-des
+IDCCTooltip                         = To pole pochodzi z modułu Digirisk dla Dolibarr <br> Nomenklatura układów zbiorowych pracy pochodzi z travail-emploi.gouv.fr
+NoEmailContact                      = Brak adresu e-mail przy tym kontakcie
+AddMedia                            = Dodaj plik multimedialny
+NoMediaLinked                       = Brak powiązanego pliku multimedialnego
+UserGroup                           = Grupa użytkowników
+ReaderGroup                         = Grupa czytelników
+UserCreated                         = Użytkownik został utworzony
+GetAPI                              = Korzystanie z tras API Digirisk metodą GET
+PostAPI                             = Korzystanie z tras API Digirisk metodą POST
+MinimizeMenu                        = Zwiń menu
+ActionsLine                         = Działania
+PhotoWellSent                       = Zdjęcie zostało dodane do biblioteki multimediów
+PhotoNotSent                        = Zdjęcie nie zostało poprawnie przesłane
+PhotoWellSaved                      = Plik(i) multimedialny(e) został(y) dodany(e)
+PhotoNotSaved                       = Plik(i) multimedialny(e) nie został(y) dodany(e)
+UseCaptcha                          = Kod graficzny (CAPTCHA)
+UseCaptchaDescription               = Korzystanie z kodu graficznego (CAPTCHA) na stronach publicznego interfejsu
+GP/UTParticipation                  = Udział GP/UT
+LabourDoctorName                    = AMETRA
+LabourDoctorFirstName               = Lekarz
+LabourDoctorLastName                = medycyny pracy
+DashBoard                           = Pulpit
+Close                               = Zamknij
+DateRange                           = Zakres dat
+UseDateRange                        = Użyj zakresu dat
+SiretNumber                         = Numer identyfikacji podatkowej
+Society                             = Firma
+MulticompanyTransverseModeEnabled   = Scentralizowane zarządzanie użytkownikami i grupami w jednostce głównej jest włączone.<br>Nie możesz zatem utworzyć użytkownika ani grupy w tej jednostce.<br>Przejdź do jednostki głównej, aby dokonać tego dodania.
+ManuelInputNBEmployees              = Wprowadź ręcznie liczbę pracowników
+ManuelInputNBEmployeesDescription   = Jeśli opcja jest włączona, możesz ręcznie wprowadzić liczbę pracowników w konfiguracji firmy.<br>W przeciwnym razie liczba pracowników jest obliczana.<br>Więcej informacji znajdziesz w dokumentacji.
+ManuelInputNBWorkedHours            = Wprowadź ręcznie liczbę przepracowanych godzin
+ManuelInputNBWorkedHoursDescription = Jeśli opcja jest włączona, możesz ręcznie wprowadzić liczbę przepracowanych godzin w konfiguracji firmy.<br>W przeciwnym razie liczba przepracowanych godzin jest obliczana.<br>Więcej informacji znajdziesz w dokumentacji.
+ShowPatchNoteAgain                  = Pokaż informacje o aktualizacji
+ShowPatchNoteAgainDescription       = Jeśli opcja jest włączona, informacja o aktualizacji bieżącej wersji pojawi się ponownie na stronie głównej Digirisk.<br>(Wymaga włączenia opcji «Pokaż informacje o aktualizacjach z GitHub», aby była widoczna.)
+HowToConfigureSetupConf             = Aby skonfigurować dane firmy powiązane z Digirisk,<br>przejdź do Digirisk - Konfiguracja - Ustawienia
+LabourDoctorNameFull                = Stowarzyszenie Lekarzy
+PermissionInheritedFromConfig       = Uprawnienia są dziedziczone z konfiguracji ogólnej lub z konfiguracji nadrzędnej
+CategorieManagement                 = Zarządzanie kategoriami
+ShowSelectedRiskTypes               = Wybierz rodzaje ryzyk do wyświetlenia
+CharRemaining                       = Pozostałe znaki
+NumberOfLinkedFiles                 = Liczba załączonych plików
+ChooseAnImage                       = Wybierz obraz
+
+# Action Plan - Gantt / Kanban
+ActionPlanGantt                     = Wykres Gantta
+ActionPlanKanban                    = Kanban
+ActionPlanView                      = Plan działania
+ColumnDraft                         = Wersja robocza
+ColumnInProgress                    = W toku
+ColumnInControl                     = Do sprawdzenia
+ColumnDone                          = Zakończone
+NoTasks                             = Brak działań korygujących
+ActionPlanGlobalProgress            = Ogólny postęp PAPRIPACT
+ActionPlanGlobalProgressInfo        = Średni postęp %s działania(ń) korygującego(ych)
+KanbanLoadMore                      = Zobacz więcej (%s)
+KanbanDisplay                       = Wyświetlanie Kanban
+KanbanPageSize                      = Liczba kart w kolumnie
+KanbanPageSizeDesc                  = Liczba działań korygujących wyświetlanych od razu w każdej kolumnie; kolejne są ładowane przyciskiem «Zobacz więcej» (poprawia wydajność przy dużych ilościach)
+KanbanDraftMax                      = Próg kolumny «Wersja robocza»
+KanbanDraftMaxDesc                  = Maksymalny postęp (%), przy którym działanie pozostaje w kolumnie «Wersja robocza»
+KanbanProgressMax                   = Próg kolumny «W toku»
+KanbanProgressMaxDesc               = Maksymalny postęp (%) dla kolumny «W toku»
+KanbanControlMax                    = Próg kolumny «Do sprawdzenia»
+KanbanControlMaxDesc                = Maksymalny postęp (%) dla kolumny «Do sprawdzenia»; powyżej działanie przechodzi do «Zakończone»
+PlannedWorkload                     = Przewidziane obciążenie
+TimeSpent                           = Poświęcony czas
+LinkedRisk                          = Powiązane ryzyko
+TaskMovedTo                         = Zadanie przeniesione do %s
+
+AddCategory                        = Dodaj kategorię
+SelectCategory                     = Wybierz kategorię
+DateEndBeforeStart                 = Data zakończenia wcześniejsza niż data rozpoczęcia
+InternalUsers                      = Użytkownicy wewnętrzni
+ExternalContacts                   = Kontakty zewnętrzne
+AddContributor                     = Dodaj współpracownika
+RemoveContact                      = Usuń kontakt
+ColumnWidth                        = Szerokość
+ColumnGap                          = Odstęp
+ActionPlanExportCsv                = Pobierz PAPRIPACT w formacie CSV
+ActionPlanExportA3                 = Pobierz PAPRIPACT w formacie PDF A3 poziomo
+ActionPlanExportGantt              = Pobierz wykres Gantta jako obraz PNG
+ActionPlanDisplayedProject         = Wyświetlany projekt
+ActionPlanChangeProject            = Zmień projekt
+ActionPlanDefaultProject           = Ocena ryzyka zawodowego (domyślnie)
+ActionPlanNoProjectConfigured      = Nie skonfigurowano żadnego projektu
+
+# ActionPlan — Rejestrowanie zdarzeń
+ActionPlanLogging                  = Plan działania — Historia zmian
+ActionPlanLoggingDescription       = Włącz tworzenie zdarzeń przy zmianach w Kanbanie
+ActionPlanLogLabel                 = Zmiana nazwy
+ActionPlanLogLabelDesc             = Utwórz zdarzenie, gdy nazwa zadania zostanie zmieniona
+ActionPlanLogWorkload              = Zmiana obciążenia
+ActionPlanLogWorkloadDesc          = Utwórz zdarzenie, gdy przewidziane obciążenie zostanie zmienione
+ActionPlanLogBudget                = Zmiana budżetu
+ActionPlanLogBudgetDesc            = Utwórz zdarzenie, gdy budżet zostanie zmieniony
+ActionPlanLogContributorAdd        = Dodanie współpracownika
+ActionPlanLogContributorAddDesc    = Utwórz zdarzenie, gdy współpracownik zostanie dodany
+ActionPlanLogContributorRemove     = Usunięcie współpracownika
+ActionPlanLogContributorRemoveDesc = Utwórz zdarzenie, gdy współpracownik zostanie usunięty
+ActionPlanLogProgress              = Zmiana postępu
+ActionPlanLogProgressDesc          = Utwórz zdarzenie, gdy postęp zostanie zmieniony
+ActionPlanLogTag                   = Zmiana tagów
+ActionPlanLogTagDesc               = Utwórz zdarzenie, gdy tag zostanie dodany lub usunięty
+ActionPlanLogDateStart             = Zmiana daty rozpoczęcia
+ActionPlanLogDateStartDesc         = Utwórz zdarzenie, gdy data rozpoczęcia zostanie zmieniona
+ActionPlanLogDateEnd               = Zmiana daty zakończenia
+ActionPlanLogDateEndDesc           = Utwórz zdarzenie, gdy data zakończenia zostanie zmieniona
+ActionPlanTaskLabelChanged         = Nazwa zmieniona: "%s" → "%s"
+ActionPlanTaskWorkloadChanged      = Obciążenie zmienione: %s → %s
+ActionPlanTaskBudgetChanged        = Budżet zmieniony: %s → %s
+ActionPlanTaskContributorAdded     = Współpracownik dodany: %s
+ActionPlanTaskContributorRemoved   = Współpracownik usunięty: ID %s
+ActionPlanTaskProgressChanged      = Postęp zmieniony: %s%% → %s%%
+ActionPlanTaskTagAdded             = Tag dodany: %s
+ActionPlanTaskTagRemoved           = Tag usunięty: ID %s
+ActionPlanTaskDateStartChanged     = Data rozpoczęcia zmieniona: %s → %s
+ActionPlanTaskDateEndChanged       = Data zakończenia zmieniona: %s → %s
+
+# ===========================================================================
+# Filtry planu działania — issue #4907 (GP/UT, poziom ryzyka, tagi)
+# ===========================================================================
+ActionPlanElement                    = GP/UT
+ActionPlanFilterElementChildren      = Z elementami podrzędnymi
+ActionPlanFilterElementChildrenHelp  = Uwzględnij działania korygujące GP/UT podrzędnych wobec wybranego GP/UT
+ActionPlanFilterScale                = Poziom ryzyka
+ActionPlanFilterAllScales            = Wszystkie poziomy
+ActionPlanFilterTags                 = Tagi
+ActionPlanFilterCount                = Wyświetlono %s działanie(ń) korygujące(ych) z %s
+ActionPlanDictionaries               = Listy Kanbana
+ActionPlanDictionariesDesc           = Zarządzaj wartościami proponowanymi na listach planu działania i Kanbanów
+ActionPlanTagDictionary              = Tagi działań korygujących
+ActionPlanTagDictionaryDesc          = Tagi (kategorie zadań) proponowane na kartach i w filtrze Kanbana planu działania
+ActionPlanTicketDictionaries         = Słowniki Kanbanów zgłoszeń
+ActionPlanTicketDictionariesDesc     = Rodzaje, grupy i poziomy istotności tworzące kolumny Kanbanów zgłoszeń
+ActionPlanManageDictionary           = Zarządzaj
+
+# ===========================================================================
+# Karta działania zgłoszenia — issue #4443 (interfejs 1 kliknięcia)
+# ===========================================================================
+TicketActionCard                     = Działanie zgłoszenia
+TicketActionCardPickerIntro          = Wybierz zgłoszenie, aby wykonać szybkie działanie jednym kliknięciem.
+TicketActionCardStatusSection        = Status
+TicketActionCardAssignSection        = Przypisanie
+TicketActionCardContentSection       = Treść
+TicketActionCardDangerSection        = Strefa wrażliwa
+TicketActionMarkRead                 = Oznacz jako przeczytane
+TicketActionInProgress               = Ustaw w toku
+TicketActionWaiting                  = Ustaw jako oczekujące
+TicketActionClose                    = Zamknij
+TicketActionCancel                   = Anuluj zgłoszenie
+TicketActionAssignSelf               = Przypisz do mnie
+TicketActionAssignOther              = Przypisz do...
+TicketActionAddMessage               = Dodaj wiadomość
+TicketActionLinkAccident             = Powiąż wypadek
+TicketActionOpenFull                 = Pełne szczegóły
+TicketActionMarkedRead               = Zgłoszenie oznaczone jako przeczytane
+TicketActionInProgressDone           = Zgłoszenie ustawione w toku
+TicketActionWaitingDone              = Zgłoszenie ustawione jako oczekujące
+TicketActionClosedDone               = Zgłoszenie zamknięte
+TicketActionCancelledDone            = Zgłoszenie anulowane
+TicketActionAssignedSelfDone         = Zgłoszenie przypisane do Ciebie
+TicketActionAssignedOtherDone        = Zgłoszenie przypisane
+TicketActionCloseConfirm             = Potwierdź zamknięcie
+TicketActionCancelConfirm            = Potwierdź anulowanie
+TicketActionCardRegistresSection      = Informacje o rejestrach
+TicketMessageTitle                    = Tytuł wiadomości
+TicketResponsibleAndProgress          = Osoba odpowiedzialna i postęp
+TicketActionCardClassificationSection = Klasyfikacja
+TicketActionCardDatesSection          = Kluczowe daty
+TicketActionCardIdentificationSection = Identyfikacja
+TicketActionCardOtherFieldsSection    = Inne informacje
+TicketActionCardEventsSection         = Ostatnie zdarzenia
+TicketActionCardRelatedSection        = Powiązane obiekty
+UnknownFieldToUpdate                  = Nieznane pole: %s
+Saved                                 = Zapisano
+SeeAll                                = Zobacz wszystko
+LayoutCustomize                       = Dostosuj
+LayoutDone                            = Zakończone
+LayoutControls                        = Elementy sterujące układem
+LayoutWidthHalf                       = Pół kolumny
+LayoutWidthFull                       = Cała kolumna
+LayoutWidthSpan                       = Pełna szerokość
+LayoutSaved                           = Układ zapisany
+LayoutReset                           = Przywróć
+LayoutResetTitle                      = Przywróć układ (powrót do wartości domyślnych)
+LayoutDensity                         = Gęstość wyświetlania
+LayoutDensityCompact                  = Kompaktowa
+LayoutDensityCozy                     = Komfortowa
+LayoutDensitySpacious                 = Przestronna
+AddTag                                = Dodaj tag
+TagAdded                              = Tag dodany
+TagRemoved                            = Tag usunięty
+Preview                               = Podgląd
+OpenInNewTab                          = Otwórz w nowej karcie
+FileDeleted                           = Plik usunięty
+OtherTicket                           = inne zgłoszenie
+OtherTickets                          = inne zgłoszenia
+SeeOtherTicketsForThisCompany         = Zobacz historię zgłoszeń tego klienta
+StatusTimeline                        = Oś czasu statusu
+WatchTicket                           = Obserwuj to zgłoszenie
+UnwatchTicket                         = Przestań obserwować to zgłoszenie
+TicketWatched                         = Zgłoszenie obserwowane
+TicketUnwatched                       = Zgłoszenie usunięte z obserwowanych
+WatchedTicket                         = Obserwowane zgłoszenie
+WatchedOnly                           = Tylko obserwowane
+AllTickets                            = Wszystkie
+NoWatchedTicket                       = Brak obserwowanych zgłoszeń
+FileUploaded                          = Plik przesłany
+UploadFile                            = Wybierz plik
+OrDropAnywhere                        = lub przeciągnij i upuść na kartę
+Messages                              = Wiadomości
+TypeYourReply                         = Wpisz swoją odpowiedź…
+PrivateMessage                        = Wiadomość prywatna
+Send                                  = Wyślij
+NoMessageYet                          = Brak wiadomości
+BeFirstToReply                        = Odpowiedz jako pierwszy
+MessagePosted                         = Wiadomość wysłana
+MessageEdited                         = Wiadomość zmodyfikowana
+MessageDeleted                        = Wiadomość usunięta
+ConfirmDeleteMessage                  = Usunąć tę wiadomość?
+ReplyByEmail                          = Wyślij e-mailem
+SentByMail                            = Wysłano e-mailem
+MailSentToNRecipients                 = e-mail wysłany do %d odbiorcy(ów)
+MailNotSent                           = nie udało się wysłać e-maila
+NoRecipientFound                      = nie znaleziono odbiorcy
+OriginalMessage                       = Wiadomość pierwotna
+JustNow                               = przed chwilą
+NMinAgo                               = %d min temu
+NHAgo                                 = %d godz. temu
+NDAgo                                 = %d dni temu
+NAttachedFiles                        = %d załączony(ch) plik(ów)
+Quote                                 = Cytuj
+NotAllowed                            = Działanie niedozwolone
+Private                               = Prywatne
+Unknown                               = Nieznane
+LayoutTagsMode                        = Wyświetlanie tagów
+LayoutTagsModeChips                   = Pełna lista (chipsy)
+LayoutTagsModeSelector                = Lista rozwijana
+LayoutActionsMode                     = Wyświetlanie działań
+LayoutActionsModeBar                  = Pasek działań
+LayoutActionsModeMenu                 = Menu (⋮)
+Move                                  = Przenieś
+Hide                                  = Ukryj
+Show                                  = Pokaż
+
+# ===========================================================================
+# Kanban zgłoszeń — konfiguracja rejestrowania zdarzeń — issue #4753
+# ===========================================================================
+TicketKanban                           = Kanban zgłoszeń
+TicketKanbanLogging                    = Kanban zgłoszeń — Historia zmian
+TicketKanbanLoggingDescription         = Włącz tworzenie zdarzeń przy zmianach w kanbanie
+TicketKanbanLogStatus                  = Zmiana statusu
+TicketKanbanLogStatusDesc              = Utwórz zdarzenie, gdy status zgłoszenia zostanie zmieniony przez kanban
+TicketKanbanLogAssignee                = Zmiana osoby przypisanej
+TicketKanbanLogAssigneeDesc            = Utwórz zdarzenie, gdy osoba przypisana do zgłoszenia zostanie zmieniona przez kanban
+TicketKanbanLogCategoryAdd             = Dodanie tagu
+TicketKanbanLogCategoryAddDesc         = Utwórz zdarzenie, gdy tag zostanie dodany do zgłoszenia przez kanban
+TicketKanbanLogCategoryRemove          = Usunięcie tagu
+TicketKanbanLogCategoryRemoveDesc      = Utwórz zdarzenie, gdy tag zostanie usunięty ze zgłoszenia przez kanban
+TicketKanbanLogType                    = Zmiana rodzaju
+TicketKanbanLogTypeDesc                = Utwórz zdarzenie, gdy rodzaj zgłoszenia zostanie zmieniony przez kanban
+TicketKanbanLogGroup                   = Zmiana grupy
+TicketKanbanLogGroupDesc               = Utwórz zdarzenie, gdy grupa zgłoszenia zostanie zmieniona przez kanban
+TicketKanbanLogSeverity                = Zmiana istotności
+TicketKanbanLogSeverityDesc            = Utwórz zdarzenie, gdy istotność zgłoszenia zostanie zmieniona przez kanban
+TicketKanbanLogSubject                 = Zmiana tematu
+TicketKanbanLogSubjectDesc             = Utwórz zdarzenie, gdy temat zgłoszenia zostanie zmieniony przez kanban
+TicketKanbanLogDeadline                = Zmiana terminu
+TicketKanbanLogDeadlineDesc            = Utwórz zdarzenie, gdy termin zgłoszenia zostanie zmieniony przez kanban
+TicketKanbanClosedLimit                = Limit zamkniętych zgłoszeń
+TicketKanbanClosedLimitDesc            = Maksymalna liczba zamkniętych/anulowanych zgłoszeń wyświetlanych w kanbanie (0 = bez ograniczeń)
+
+# ===========================================================================
+# Ticket — identyfikowalność zmian — issue #4885
+# ===========================================================================
+TicketLogModifications                 = Identyfikowalność zmian
+TicketLogModificationsDesc             = Utwórz zdarzenie dla każdej edycji wykonanej z karty zgłoszenia (temat, wiadomość, rejestry, osoba przypisana, kontrahent, projekt, postęp, status, zadania, dokumenty)
+TicketMessageEdited                    = Wiadomość zmodyfikowana
+TicketMessageDeleted                   = Wiadomość usunięta
+TicketTaskCreated                      = Zadanie utworzone: %s
+TicketDocumentGenerated                = Dokument wygenerowany
+TicketFileDeleted                      = Plik usunięty
+
+# Panel szybkiego tworzenia zgłoszenia
+SelectNothing                          = — Wybierz —
+QuickCreateTicket                      = Szybko utwórz zgłoszenie
+TicketSubjectPlaceholder               = Tytuł zgłoszenia...
+TicketInitialMessage                   = Wiadomość początkowa
+OptionalDescription                    = Opis (opcjonalnie)...
+Unassigned                             = Nieprzypisane
+QuickCreateAttachments                 = Załączniki
+QuickCreateDropzone                    = Przeciągnij i upuść lub kliknij, aby wybrać
+QuickCreateDropzoneActive              = Upuść tutaj…
+QuickCreateAttachmentHint              = Akceptowane formaty: obrazy, PDF, dokumenty. Maks. 10 MB na plik.
+QuickCreateTicketSuccess               = Zgłoszenie %s zostało utworzone pomyślnie.
+
+# MeteoVigilance - Ostrzeżenie pogodowe Météo-France
+MeteoVigilance = Ostrzeżenie pogodowe Météo-France
+MeteoVigilancePanelTitle = Ostrzeżenie %s
+MeteoVigilanceAdvice2 = Zachowaj uwagę
+MeteoVigilanceAdvice3 = Zachowaj szczególną czujność
+MeteoVigilanceAdvice4 = Najwyższa czujność
+MeteoVigilanceUpdatedAt = Zaktualizowano %s
+MeteoVigilanceEnabled = Włącz ostrzeżenia pogodowe
+MeteoVigilanceEnabledDescription = Wyświetla widget Ostrzeżenie pogodowe Météo-France na pulpicie (oraz pasek alertu w przypadku ostrzeżenia pomarańczowego/czerwonego).
+MeteoVigilanceLevel = Poziom ostrzeżenia
+MeteoVigilanceActivePhenomena = Aktywne zjawiska
+MeteoVigilanceNoAlert = Brak szczególnych ostrzeżeń
+MeteoVigilanceSource = Źródło
+MeteoVigilanceSeeOnMeteoFrance = Zobacz na vigilance.meteofrance.fr
+MeteoVigilanceNotConfigured = Klucz API Météo-France nie został skonfigurowany — kliknij, aby skonfigurować
+MeteoVigilanceUnknownDepartment = Nie ustalono departamentu firmy
+MeteoVigilanceUnavailable = Dane ostrzeżeń chwilowo niedostępne
+MeteoVigilanceBannerTitle = Ostrzeżenie %s obowiązuje w departamencie %s
+MeteoVigilanceLevel1 = Zielony
+MeteoVigilanceLevel2 = Żółty
+MeteoVigilanceLevel3 = Pomarańczowy
+MeteoVigilanceLevel4 = Czerwony
+MeteoVigilancePhenomenon1 = Silny wiatr
+MeteoVigilancePhenomenon2 = Deszcz i powódź
+MeteoVigilancePhenomenon3 = Burze
+MeteoVigilancePhenomenon4 = Wezbrania
+MeteoVigilancePhenomenon5 = Śnieg i gołoledź
+MeteoVigilancePhenomenon6 = Fala upałów
+MeteoVigilancePhenomenon7 = Silny mróz
+MeteoVigilancePhenomenon8 = Lawiny
+MeteoVigilancePhenomenon9 = Fale i zalanie wybrzeża
+MeteoVigilanceSetup = Konfiguracja ostrzeżeń pogodowych
+MeteoVigilanceApiKey = Klucz API Météo-France
+MeteoVigilanceApiKeyDescription = Klucz API portalu Météo-France (utwórz konto i aplikację «Bulletin Vigilance» na <a href="https://portail-api.meteofrance.fr" target="_blank">portail-api.meteofrance.fr</a>, aby wygenerować klucz).
+MeteoVigilanceDepartment = Kod departamentu (nadpisanie)
+MeteoVigilanceDepartmentDescription = Pozostaw puste, aby automatycznie ustalić departament na podstawie adresu firmy. W przeciwnym razie wpisz kod (np. 35, 2A).
+MeteoVigilanceCacheTTL = Czas trwania pamięci podręcznej (sekundy)
+MeteoVigilanceCacheTTLDescription = Czas, przez jaki dane API są przechowywane w pamięci podręcznej przed kolejnym wywołaniem (domyślnie 3600).
+MeteoVigilanceSettings = Konfiguracja ostrzeżeń pogodowych
+MeteoVigilanceRefreshNow = Odśwież teraz
+MeteoVigilanceRefreshed = Dane odświeżone: ostrzeżenie %s w departamencie %s
+
+# System konwersacji zgłoszeń
+Conversation = Konwersacja
+PublicMessage = Wiadomość publiczna
+ConvTo = Do
+ConvCc = DW
+
+SaveNote = Zapisz notatkę
+
+AddRecipient = Dodaj odbiorcę
+NoRecipientFound = Brak odbiorcy
+
+AddFile = Dodaj plik
+
+MentionAgents = Wspomnij pracowników
+YouWereMentionedOnTicket = Zostałeś wspomniany w zgłoszeniu %s
+YouWereMentionedOnTicketBody = %s wspomniał(a) Cię w zgłoszeniu %s:
+
+Mentioned = Wspomniany
+
+# Szybkie mobilne tworzenie planu prewencji
+MobileQuickCreation = Szybkie tworzenie mobilne
+MobilePPInteriorCompany = Przedsiębiorstwo użytkujące (wewnętrzne)
+MobilePPResponsibleAutoSign = Osoba odpowiedzialna (podpisuje automatycznie)
+MobilePPSignatureSaved = Podpis zapisany
+MobilePPEditSignature = Zmodyfikuj podpis
+MobilePPDrawSignatureHint = Narysuj poniżej swój podpis, a następnie go zapisz. Zostanie użyty ponownie w kolejnych planach.
+MobilePPClearSignature = Wyczyść
+MobilePPSaveSignature = Zapisz mój podpis
+MobilePPExteriorCompany = Przedsiębiorstwo zewnętrzne
+MobileSirenOrSiret = SIREN / SIRET
+MobileSirenOrSiretPlaceholder = 9 lub 14 cyfr
+MobilePPResponsibleToSign = Osoba odpowiedzialna do podpisu
+MobilePPChooseExistingContact = Wybierz istniejący kontakt
+MobilePPNewContact = Nowy kontakt
+MobilePPEmailForSignatureHelp = Na ten adres e-mail zostanie wysłana prośba o podpis.
+MobilePPPeriod = Okres realizacji prac
+MobilePPMaxOneYearHint = Maksymalnie 1 rok między datą rozpoczęcia a datą zakończenia.
+MobilePPSubmit = Utwórz plan prewencji
+MobilePPErrorNoSignature = Musisz zapisać swój podpis przed utworzeniem planu.
+MobilePPErrorEmptySignature = Podpis jest pusty.
+MobilePPErrorInvalidSiren = Nieprawidłowy SIREN lub SIRET (oczekiwano 9 lub 14 cyfr).
+MobilePPErrorEndBeforeStart = Data zakończenia musi być późniejsza niż data rozpoczęcia.
+MobilePPErrorMaxOneYear = Czas trwania nie może przekraczać 1 roku.
+MobilePPErrorDatesRequired = Podaj datę rozpoczęcia i datę zakończenia.
+MobilePPErrorStartRequired = Brakuje daty rozpoczęcia.
+MobilePPErrorEndRequired = Brakuje daty zakończenia.
+MobilePPErrorNoProject = Nie skonfigurowano domyślnego projektu planu prewencji.
+MobilePPCompanyFound = Znaleziono przedsiębiorstwo:
+MobilePPCompanyNotFound = Nie znaleziono przedsiębiorstwa w bazie danych: zostanie utworzone nowe.
+MobilePPWarningEmailNotSent = Plan został utworzony, ale nie udało się wysłać e-maila z prośbą o podpis.
+MobilePPWarningEmailNotConfigured = Plan został utworzony, ale e-mail nie jest skonfigurowany: prośba o podpis nie została wysłana.
+MobilePPCreated = Plan prewencji %s został utworzony.
+MobilePPUpdated = Plan prewencji %s został zaktualizowany.
+MobilePPSignatureEmailSubject = Prośba o podpisanie planu prewencji %s
+MobilePPSignatureEmailContent = Dzień dobry,<br><br>Zapraszamy do podpisania planu prewencji dotyczącego %s.<br><br><a href="%s">Kliknij tutaj, aby podpisać</a><br><br>Z poważaniem.
+MobilePPSuccessTitle = Plan prewencji utworzony
+MobilePPSuccessText = Osoba odpowiedzialna wewnętrzna podpisała automatycznie. Prośba o podpis została wysłana do przedsiębiorstwa zewnętrznego.
+MobilePPViewPlan = Zobacz plan
+MobilePPCreateAnother = Utwórz kolejny plan
+MobileSuccessInteriorSigned = Osoba odpowiedzialna wewnętrzna: podpisano
+MobileSuccessExteriorNotified = Przedsiębiorstwo zewnętrzne: prośba o podpis wysłana
+MobileSuccessExteriorNotSigned = Przedsiębiorstwo zewnętrzne: podpis do uzyskania
+MobileSuccessExteriorNotNotified = Przedsiębiorstwo zewnętrzne: prośba o podpis niewysłana
+MobileSuccessExteriorSigned = Przedsiębiorstwo zewnętrzne: podpisano
+MobileSuccessDocumentGenerated = Dokument planu wygenerowany
+MobilePPWarningEmailNotSentDetail = Nie udało się wysłać e-maila z prośbą o podpis: %s
+MobilePPWarningNoRecipientEmail = brak prawidłowego adresu e-mail osoby odpowiedzialnej zewnętrznej
+MobilePPSignatureEmailSentTo = Prośba o podpis wysłana do %s
+MobilePPExtSignatureTitle = Podpis przedsiębiorstwa zewnętrznego
+MobilePPExtEmailSentOn = Prośba wysłana do %s dnia %s
+MobilePPExtEmailNotSent = Prośba o podpis niewysłana: przekaż link lub uzyskaj podpis teraz
+MobilePPSpreadDefaultsTitle = Publiczne wyświetlanie rozpowszechniania
+MobilePPSpreadShowCount = Pokaż liczbę sygnatariuszy
+MobilePPSpreadShowName = Pokaż imię i nazwisko
+MobilePPSpreadShowContact = Pokaż telefon i e-mail
+MobilePPSpreadHidePublicNote = Nie pokazuj notatki publicznej
+MobilePPExtAlreadySigned = Podpisano dnia %s
+MobilePPExtSignNow = Uzyskaj podpis teraz
+MobilePPExtResendEmail = Wyślij ponownie e-mail
+MobilePPNoTagAvailable = Brak dostępnych tagów planu prewencji.
+MobilePPCreateTag = Utwórz tag
+MobileSpreadShareTitle = Udostępnij rozpowszechnianie
+MobileSpreadShareText = Poproś zainteresowane osoby o zeskanowanie tego kodu. Bez konta i bez logowania podają swoje dane kontaktowe, przesyłają dokumenty i podpisują.
+MobileSpreadOpen = Otwórz rozpowszechnianie
+MobilePPRisks = Ryzyka
+MobilePPAddRisk = Dodaj ryzyko
+MobilePPRiskModalTitle = Wybierz ryzyko
+MobilePPRiskComment = Komentarz
+MobilePPRiskDescriptionPlaceholder = Opisz ryzyko na terenie zakładu
+MobilePPNoRiskYet = Nie dodano jeszcze żadnego ryzyka.
+MobilePPDeleteRiskTitle = Usuń ryzyko
+MobilePPDeleteRiskConfirm = «%s» zostanie usunięte z planu wraz z opisem, zdjęciami i środkami ochrony.
+MobilePPUserCompany = Przedsiębiorstwo użytkujące
+MobilePPUserCompanyShort = EU
+MobilePPConcernedCompanies = Dotyczy
+MobilePPExteriorCompanyShort = EE
+MobilePPPriorFormalities = Formalności wstępne
+MobilePPPriorVisitDone = Wspólna kontrola wstępna przeprowadzona
+MobilePPPriorVisitTextPlaceholder = Co stwierdzono podczas kontroli
+MobileRiskCompanies = Przedsiębiorstwa objęte ryzykami (mobilne)
+CertificationDictionary = Certyfikaty i uprawnienia
+MobilePPChooseExistingCompany = Wybierz istniejącego kontrahenta
+MobilePPOrFillManually = lub wprowadź informacje
+MobilePPProtections = Środki ochrony
+MobilePPAddProtection = Dodaj środek ochrony
+MobilePPProtectionModalTitle = Wybierz środek ochrony
+MobilePPMandatory = Obowiązkowe
+MobileProtections = Środki ochrony (mobilne)
+MobilePPCertifications = Wymagane certyfikaty
+MobilePPAddCertification = Dodaj certyfikat
+MobileCertifications = Certyfikaty (mobilne)
+MobilePPUploadCertPhoto = Prześlij zdjęcie
+MobilePPErrorCreatingThirdparty = Błąd podczas tworzenia kontrahenta.
+MobilePPErrorCreatingContact = Błąd podczas tworzenia kontaktu.
+MobilePPErrorUpdatingPlan = Błąd podczas aktualizacji planu prewencji.
+MobilePPErrorCreatingPlan = Błąd podczas tworzenia planu prewencji.
+MobileSuccessViewDocument = Zobacz dokument
+MobileSuccessPlanSentByEmailOn = Plan prewencji wysłany e-mailem dnia %s
+MobileSuccessExteriorSignedOn = Osoba odpowiedzialna Przedsiębiorstwa Zewnętrznego (EE): Podpisano dnia %s
+MobileSuccessExteriorPendingSignature = Osoba odpowiedzialna Przedsiębiorstwa Zewnętrznego (EE): Oczekuje na podpis
+MobilePPDefaultsTitle = Wartości domyślne (tworzenie mobilne)
+MobilePPDefaultDateStartToday = Data rozpoczęcia = data dzisiejsza
+MobilePPDefaultDuration = Domyślny czas trwania okresu (dni)
+MobilePPEmailAutoSend = Automatycznie wysyłaj e-mail z prośbą o podpis przy tworzeniu
+
+# Szybkie mobilne tworzenie zezwolenia na prace pożarowe
+MobileFPPreventionPlanHelp = Przedsiębiorstwo zewnętrzne i okres wybranego planu są przejmowane automatycznie.
+MobileFPPeriod = Miejsce i okres prac
+MobileFPMaxOneMonthHint = Maksymalnie jeden miesiąc między rozpoczęciem a zakończeniem prac.
+MobileFPErrorMaxOneMonth = Czas trwania nie może przekraczać jednego miesiąca.
+MobileFPErrorNoProject = Nie skonfigurowano domyślnego projektu zezwolenia na prace pożarowe.
+MobileFPWorkTypes = Rodzaje prac
+MobileFPAddWorkType = Dodaj rodzaj prac
+MobileFPWorkTypeModalTitle = Wybierz rodzaj prac
+MobileFPSubmit = Utwórz zezwolenie na prace pożarowe
+MobileFPCreated = Zezwolenie na prace pożarowe %s zostało utworzone.
+MobileFPUpdated = Zezwolenie na prace pożarowe %s zostało zaktualizowane.
+MobileFPSignatureEmailSubject = Prośba o podpisanie zezwolenia na prace pożarowe %s
+MobileFPSignatureEmailContent = Dzień dobry,<br><br>Zapraszamy do podpisania zezwolenia na prace pożarowe dla %s.<br><br><a href="%s">Kliknij tutaj, aby podpisać</a><br><br>Z poważaniem.
+MobileFPSuccessTitle = Zezwolenie na prace pożarowe utworzone
+MobileFPViewPermit = Zobacz zezwolenie
+MobileFPCreateAnother = Utwórz kolejne zezwolenie
+
+# Digirisk PWA
+PwaApplication = Aplikacja mobilna
+PwaNavHome = Start
+PwaNavPreventionPlans = Plany
+PwaNavFirePermits = Zezwolenia
+PwaNavMenu = Menu
+PwaNavFavoritesHint = Ulubione wyświetlane na dole (maks. %s)
+PwaNavAddFavorite = Dodaj do ulubionych
+PwaNavRemoveFavorite = Usuń z ulubionych
+PwaHello = Dzień dobry %s
+PwaResultCount = %s wynik(ów)
+AllStatus = Wszystkie statusy
+PwaTilePreventionPlanInProgress = Plany w toku
+PwaTilePreventionPlanToSign = Plany do podpisu
+PwaTileFirePermitInProgress = Zezwolenia w toku
+PwaTileFirePermitToSign = Zezwolenia do podpisu
+
+# Działania masowe na zadaniach
+MassValidateTasks = Zatwierdź zadania
+MassChangeTasksProject = Zmień projekt
+ConfirmMassValidateTasksQuestion = Czy na pewno chcesz zatwierdzić %s wybrane zadanie(a)? Zatwierdzone zostaną wyłącznie zadania o statusie wersja robocza.
+ConfirmMassChangeTasksProjectQuestion = Czy na pewno chcesz przypisać %s wybrane zadanie(a) do wybranego projektu?
+MassValidateTasksSuccess = Zatwierdzono %s zadanie(a) z %s wybranych
+MassChangeTasksProjectSuccess = Przypisano %s zadanie(a) do projektu %s
+
+# PDF planu prewencji
+PreventionPlanLegalNotice = Plan prewencji jest dokumentem obowiązkowym, mającym na celu zapobieganie ryzykom wynikającym z nakładania się działalności kilku przedsiębiorstw na tym samym terenie, zgodnie z artykułem R4512-7 francuskiego kodeksu pracy.
+PreventionPlanUserCompany = Przedsiębiorstwo Użytkujące - EU
+PreventionPlanExteriorCompany = Przedsiębiorstwo Zewnętrzne - EE
+PreventionPlanUserCompanyResponsible = Osoba odpowiedzialna Przedsiębiorstwa Użytkującego (EU)
+PreventionPlanExteriorCompanyResponsible = Osoba odpowiedzialna Przedsiębiorstwa Zewnętrznego (EE)
+EmergencyNumbers = Numery alarmowe
+Firefighters = Straż pożarna
+AnyEmergency = Wszelkie zagrożenia
+PriorVisitIntro = Przedsiębiorstwo użytkujące przeprowadziło, przed rozpoczęciem prac, wspólną kontrolę wstępną w dniu %s. Podczas tej wizyty przedsiębiorstwo użytkujące przedstawiło następujące punkty (art. R. 4512-2 i R. 4512-3 francuskiego kodeksu pracy):
+PriorVisitCheckList = Miejsca pracy|Znajdujące się tam instalacje|Sprzęt ewentualnie udostępniony przedsiębiorstwom zewnętrznym|Wyznaczenie obszaru prac przedsiębiorstw zewnętrznych|Oznaczenie stref tego obszaru, które mogą stwarzać zagrożenie dla pracowników|Wskazanie dróg komunikacyjnych, z których mogą korzystać pracownicy oraz pojazdy i maszyny wszelkiego rodzaju należące do przedsiębiorstw zewnętrznych|Określenie dróg dostępu pracowników do pomieszczeń i instalacji przeznaczonych dla EE (w szczególności urządzeń sanitarnych, szatni zbiorowych i pomieszczeń do spożywania posiłków)
+PriorVisitComments = Odnotowano następujące uwagi:
+InterventionPeriodSentence = Ten plan rozpoczyna się %s i kończy %s. Prace będą realizowane w następujących godzinach:
+RiskAnalysisIntro = Przewidziano %s prac(y) dla tego planu prewencji: poniżej szczegóły przewidzianych czynności, generowane ryzyka oraz wdrożone środki prewencji.
+PreventionPlanAttendants = Wykonawcy: Przedsiębiorstwo Zewnętrzne (EE) i podwykonawcy
+Morning = Rano
+Afternoon = Po południu
+Signatures = Podpisy
+SignaturePending = Oczekuje
+PreventionPlanRiskPhotos = Zdjęcia ryzyka
+InterventionPeriodOnly = Ten plan rozpoczyna się %s i kończy %s.
+
+DigiRisk=DigiRisk
+DigiriskIdentification=OPIS I CHARAKTERYSTYKA
+DigiriskSecurity=BEZPIECZEŃSTWO
+DigiriskUserManual=UPROSZCZONA INSTRUKCJA OBSŁUGI
+DigiriskQualification=KWALIFIKACJE I UPRAWNIENIA
+DigiriskHygiene=HIGIENA I CZYSZCZENIE
+DigiriskMaintenance=KONSERWACJA I KONTROLE
+DangerCategory=Rodzina ryzyka
+SelectDangerCategory=Wybierz rodzinę ryzyka
+DescribeRiskOnProduct=Opisz ryzyko dotyczące tego produktu...
+ConfirmDeleteProductRisk=Usunąć to ryzyko?
+AddProductRisk=Dodaj ryzyko produktu
+ClickToAddContent=Kliknij, aby dodać treść...
+AddProtection=Dodaj środek ochrony
+
+SelectProtection=Wybierz środek ochrony indywidualnej
+TechnicalSheet=Karta techniczna
+DigiriskRisks=RYZYKA I ŚRODKI OCHRONY
+MobileSuccessInteriorSignedOn=Osoba odpowiedzialna Przedsiębiorstwa Użytkującego (EU): Podpisano dnia %s
+
+MobileSuccessPlanSentByEmailOn = Plan prewencji wysłany e-mailem dnia %s
+MobileSuccessExteriorSignedOn = Osoba odpowiedzialna Przedsiębiorstwa Zewnętrznego (EE): Podpisano dnia %s
+MobileSuccessExteriorPendingSignature = Osoba odpowiedzialna Przedsiębiorstwa Zewnętrznego (EE): Oczekuje na podpis
+
+MobilePPErrorInvalidEmail = Zachowaj poprawny format adresu e-mail.
+MobilePPErrorInvalidPhone = Zachowaj poprawny format numeru telefonu.
+MobilePPExtSendEmail = Wyślij e-mail
+MobilePPErrorMailServerNotConfigured = Twój serwer poczty nie jest skonfigurowany, skontaktuj się z administratorem.
+MobilePPDoliletterNotInstalled = Moduł Doliletter nie jest zainstalowany. Rozpowszechnianie planów prewencji i zezwoleń na prace pożarowe nie będzie dostępne (skontaktuj się z administratorem)
+
+# Statusy i rodzaje dla podpowiedzi
+preventionplan = Plan prewencji
+Locked = Zablokowany
+InProgress = W toku
+ValidatePendingSignature = Oczekuje na podpis
+Archived = Zarchiwizowany
+
+ProductFIChaptersManagement=Dostosowanie rozdziałów karty instruktażowej
+ProductFIChaptersManagementSub=Dostosowanie zakładki "Karta instruktażowa" oraz zakładki "Ryzyka" w karcie produktu
+DefaultContent=Treść domyślna
+CustomSvgUploaded=Niestandardowy SVG
+DeleteCustomSvg=Usuń
+DefaultSvgUsed=Domyślny SVG
+
+PwaTilePreventionPlanLocked = Zatwierdzone plany
+PwaTileFirePermitLocked = Zatwierdzone zezwolenia
+
+# ===========================================================================
+# Słownik kolumn Kanbana planu działania — issue #5017
+# ===========================================================================
+ActionPlanColumnDictionary           = Kolumny Kanbana planu działania
+ActionPlanColumnDictionaryDesc       = Kolumny wyświetlane w Kanbanie PAPRIPACT, gdy tryb słownika jest włączony: nazwa, zakres postępu, kolor i ikona
+KanbanColumnSource                   = Źródło kolumn
+KanbanColumnSourceDesc               = Podziel Kanban za pomocą poniższych progów procentowych (działanie historyczne) lub za pomocą słownika kolumn
+KanbanColumnSourceThresholds         = Progi procentowe (domyślnie)
+KanbanColumnSourceDictionary         = Słownik kolumn
+ActionPlanColumnProgressHelp         = Granice postępu objęte kolumną, od 0 do 100
+ActionPlanColumnColorHelp            = Kolor szesnastkowy kolumny, na przykład #3085d6
+ActionPlanColumnPictoHelp            = Nazwa ikony Font Awesome, na przykład fa-check
+Progress_min                         = Postęp min.
+Progress_max                         = Postęp maks.
+Picto                                = Ikona
+
+# Ewidencja poświęconego czasu
+GenerateTimeSpentReport = Wygeneruj ewidencję czasu (PDF)
+TimeSpentReport = Ewidencja poświęconego czasu
+TimeSpentReportUsersHelp = Pozostaw puste, aby uwzględnić wszystkie osoby, które zarejestrowały czas w tym projekcie.
+TimeSpentReportSummary = Podsumowanie według użytkownika
+TimeSpentReportGrandTotal = Suma całkowita
+TimeSpentReportGeneratedAt = Wygenerowano
+TimeSpentReportWholePeriod = Od początku projektu
+TimeSpentReportNoData = Żaden poświęcony czas nie odpowiada wybranym użytkownikom i okresowi.
+TimeSpentDocumentPDFDescription = Czas poświęcony na projekt, pogrupowany według użytkownika
+
+# Ujednolicenie mobilnego zezwolenia na prace pożarowe z planem prewencji - issue #5042
+MobileProgress = Postęp
+MobileStepDone = WYKONANE
+MobileStepInProgress = W TOKU
+MobileStepTodo = DO WYKONANIA
+MobileStepSignedOn = PODPISANO DNIA
+MobilePPStepCreated = PP utworzony
+MobileFPStepCreated = ZP utworzone
+MobileStepUserCompanyResponsible = Odp. EU
+MobileStepExteriorCompanyResponsible = Odp. EE
+MobileStepLock = Zablokuj
+MobileStepArchive = Zarchiwizuj
+MobileLock = Zablokuj
+MobileResponsibleShort = Odp.
+MobileMailSentTo = E-mail wysłany do
+MobilePPMotif = Powód prac
+MobilePPSchedules = Godziny prac
+MobilePPConfigHours = Skonfiguruj tutaj swoje godziny
+MobilePPCopyCompanyHours = Skopiuj godziny firmy
+FirePermitUserCompany = Przedsiębiorstwo Użytkujące - EU
+FirePermitExteriorCompany = Przedsiębiorstwo Zewnętrzne - EE
+MobileFPMotif = Powód prac
+MobileFPMotifPlaceholder = Np.: spawanie więźby dachowej
+MobileFPNoMotif = Nie podano powodu
+MobileFPSchedules = Godziny prac
+MobileFPWorkTypeDescriptionPlaceholder = Opisz prace na terenie zakładu
+MobileFPNoWorkTypeYet = Nie dodano jeszcze żadnego rodzaju prac.
+MobileFPDeleteWorkTypeTitle = Usuń rodzaj prac
+MobileFPDeleteWorkTypeConfirm = «%s» zostanie usunięty z zezwolenia wraz z opisem, sprzętem, zdjęciami i środkami ochrony.
+MobileFPNoTagAvailable = Brak dostępnych tagów zezwolenia na prace pożarowe.
+MobileFPErrorUpdatingPermit = Błąd podczas aktualizacji zezwolenia na prace pożarowe.
+MobileFPErrorCreatingPermit = Błąd podczas tworzenia zezwolenia na prace pożarowe.
+MobileFPLockNeedsSignature = Zezwolenie musi zostać podpisane, zanim będzie mogło zostać zablokowane.
+MobileFPSpreadAvailableOnceSignedAndLocked = Rozpowszechnianie będzie dostępne, gdy zezwolenie zostanie podpisane przez osoby odpowiedzialne i zablokowane.
+MobileFPDefaultDateStartToday = Data rozpoczęcia = data dzisiejsza
+MobileFPDefaultDuration = Domyślny czas trwania okresu (dni)
+firepermit = Zezwolenie na prace pożarowe
+ErrorRecordIsLocked = Ten zapis jest zablokowany i nie może już być modyfikowany.
+MobilePPEmailTemplateExt = Szablon e-maila dla osoby odpowiedzialnej przedsiębiorstwa zewnętrznego
+MobilePPEmailTemplateInt = Szablon e-maila dla pracowników przedsiębiorstwa zewnętrznego
+
+#
+# ListingRisksDocument PDF - Zestawienie ryzyk w formacie PDF
+#
+
+ListingRisksDocumentPDF            = Zestawienie ryzyk PDF
+ListingRisksDocumentPDFDescription = Zestawienie ryzyk w natywnym PDF, otwarte na mini ocenie ryzyka zawodowego elementu
+ListingRisksDocumentPDFTitle       = OCENA RYZYKA ZAWODOWEGO
+ListingRisksEstablishment          = Zakład
+ListingRisksCoverContent           = Spis treści
+ListingRisksCoverHierarchy         = Hierarchia
+ListingRisksCoverDuerpFollowUp     = Monitorowanie oceny ryzyka zawodowego
+ListingRisksCoverEmergencyNumbers  = Numery alarmowe
+ListingRisksCoverReportIncident    = Zgłoś wypadek lub problem
+ListingRisksCoverRegisters         = Rejestry BHP oraz poważnych i bezpośrednich zagrożeń
+ListingRisksCoverIllustration      = Obraz ilustracyjny
+NoPreventionOfficerAssigned        = Nie wyznaczono osoby odpowiedzialnej za prewencję
+NoEmergencyNumberConfigured        = Nie skonfigurowano numeru alarmowego
+NoResponsibleAssigned              = Nie wyznaczono osoby odpowiedzialnej
+ListingRisksLegalTitle             = Ramy prawne
+RiskDefinitionTitle                = Definicja ryzyka
+RiskDefinitionText                 = Ryzyko: rzecz. Niebezpieczeństwo lub niedogodność, na które się narażamy. Robić coś na własne ryzyko, przyjmując pełną odpowiedzialność za konsekwencje. Skalkulowane ryzyko. Podejmować ryzyko: narażać się na niebezpieczeństwo.
+DangerDefinitionTitle              = Definicja zagrożenia
+DangerDefinitionText               = Zagrożenie: rzecz. (z łaciny ludowej dominiarium «władza», od dominus «pan»; pierwotnie fakt bycia zdanym na czyjąś łaskę). To, co zagraża bezpieczeństwu lub życiu człowieka; to, co może zagrozić sytuacji, przedsięwzięciu itp.
+SingleDocumentTitle                = Ocena ryzyka zawodowego
+SingleDocumentText                 = Ocena ryzyka zawodowego jest regulowana artykułami R4121-1 do 4 francuskiego kodeksu pracy. Ogólne zasady prewencji określają kolejność postępowania z ryzykiem.
+PreventionPrinciplesTitle          = Ogólne zasady prewencji - Artykuł L4121-2
+PreventionPrinciplesIntro          = Pracodawca wdraża środki przewidziane w artykule L. 4121-1 w oparciu o następujące ogólne zasady prewencji:
+PreventionPrinciple1               = Unikanie ryzyka.
+PreventionPrinciple2               = Ocena ryzyka, którego nie można uniknąć.
+PreventionPrinciple3               = Zwalczanie ryzyka u źródła.
+PreventionPrinciple4               = Dostosowanie pracy do człowieka, w szczególności w zakresie projektowania stanowisk pracy oraz doboru wyposażenia roboczego i metod pracy i produkcji, zwłaszcza w celu ograniczenia pracy monotonnej i pracy w narzuconym tempie oraz zmniejszenia ich wpływu na zdrowie.
+PreventionPrinciple5               = Uwzględnianie stanu rozwoju techniki.
+PreventionPrinciple6               = Zastępowanie tego, co niebezpieczne, tym, co nie jest niebezpieczne lub co jest mniej niebezpieczne.
+PreventionPrinciple7               = Planowanie prewencji poprzez spójne połączenie techniki, organizacji pracy, warunków pracy, relacji społecznych oraz wpływu czynników środowiskowych, w szczególności ryzyk związanych z mobbingiem i molestowaniem seksualnym, a także z zachowaniami seksistowskimi.
+PreventionPrinciple8               = Stosowanie środków ochrony zbiorowej, dając im pierwszeństwo przed środkami ochrony indywidualnej.
+PreventionPrinciple9               = Udzielanie pracownikom odpowiednich instrukcji.
+ListingRisksCotationMethodTitle    = Metoda obliczania punktacji
+ListingRisksCotationMethodText     = Punktacja ryzyka to ocena od 0 do 100 przyznawana podczas jego oceny. Poziom ryzyka podany w zestawieniu wynika z niej bezpośrednio, zgodnie z poniższą tabelą.
+ListingRisksCotationLevel          = Poziom
+ListingRisksCotationRange          = Punktacja
+ListingRisksCotationMeaning        = Znaczenie
+ListingRisksCotationAction         = Postępowanie
+ListingRisksCotationAction1        = Utrzymanie istniejących środków prewencji.
+ListingRisksCotationAction2        = Wpisanie działania do rocznego programu prewencji.
+ListingRisksCotationAction3        = Podjęcie działania prewencyjnego w krótkim terminie.
+ListingRisksCotationAction4        = Działać natychmiast, narażenie musi ustać.
+ListingRisksListTitle              = Lista ryzyk
+ListingRisksActionPlan             = Działania rocznego programu prewencji
+ListingRisksCotationColumn         = Pkt.
+ListingRisksRiskColumn             = Ryzyko
+ListingRisksAssessmentColumn       = Informacje o ocenie
+NoRiskAssessed                     = Nie oceniono żadnego ryzyka w tym zakresie

--- a/langs/pl_PL/index.php
+++ b/langs/pl_PL/index.php
@@ -1,0 +1,2 @@
+<?php
+//Silence is golden

--- a/langs/pt_PT/digiriskdolibarr.lang
+++ b/langs/pt_PT/digiriskdolibarr.lang
@@ -1,0 +1,2387 @@
+# Copyright (C) 2021-2023 EVARISK <technique@evarisk.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#
+# Genérico
+#
+
+# Module label 'ModuleDigiriskdolibarrName'
+ModuleDigiriskdolibarrName = Digirisk
+
+# Module description 'ModuleDigiriskdolibarrDesc'
+ModuleDigiriskdolibarrDesc = Digirisk para Dolibarr
+
+# Módulo Saturne em falta
+SaturneModuleMissing = O módulo Saturne é necessário ao Digirisk. Descarregue-o gratuitamente na Dolistore (https://dolistore.com/en/modules/1906-Saturne.html) e instale-o antes de ativar o Digirisk.
+
+# Coluna das imagens de tutorial das páginas de configuração
+TutoImage = Imagem
+
+#
+# Página de administração
+#
+
+# Dados
+DigiriskdolibarrSetup       = Configuração do módulo Digirisk
+DigiriskdolibarrSetupPage        = Página de configuração do módulo Digirisk
+AgendaModuleRequired        = Para garantir a rastreabilidade das ações no Digirisk, certifique-se de que o módulo Agenda está ativado
+DigiriskDolibarrDescription = Digirisk para Dolibarr
+HowToSetupOtherModules      = Para mais funcionalidades no Digirisk, pode ativar muitos módulos (gestão de fornecedores, de faturas, etc.) nesta ligação:
+ConfigMyModules             = Configuração dos módulos
+AvoidLogoProblems              = Para evitar qualquer problema com os logótipos nos documentos gerados, consulte estes conselhos de configuração:
+LogoHelpLink                = https://wiki.dolibarr.org/index.php?title=Premiers_paramétrages
+SecurityConfiguration       = Configuração dos dados de segurança
+SocialConfiguration          = Configuração dos dados sociais
+Uncompleted                     = Não preenchido
+DigiriskData                 = Dados configuráveis do Digirisk
+DigiriskManagement          = Redirecionamento após a ligação ao site
+DigiriskDescription          = Redirecionamento para a página de boas-vindas do Digirisk por predefinição, em vez da do Dolibarr.
+HowToSetupIHM                   = Para mais funcionalidades sobre a apresentação do Dolibarr (configuração da imagem de fundo, etc.), pode aceder a esta ligação:
+ConfigIHM                    = Configuração da apresentação
+ConfigDico                     = Aceder à página de configuração dos dicionários
+LinkedProject               = Projeto associado
+DigiriskUpdate                  = Atualização do Digirisk:
+Security                       = Segurança
+HowToSharedElement          = Para mais informações sobre a configuração dos elementos partilhados, aceda a esta ligação:
+
+HowToSharedElementLink        = https://wiki.dolibarr.org/index.php?title=Module_Digirisk#Configuration
+ConfigSharedElement         = Configuração dos elementos partilhados (riscos/sinalizações)
+DisabledSharedElement       = Opção desativada porque o Multiempresa não está ativado ou a configuração dos elementos partilhados (riscos/sinalizações) não foi efetuada
+DigiriskEventAutoDesc       = Defina aqui os eventos para os quais o Digirisk criará automaticamente uma entrada na agenda. Cada evento contém as informações relativas à ação efetuada.
+DigiriskActionsEvents       = Eventos para os quais o Digirisk deve inserir automaticamente um evento na agenda.
+DigiriskDolibarr            = Digirisk
+Create                      = Criar
+
+# Ticket
+MultiCompanyTicketPublicInterfaceConfig = Configuração da interface pública de tickets multiempresa
+Subtitle                                = Subtítulo
+
+# DigiriskElement
+DigiriskElementDepthGraph            = Nível de profundidade nos gráficos dos elementos Digirisk
+DigiriskElementDepthGraphDescription = Esta opção permite escolher o nível de profundidade nos gráficos dos elementos Digirisk <br> Predefinição: nível 1
+
+# WHSRegister = Registo de segurança e saúde no trabalho
+TicketsPublicInterfaceConfig         = Configuração da interface pública de tickets
+WHSRegister                          = Registo de segurança e saúde no trabalho
+CurrentTicketPublicInterfaceURL      = URL da interface pública de tickets
+MulticompanyTicketPublicInterfaceURL = URL da interface pública de tickets multiempresa
+OriginURL                            = URL de origem
+ShortURL                             = URL abreviado
+ExternalURL                          = URL externo
+AddExtraField                        = Criar um campo adicional
+IfEmptyVisibleAllCategories          = Se estiver vazio, visível em todas as categorias
+
+# DigiQuali Sheet - Modelos
+LinkDigiriskdolibarr_digiriskstandard                 = Ativar a associação com as entidades principais do Digirisk Standard
+LinkDigiriskdolibarr_digiriskstandardDescription      = Permite associar as entidades padrão do Digirisk aos modelos
+LinkDigiriskdolibarr_digiriskelement                  = Ativar a associação com os agrupamentos e unidades de trabalho
+LinkDigiriskdolibarr_digiriskelementDescription       = Permite associar os agrupamentos e unidades de trabalho aos modelos
+LinkDigiriskdolibarr_risk                             = Ativar a associação com os riscos
+LinkDigiriskdolibarr_riskDescription                  = Permite associar os riscos aos modelos
+LinkDigiriskdolibarr_riskassessment                   = Ativar a associação com as avaliações
+LinkDigiriskdolibarr_riskassessmentDescription        = Permite associar as avaliações aos modelos
+LinkDigiriskdolibarr_evaluator                        = Ativar a associação com os avaliadores
+LinkDigiriskdolibarr_evaluatorDescription             = Permite associar os avaliadores aos modelos
+LinkDigiriskdolibarr_risksign                         = Ativar a associação com as sinalizações
+LinkDigiriskdolibarr_risksignDescription              = Permite associar as sinalizações aos modelos
+LinkDigiriskdolibarr_preventionplan                   = Ativar a associação com os planos de prevenção
+LinkDigiriskdolibarr_preventionplanDescription        = Permite associar os planos de prevenção aos modelos
+LinkDigiriskdolibarr_firepermit                       = Ativar a associação com as licenças de fogo
+LinkDigiriskdolibarr_firepermitDescription            = Permite associar as licenças de fogo aos modelos
+LinkDigiriskdolibarr_accident                         = Ativar a associação com os acidentes
+LinkDigiriskdolibarr_accidentDescription              = Permite associar os acidentes aos modelos
+LinkDigiriskdolibarr_accidentinvestigation            = Ativar a associação com as investigações de acidente
+LinkDigiriskdolibarr_accidentinvestigationDescription = Permite associar as investigações aos modelos
+
+#
+# DigiriskDolibarr
+#
+
+# Permissão
+LireDigirisk                 = Consultar o painel do Digirisk
+ReadDigirisk                 = Consultar o painel do Digirisk (leitura)
+YouDontHaveTheRightToSeeThis = Não tem permissão para ver os agrupamentos e unidades de trabalho
+CanNotDoThis                 = Não tem permissão para fazer isto
+EnableDigiriskdolibarr       = Ative o módulo DigiriskDolibarr para aceder a esta página
+
+# Dados
+DigiriskMenu          = Adicione informações sobre a sua empresa/organização. Clique no botão "Guardar" no fundo da página para as conservar
+DigiriskConfigSociety = Configuração da empresa
+PermissionDenied      = Permissão recusada
+AddUser               = Criar um utilizador
+StartDate             = Data de início
+EndDate               = Data de fim
+NoPhoneNumber         = Sem número de telefone
+HasBeenCreatedF       = foi criada
+HasBeenCreatedM       = foi criado
+HasNotBeenCreatedF    = não foi criada
+HasNotBeenCreatedM    = não foi criado
+YourDocuments         = Documentos
+NoData                = N/D
+HasBeenEditedF        = foi editada
+HasBeenEditedM        = foi editado
+HasNotBeenEditedF     = não foi editada
+HasNotBeenEditedM     = não foi editado
+
+HasBeenDeletedF    = foi eliminada
+HasBeenDeletedM    = foi eliminado
+HasNotBeenDeletedF = não foi eliminada
+HasNotBeenDeletedM = não foi eliminado
+
+DigiriskUserGroup                 = Digirisk - Utilizadores
+DigiriskUserGroupDescription      = O grupo de utilizadores do DigiRisk tem permissão para consultar e modificar os objetos relativos ao DigiRisk
+DigiriskAdminUserGroup            = DigiRisk - Administradores
+DigiriskAdminUserGroupDescription = O grupo de administradores tem todas as permissões sobre o DigiRisk e os módulos necessários
+DigiriskReaderGroup               = DigiRisk - Leitores
+DigiriskReaderGroupDescription    = O grupo de leitores tem todas as permissões de leitura sobre o DigiRisk e os módulos necessários
+
+ContractType              = Tipo de contrato
+Apprentice/Student        = Aprendiz/Estudante
+Interim                   = Trabalhador temporário
+ProfessionalQualification = Qualificação profissional
+DigiriskDocumentation     = Documentação do Digirisk
+
+SelectUser               = Selecionar um utilizador
+LabourInspectorFirstName = Inspetor do
+LabourInspectorLastName  = trabalho
+LabourInspector          = Inspetor do trabalho
+LabourInspectorSociety   = Terceiro Inspetor do trabalho
+LabourInspectorAssigned  = Inspetor do trabalho
+
+SocieteSchedules = Horário da empresa
+weekDayDefault   = Ver sítio web
+weekEndDefault   = Encerrado Encerrado
+
+#
+# DigriskDocuments - Documentos Digirisk
+#
+
+# Dados
+DigiriskDocuments              = Documento Digirisk
+Responsible                    = Responsável
+ContactsAction                 = Contactos da ação
+PERCOTooltip                   = Se a sua empresa possui um plano de poupança-reforma coletivo (PERCO), assinale esta caixa
+PEETooltip                     = Se a sua empresa possui um plano de poupança de empresa (PEE), assinale esta caixa
+ShowPictoName                  = Mostrar o nome do pictograma de perigo
+ShowPictoNameDescription       = Mostrar o nome do pictograma de perigo do risco nos documentos <br> Útil se pretender transferir a tabela para uma folha de cálculo
+RiskAssessmentColor            = Cor das avaliações
+RiskAssessmentColorDescription = Mostra a cor das avaliações no documento Papripact-A3-Paisagem
+
+#
+# LegalDisplay - Afixação legal
+#
+
+# Permissão
+LegalDisplaysMin = Afixações legais
+
+# Dados
+LegalDisplay             = Afixação legal
+Legaldisplay             = Afixação legal
+HowToSetDataLegalDisplay = Para configurar os dados da afixação legal, aceda a Início - Configuração - Empresa/Organização - Segurança
+
+LegalDisplayDocumentGenerated       = Geração da afixação legal
+LabourDoctor                        = Médico do trabalho
+LabourInspector                     = Inspetor do trabalho
+FireBrigade                         = Bombeiros
+AllEmergencies                      = Qualquer emergência
+RightsDefender                      = Provedor de Justiça
+PoisonControlCenter                 = Centro de Informação Antivenenos
+Police                              = Polícia de emergência
+SafetyInstructions                  = Instruções de segurança
+ResponsibleToNotify                 = Responsável a avisar
+PreventionOfficers                  = Responsáveis pela prevenção
+PreventionOfficer                   = Responsável pela prevenção
+LocationOfDetailedInstructions      = Localização da instrução detalhada
+LocationOfDetailedInstructionsValue = Sem instrução detalhada neste local
+FirstAid                            = Primeiros socorros
+FirstAidValue                       = <h2>Lista dos socorristas presentes no local (Nome, Empresa, Telefone)</h2><br><br>Cada equipa deve ser constituída de forma a poder prestar os primeiros socorros a qualquer membro da equipa em todas as circunstâncias.<br />Os socorristas do trabalho devem estar claramente identificados e ser conhecidos por todos.<h2>Como proceder em caso de acidente</h2><br><br><h3>Acidente ligeiro</h3><br><ul><li> - Cuidados prestados pelos socorristas</li><br><li> - Existência de um estojo de primeiros socorros</li></ul><br><br>Cada máquina está equipada com, pelo menos, um estojo de primeiros socorros que permite prestar cuidados a ferimentos ligeiros.<br><br><h3>Acidente grave</h3><br><ul><li> - Avisar o socorrista presente no local</li><br><li> - Desencadear o procedimento de emergência</li><br><li> - Informar o responsável da empresa utilizadora, piquete de exploração 24 h</li><br><li> - Contactar em caso de acidente</li></ul><br><br>A empresa utilizadora recorda em anexo os números de emergência. <br />
+AddPhoneNumber                      = Adicionar um número de telefone ao utilizador
+ConfigureLabourInspector            = Configurar um inspetor do trabalho
+SocietyAdditionalDetails            = Informações complementares da empresa
+GeneralMeansAtDisposal              = Meios gerais disponibilizados
+GeneralMeansAtDisposalValue         = <h2>Meios de socorro disponibilizados</h2><br><ul><li> - Enfermaria</li><br><li> - O nosso pessoal socorrista está identificado nos capacetes e no equipamento de trabalho com o crachá de socorrista</li><br><li> - Estojos de primeiros socorros para acidentes ligeiros disponíveis em cada local</li></ul><br><br><h2>Instruções em caso de acidente ligeiro</h2><br><ul><li> - Contactar o socorrista mais próximo</li><br><li> - Cuidados com o estojo de primeiros socorros disponibilizado</li><br><li> - Declaração no local:</li></ul><br><br><h2>Instruções em caso de acidente</h2><br><ul><li> - Chamada aos bombeiros: 18</li><br><li> - Emergência médica: 15</li><br><li> - Polícia e Guarda: 17</li><br><li> - N&deg; de emergência europeu: 112</li></ul><br><br><h2>Instruções em caso de incêndio</h2><br>Em caso de incêndio, proceda por esta ordem:<br><ol><li> - Acionar o sinal de alarme.</li><br><li> - Combater o fogo (se não for demasiado importante) com um extintor.</li><br><li> - Se o fogo não estiver extinto após a utilização de um único extintor, ou se o fogo já for demasiado importante, avisar os bombeiros.</li><br><li> - Fechar as portas e as janelas antes de sair das instalações.</li><br><li> - Pedir ajuda às equipas formadas.</li><br></ol>
+GeneralInstructions                 = Instruções gerais
+GeneralInstructionsValue            = <h2>Todas as instalações</h2><br><br><p>É formalmente proibido fumar, fazer fogo ou utilizar chama nua nas e sobre as instalações.<br />Se a intervenção exigir a utilização de chama viva (trabalhos de soldadura, etc.), é imperativo emitir uma licença de fogo (ver exemplo no anexo 9.5).<br />De um modo geral, o acesso às instalações é proibido a pessoas não autorizadas.<br />Cada interveniente deve estar munido dos seus títulos de habilitação e certificados de formação. Deve poder mostrá-los no local a pedido da empresa utilizadora.</p><br><br><h2>Habilitações</h2><br>Qualquer pessoa interveniente deve dispor de uma cópia das seguintes habilitações:<br><ul><li> - Habilitação elétrica em função dos trabalhos a realizar</li><br><li> - Certificado de formação ou habilitação para trabalhos em altura e salvamento em altura</li></ul><br>E poder apresentá-la a simples pedido da empresa utilizadora, do responsável pela intervenção ou pelos trabalhos, ou de qualquer inspetor ajuramentado<br><br><h2>Proteções individuais</h2><br>Qualquer pessoa interveniente deve poder dispor dos seguintes equipamentos de proteção individual, consoante os tipos de trabalho efetuados e as medidas de proteção definidas na análise de riscos.<br><br><h3>Trabalhos diversos</h3><br><ul><li> - Capacete concebido para trabalhos em altura (EN397) com francalete e/ou que cumpra o isolamento elétrico (ambiente elétrico)</li><br><li> - Calçado de segurança</li><br><li> - Proteções auditivas, se necessário</li><br><li> - Outros (a especificar): em função dos trabalhos realizados e dos riscos associados.</li></ul><br><br><h3>Trabalhos elétricos</h3><br><ul><li> - Tapete ou banco isolante</li><br><li> - Luvas adaptadas ao nível de tensão</li><br><li> - Capacetes para trabalhos elétricos com viseira facial (EN166)</li><br><li> - EPI regulamentares para intervenção em média tensão (UTE C 18-510)</li></ul><br><br><h3>Outros</h3><br>Nota: as empresas externas devem fornecer aos seus intervenientes os EPI acima designados. Um banco e uma vara encontram-se nos postos de transformação.<br><br><h3>Trabalhos em altura</h3><br><ul><li> - EPI regulamentares (arnês, capacete, 2 cabos com absorsor ou cabo duplo em Y, mosquetões, antiqueda, etc.) com verificação em dia</li><br><li> - Sistema de evacuação automática:</li><br><li> - Quantidade: 1 kit de evacuação (previsto para 2 pessoas)</li><li>Localização: na plataforma elevatória</li><br><li> - Lembre-se de levar um kit de evacuação adicional se estiverem mais de duas pessoas na plataforma</li><br><li> - Outro (a especificar): antiqueda utilizado: HACA com a referência 0529 7103 (fixação esternal no arnês)</li></ul><br><br>Os antiqueda devem ser compatíveis com o sistema de segurança rígido que equipa as máquinas. Os antiqueda devem estar conformes com a última norma e ter passado com êxito os ensaios complementares (testes adicionais CNB/P/11.073 de 13/10/2010) tornados obrigatórios pelo Parecer do Ministério do Trabalho francês de 28 de setembro de 2010, a fim de garantir a conformidade com os requisitos da diretiva 89/686/CEE.
+RulesOfProcedure                    = Regulamento interno
+RulesOfProcedureValue               = Disponível na afixação obrigatória da sala de pausa
+CollectiveAgreement                 = Convenções coletivas
+CollectiveAgreementValue            = Disponível no sítio do governo:<br /><a href="https://www.service-public.fr/particuliers/vosdroits/F78" target="_blank">https://www.service-public.fr/particuliers/vosdroits/F78</a>
+legaldisplay.odt                    = Afixação legal
+legaldisplay_custom.odt             = Afixação legal personalizada
+
+#
+# InformationsSharing - Difusão de informação
+#
+
+# Permissão
+InformationsSharingsMin = Difusões de informação
+
+# Dados
+InformationsSharing                  = Difusão de informação
+Informationssharing                  = Difusão de informação
+InformationsSharingDocumentGenerated = Geração da difusão de informação
+HowToSetDataInformationsSharing      = Para configurar os dados da difusão de informação, aceda a Início - Configuração - Empresa/Organização - Social
+ConfigureSecurityAndSocialData       = Configurar os dados da empresa
+LastMainDoc                          = Último documento gerado
+
+ParticipationAgreement      = Acordos de participação nos lucros
+ParticipationAgreementValue = Sim, todos os colaboradores com um contrato de trabalho sem termo ou a termo em vigor com a empresa, qualquer que seja a sua natureza, poderão beneficiar da participação nos lucros.<br />No entanto, é exigida uma condição de antiguidade: 6 meses na empresa.<br />Para a determinação da antiguidade exigida, são tidos em conta todos os contratos de trabalho executados durante o período de cálculo e nos 12 meses que o precedem.<br />A antiguidade é apreciada à data de encerramento do exercício em causa ou à data de saída em caso de cessação do contrato durante o exercício.
+TermsAndConditions          = Modalidades
+
+ESC                  = Comité Social e Económico
+StaffRepresentatives = Delegados do pessoal
+ElectionDate         = Data de eleição
+ElectionDateCSE      = Data de eleição do Comité Social e Económico
+ElectionDateDP       = Data de eleição dos delegados do pessoal
+
+Titulars                       = Efetivos
+Alternates                     = Suplentes
+informationssharing.odt        = Difusão de informação
+informationssharing_custom.odt = Difusão de informação personalizada
+ActionOnUser                   = Utilizador em causa
+HarassmentOfficer              = Responsável por assédio
+HarassmentOfficerCSE           = Responsável por assédio do Comité Social e Económico
+ExceptionsToWorkingHours       = Derrogações ao horário de trabalho
+PermanentDerogation            = Derrogação permanente
+PermanentDerogationValue       = Não
+OccasionalDerogation           = Derrogação ocasional
+OccasionalDerogationValue      = Sim
+
+
+#
+# PreventionPlan - Plano de prevenção
+#
+
+# Permissão
+PreventionPlansMin = planos de prevenção
+
+# Dados
+
+PreventionPlan                                        = Plano de prevenção
+Preventionplan                                        = Plano de prevenção
+ThePreventionplan                                     = o plano de prevenção
+PreventionPlanDocument                                = Plano de prevenção
+Preventionplandocument                                = Plano de prevenção
+PreventionPlanDocumentGenerated                       = Geração do plano de prevenção
+PreventionPlanList                                    = Lista dos planos de prevenção
+PreventionPlanLine                                    = risco(s)
+PreventionPlanLineCreated                             = Criação de risco no plano de prevenção
+PreventionPlanLineModified                            = Modificação de risco no plano de prevenção
+PreventionPlanLineDeleted                             = Eliminação de risco no plano de prevenção
+NewPreventionPlan                                     = Novo plano de prevenção
+PriorVisit                                            = Inspeção conjunta prévia
+PriorVisitYesNo                                       = Visita preliminar efetuada
+PriorVisitText                                        = Nota da inspeção
+CSSCTIntervention                                     = Intervenção do CSSCT
+CSSCTInterventionText                                 = Intervenção do CSSCT?
+MasterWorker                                          = Responsável da empresa utilizadora
+MasterWorker                                          = Responsável da empresa utilizadora
+ExtSociety                                            = Empresa externa
+ExtSocietyResponsible                                 = Responsável da empresa externa
+ExtSocietyResponsible                                 = Responsável da empresa externa
+ExtSocietyAttendant                                   = Interveniente da empresa externa
+ActionsDescription                                    = Descrição das ações
+INRSRisk                                              = Risco (INRS)
+PreventionMethod                                      = Meios de prevenção
+PreventionplanSchedules                               = Horário do plano de prevenção
+Attendants                                            = Participantes
+ModifyPreventionPlan                                  = Modificar o plano de prevenção
+ActionsDescriptionTooltip                             = Descrição das ações realizadas pelo interveniente
+INRSRiskTooltip                                       = Lista das categorias de risco propostas no referencial do INRS
+PreventionMethodTooltip                               = Meio de prevenção a implementar para limitar o risco
+LockPreventionPlan                                    = Bloquear o plano de prevenção
+ConfirmLockPreventionPlan                             = Tem a certeza de que pretende bloquear o plano de prevenção?<br>Este bloqueio permite fixar os dados e a geração do documento.
+AllSignatoriesMustHaveSigned                          = Todos os participantes devem ter assinado para bloquear o objeto
+ValidatePreventionPlan                                = Validar o plano de prevenção
+ConfirmValidatePreventionPlan                         = Tem a certeza de que pretende validar o plano de prevenção? <br> A validação permite aos participantes assinar o documento, mas <b> impede a adição de novos participantes ou a modificação do plano de prevenção </b>.
+ReOpenPreventionPlan                                  = Reabrir o plano de prevenção
+ConfirmReOpenPreventionPlan                           = Tem a certeza de que pretende reabrir o plano de prevenção? A reabertura permite modificar o plano de prevenção e adicionar novos participantes, mas <b>todas as assinaturas do documento serão perdidas</b>.
+PreventionPlanRiskList                                = Lista dos riscos do plano de prevenção
+ActionsPreventionPlanRisk                             = Ações
+PreventionPlanDescription                             = Projeto dos planos de prevenção
+PriorVisitDate                                        = Data da inspeção conjunta prévia
+AddPreventionPlanLine                                 = Adição do risco
+UpdatePreventionPlanLine                              = Atualização do risco
+DeletePreventionPlanLine                              = Eliminação do risco
+PreventionPlanDet                                     = Risco do plano de prevenção
+Preventionplandet                                     = Risco do plano de prevenção
+PreventionPlanMessage                                 = ao plano de prevenção
+PreventionPlanMustBeValidated                         = O plano de prevenção deve estar validado para poder ser reaberto
+PreventionPlanMustBeInProgress                        = O plano de prevenção deve estar em curso para aceder a esta funcionalidade
+PreventionPlanMustBeInProgressToValidate              = O plano de prevenção já está validado
+CSEMustBeAlerted3DaysBeforeVisit                      = O CSE deve ser avisado 3 dias antes da inspeção conjunta prévia (art. R. 4514-1 1°, R. 4514-3 e R. 4514-9 do Código do Trabalho francês)
+PreventionPlanData                                    = Dados do plano de prevenção
+MasterWorkerDescription                               = O utilizador utilizado por predefinição como responsável da empresa utilizadora
+NoPreventionPlanRisk                                  = Nenhum risco no plano de prevenção
+NoPreventionPlanLinked                                = Nenhum plano de prevenção associado
+PreventionPlanLinked                                  = Plano de prevenção associado
+PreventionPlanManagement                              = Gestão dos planos de prevenção
+PPRProject                                            = Projeto associado aos planos de prevenção
+NewLabelForClonePreventionPlan                        = Designação do novo plano de prevenção
+ClonePreventionPlanRisk                               = Clonar os riscos do plano de prevenção
+CloneAttendantsPreventionPlan                         = Clonar os participantes do plano de prevenção
+CloneSchedulePreventionPlan                           = Clonar os horários do plano de prevenção
+ConfirmClonePreventionPlan                            = Tem a certeza de que pretende clonar o plano de prevenção <b> %s </b>?
+preventionplandocument.odt                            = Plano de prevenção
+preventionplandocument_custom.odt                     = Plano de prevenção personalizado
+ErrorThirdPartyHasAtLeastOneChildOfTypePreventionPlan = O terceiro está associado a, pelo menos, um filho do tipo plano de prevenção:
+ErrorContactHasAtLeastOneChildOfTypePreventionPlan    = O contacto está associado a, pelo menos, um filho do tipo plano de prevenção:
+ConfirmDeletePreventionPlan                           = Tem a certeza de que pretende eliminar este plano de prevenção?
+PreventionPlanRole                                    = Os papéis do plano de prevenção
+
+# Email
+PreventionPlanLabel   = Resumo do plano de prevenção
+PreventionPlanSubject = Email do plano de prevenção
+PreventionPlanContent = Em anexo encontra o documento ODT do plano de prevenção.
+
+# Acionadores
+PreventionPlanCreated          = Criação de plano de prevenção
+PreventionPlanModified         = Modificação de plano de prevenção
+PreventionPlanDeleted          = Eliminação de plano de prevenção
+PreventionPlanInProgress       = Reabertura do plano de prevenção
+PreventionPlanPendingSignature = Colocação do plano de prevenção a aguardar assinatura
+PreventionPlanLocked           = Bloqueio do plano de prevenção
+PreventionPlanArchived         = Arquivo do plano de prevenção
+PreventionPlanSentByMail       = Envio do plano de prevenção por email
+
+#
+# FirePermit - Licença de fogo
+#
+
+# Permissão
+FirePermitMin  = licença de fogo
+FirePermitsMin = licenças de fogo
+
+# Dados
+NewFirePermit                                     = Nova licença de fogo
+ModifyFirePermit                                  = Modificar a licença de fogo
+FirePermitList                                    = Lista das licenças de fogo
+FirePermit                                        = Licença de fogo
+Firepermit                                        = Licença de fogo
+TheFirepermit                                     = a licença de fogo
+FirePermitDocument                                = Licença de fogo
+Firepermitdocument                                = Licença de fogo
+FirePermitDocumentGenerated                       = Geração da licença de fogo
+FirePermitCreated                                 = Criação de licença de fogo
+FirePermitModified                                = Modificação de licença de fogo
+FirePermitDeleted                                 = Eliminação de licença de fogo
+FirePermitInProgress                              = Reabertura da licença de fogo
+FirePermitPendingSignature                        = Colocação da licença de fogo a aguardar assinatura
+FirePermitLocked                                  = Bloqueio da licença de fogo
+FirePermitArchived                                = Arquivo da licença de fogo
+FirePermitSignatureAddAttendant                   = Adição de participante à licença de fogo
+FirePermitSentByMail                              = Envio da licença de fogo por email
+FirePermitLine                                    = risco(s)
+FirePermitDet                                     = Risco da licença de fogo
+Firepermitdet                                     = Risco da licença de fogo
+FirePermitLineCreated                             = Criação de risco na licença de fogo
+FirePermitLineModified                            = Modificação de risco na licença de fogo
+FirePermitLineDeleted                             = Eliminação de risco na licença de fogo
+FirePermitRiskList                                = Lista dos riscos da licença de fogo
+AddFirePermitLine                                 = Adição do risco
+UpdateFirePermitLine                              = Atualização do risco
+DeleteFirePermitLine                              = Eliminação do risco
+FirePermitMessage                                 = à licença de fogo
+UsedMaterialTooltip                               = Material a utilizar para limitar o risco
+ActionsFirePermitRisk                             = Ações
+ConfirmValidateFirePermit                         = Tem a certeza de que pretende validar a licença de fogo? <br> A validação permite aos participantes assinar o documento, mas <b> impede a adição de novos participantes ou a modificação da licença de fogo </b>.
+ConfirmReOpenFirePermit                           = Tem a certeza de que pretende reabrir a licença de fogo? A reabertura permite modificar a licença de fogo e adicionar novos participantes, mas <b>todas as assinaturas do documento serão perdidas</b>.
+ConfirmLockFirePermit                             = Tem a certeza de que pretende bloquear a licença de fogo?<br>Este bloqueio permite fixar os dados e a geração do documento.
+FirePermitMustBeInProgress                        = A licença de fogo deve estar em curso para aceder a esta funcionalidade
+NewLabelForCloneFirePermit                        = Designação da nova licença de fogo
+CloneFirePermitRisk                               = Clonar os riscos da licença de fogo
+CloneAttendantsFirePermit                         = Clonar os participantes da licença de fogo
+CloneScheduleFirePermit                           = Clonar os horários da licença de fogo
+ConfirmCloneFirePermit                            = Tem a certeza de que pretende clonar a licença de fogo <b> %s </b>?
+FirePermitDescription                             = Projeto das licenças de fogo
+FirePermitData                                    = Dados da licença de fogo
+FirePermitManagement                              = Gestão das licenças de fogo
+FPRProject                                        = Projeto associado às licenças de fogo
+firepermitdocument.odt                            = Licença de fogo
+firepermitdocument_custom.odt                     = Licença de fogo personalizada
+UsedEquipment                                     = Material utilizado
+ErrorThirdPartyHasAtLeastOneChildOfTypeFirePermit = O terceiro está associado a, pelo menos, um filho do tipo licença de fogo:
+ErrorContactHasAtLeastOneChildOfTypeFirePermit    = O contacto está associado a, pelo menos, um filho do tipo licença de fogo:
+ConfirmDeleteFirePermit                           = Tem a certeza de que pretende eliminar esta licença de fogo?
+FirePermitRole                                    = Os papéis da licença de fogo
+FirepermitSchedules                               = Horário da licença de fogo
+
+# Email
+FirePermitLabel   = Resumo da licença de fogo
+FirePermitSubject = Email da licença de fogo
+FirePermitContent = Em anexo encontra o documento ODT da licença de fogo.
+
+
+#
+# Accident - Acidente
+#
+
+# Permissão
+AccidentsMin = acidentes
+
+# Acionador
+AccidentCreateTrigger         = Acidente %s criado
+ActionsOnAccident             = Eventos associados ao acidente
+AccidentGeneratedWithDolibarr = Acidente gerado com o Dolibarr
+AccidentWorkStopCreateTrigger = Baixa médica %s adicionada ao acidente
+AccidentWorkStopModifyTrigger = Baixa médica %s modificada no acidente
+AccidentWorkStopDeleteTrigger = Baixa médica %s eliminada do acidente
+AccidentModifyTrigger         = Acidente %s modificado
+AccidentDeleteTrigger         = Acidente %s eliminado
+AccidentMetaDataCreateTrigger = Registo dos dados complementares do acidente
+AccidentLesionCreateTrigger   = Lesão %s adicionada ao acidente
+AccidentLesionModifyTrigger   = Lesão %s modificada no acidente
+AccidentLesionDeleteTrigger   = Lesão %s eliminada do acidente
+ACC_USER_EMPLOYERSigned       = Assinatura do responsável da empresa
+VictimAndCaregivers           = Vítima e prestador de cuidados
+Victim                        = Vítima
+Caregiver                     = Prestador de cuidados
+
+# Modelo de numeração
+DigiriskAccidentNumberingModule         = Modelo de numeração dos acidentes do Digirisk
+DigiriskAccidentStandardModel           = Devolve o número no formato ACCn, em que n é um contador sequencial sem interrupção e sem reposição a 0.
+DigiriskAccidentWorkStopNumberingModule = Modelo de numeração das baixas médicas associadas ao acidente
+DigiriskAccidentWorkStopStandardModel   = Devolve o número no formato ACCWn, em que n é um contador sequencial sem interrupção e sem reposição a 0.
+DigiriskAccidentLesionNumberingModule   = Modelo de numeração das lesões associadas ao acidente
+DigiriskAccidentLesionStandardModel     = Devolve o número no formato ACCLn, em que n é um contador sequencial sem interrupção e sem reposição a 0.
+DigiriskAccidentDocumentNumberingModule = Modelo de numeração das fichas de acidente do Digirisk
+DigiriskAccidentDocumentStandardModel   = Devolve o número no formato ACCDn, em que n é um contador sequencial sem interrupção e sem reposição a 0.
+
+# Modelo ODT
+DigiriskTemplateDocumentAccident       = Modelos de documento dos acidentes do Digirisk
+AccidentDocumentCustomDigiriskTemplate = ODT personalizado dos acidentes
+AccidentDocumentDigiriskTemplate       = ODT predefinido dos acidentes
+AccidentDocument                       = Ficha de acidente
+AccidentDocumentGeneratedWithDolibarr  = Acidente gerado com o Dolibarr
+
+# Dados
+NewAccident                              = Novo acidente
+ModifyAccident                           = Modificar o acidente
+AccidentList                             = Lista dos acidentes
+Accident                                 = Acidente
+AccidentCreated                          = Criação de um acidente
+DeleteAccident                           = Eliminar o acidente?
+AccidentModified                         = Modificação de um acidente
+AccidentDeleted                          = Eliminação de um acidente
+AccidentLine                             = risco(s)
+AccidentDate                             = Data do acidente
+AccidentSchedule                         = Horário do acidente
+AccidentRiskList                         = Lista de informações complementares sobre o acidente
+Accidentworkstop                         = Baixa médica
+AccidentWorkStopCreated                  = Criação de uma baixa médica
+AccidentWorkStopModified                 = Modificação de uma baixa médica
+AccidentWorkStopDeleted                  = Eliminação de uma baixa médica
+AddAccidentWorkStop                      = Adição de uma baixa médica ao acidente
+UpdateAccidentWorkStop                   = Atualização de uma baixa médica no acidente
+DeleteAccidentWorkStop                   = Eliminação de uma baixa médica do acidente
+Accidentlesion                           = Lesão
+AccidentLesionCreated                    = Criação de uma lesão
+AccidentLesionModified                   = Modificação de uma lesão
+AccidentLesionDeleted                    = Eliminação de uma lesão
+AddAccidentLesion                        = Adição de uma lesão ao acidente
+UpdateAccidentLesion                     = Atualização de uma lesão no acidente
+DeleteAccidentLesion                     = Eliminação de uma lesão do acidente
+AccidentDescription                      = Projeto dos acidentes
+AccidentManagement                       = Gestão dos acidentes
+AccidentWorkstopManagement               = Gestão das baixas médicas
+AccidentLesionManagement                 = Gestão das lesões
+AccidentInvestigationManagement          = Gestão das investigações de acidente
+ACCProject                               = Projeto associado aos acidentes
+UserVictim                               = Vítima do acidente
+AccidentType                             = Tipo de acidente
+WorkAccidentStatement                    = Acidente de trabalho
+CommutingAccident                        = Acidente in itinere
+AccidentMetaData                         = Dados complementares
+RelativeLocation                         = Precisões complementares sobre o local do acidente
+VictimActivity                           = Atividade da vítima no momento do acidente
+AccidentNature                           = Natureza do acidente
+AccidentObject                           = Objeto cujo contacto feriu a vítima
+AccidentNatureDoubt                      = Eventuais reservas fundamentadas (junte, se necessário, uma carta de acompanhamento)
+AccidentNatureDoubtLink                  = Ligação para a carta de acompanhamento
+VictimTransportedTo                      = A vítima foi transportada para
+VictimWorkHours                          = Horário de trabalho da vítima no dia do acidente
+WorkHoursMorningDateStart                = Início do horário de trabalho da vítima (manhã)
+WorkHoursMorningDateEnd                  = Fim do horário de trabalho da vítima (manhã)
+WorkHoursAfternoonDateStart              = Início do horário de trabalho da vítima (tarde)
+WorkHoursAfternoonDateEnd                = Fim do horário de trabalho da vítima (tarde)
+AccidentNoticed                          = Informação do acidente
+Found                                    = Constatado
+Known                                    = Conhecido
+AccidentNoticeDate                       = Data em que se tomou conhecimento do acidente
+AccidentNoticeBy                         = Pessoa que informou do acidente
+ByEmployer                               = Pelo empregador
+ByEmployees                              = Pelos seus trabalhadores
+AccidentDescribedByVictim                = O acidente foi descrito pela vítima
+RegisteredInAccidentRegister             = O acidente está inscrito no registo de acidentes de trabalho ligeiros
+RegisterDate                             = Data de inscrição no registo de acidentes de trabalho ligeiros
+RegisterNumber                           = Número de inscrição no registo de acidentes de trabalho ligeiros
+Consequence                              = Consequências
+WithoutWorkStop                          = Sem baixa médica
+LessThanFourDays                         = Menos de 4 dias
+LessThanTwentyOneDays                    = Menos de 21 dias
+LessThanThreeMonth                       = Menos de 3 meses
+LessThanSixMonths                        = Menos de 6 meses
+LongTimeWorkStop                         = Mais de 6 meses
+WithWorkStop                             = Com baixa médica
+Fatal                                    = Óbito
+PoliceReport                             = Auto policial
+PoliceReportBy                           = Pessoa que elaborou o auto policial
+FirstPersonNoticedIsWitness              = Pessoa avisada
+Witness                                  = Testemunha
+FirstPersonNoticed                       = Primeira pessoa avisada
+ThirdPartyResponsability                 = O acidente foi causado por um terceiro?
+FkSocResponsible                         = Empresa do terceiro responsável
+FkSocResponsibleInsuranceSociety         = Companhia de seguros do terceiro
+LesionLocalization                       = Localização das lesões
+LesionNature                             = Natureza das lesões
+AccidentInvestigation                    = Investigação de acidente
+Accidentinvestigation                    = Investigação de acidente
+AccidentInvestigationLink                = Ligação para a investigação de acidente
+AccidentLocation                         = Local do acidente
+DigiriskDolibarrActionTrigger            = Acionador dos eventos Digirisk
+CollateralVictim                         = Vítima colateral
+FromDigirisk                             = De
+At                                       = A
+AndFrom                                  = E de
+ExternalAccident                         = O acidente ocorreu num estabelecimento diferente daquele a que a vítima está afeta?
+AccidentAttendants                       = Acidente - Participantes
+UserEmployer                             = Responsável da empresa
+SignatureUserEmployer                    = Assinatura do responsável da empresa
+CerfaLink                                = Ligação para o formulário Cerfa
+WorkStopDays                             = Número de dias de baixa médica
+AccidentLesionList                       = Lista das lesões associadas ao acidente
+DocumentsMetaData                        = Ficheiros anexos complementares
+WorkStopDocument                         = Declaração de baixa médica
+AccidentMetaDataSave                     = Os dados complementares do acidente foram registados
+ErrorFieldNotEmpty                       = Erro: o campo <b>'%s'</b> não pode estar vazio
+ErrorFieldMustBeGreaterOrEqualZero       = Erro: o campo <b>'%s'</b> deve ser maior ou igual a 0
+ConfirmDeleteAccidentWorkStop            = Tem a certeza de que pretende eliminar a baixa médica <b>%s</b> do acidente?
+AccidentMetaDataLesion                   = Dados complementares das lesões
+TotalWorkStopDays                        = Número total de dias de baixa médica
+RegisterAccident                         = Acidente ligeiro
+AccidentsLinked                          = Acidente(s) associado(s)
+GaugeCounter                             = Este campo é utilizado no contador do indicador
+DateStartWorkStop                        = Data de início da baixa médica
+DateEndWorkStop                          = Data de fim da baixa médica
+ReturnWorkDate                           = Data de retoma da atividade
+DayWithoutAccident                       = Dias sem acidente(s)
+AccidentRepartition                      = Distribuição dos acidentes por tipo
+AccidentByYear                           = Distribuição dos acidentes por ano
+NbAccidentsByEmployees                   = Número de acidentes por trabalhador
+AccidentRegister                         = Acidente por registo
+AccidentWithoutRegister                  = Acidentes sem registo
+AccidentWithRegister                     = Acidentes com registo
+WorkStopDurationDistribution             = Distribuição do tempo por baixa médica
+WorkStopDurationDistributionDigiriskElem = Distribuição do tempo de baixa médica por GP/UT
+WorkStopDuration                         = Duração da baixa médica
+NoAbsence                                = Nenhuma baixa
+UpTo4Days                                = Até 4 dias
+UpTo21Days                               = Até 21 dias
+UpTo3Months                              = Até 3 meses
+UpTo6Months                              = Até 6 meses
+MoreThan6Months                          = Mais de 6 meses
+FrequencyIndex                           = Índice de frequência
+FrequencyRate                            = Taxa de frequência
+GravityIndex                             = Índice de gravidade
+GravityRate                              = Taxa de gravidade
+AccidentRateIndicator                    = Taxas e índices dos indicadores de desempenho dos acidentes
+NbPresquAccidents                        = Número de quase acidentes
+NbAccidentInvestigations                 = Número de investigações de acidente
+AccidentInvestigationsMin                = investigações de acidente
+NbWorkedHours                            = Número de horas trabalhadas
+ConfirmDeleteAccident                    = Tem a certeza de que pretende eliminar o acidente?
+TheAccident                              = o acidente
+AccidentInvestigation                    = Investigação de acidente
+Accident_investigation                   = Investigação de acidente
+AccidentInvestigationDocument            = Documento de investigação de acidente
+Accidentinvestigationdocument            = Documento de investigação de acidente
+accidentinvestigationdocument.odt        = Investigação de acidente
+NewAccidentInvestigation                 = Nova investigação de acidente
+UpdateAccidentInvestigation              = Modificar uma investigação de acidente
+AccidentInvestigationList                = Lista das investigações de acidente
+TheAccidentinvestigation                 = a investigação de acidente
+SeniorityInPosition                      = Antiguidade no posto
+VictimSkills                             = Competências do acidentado
+CollectiveEquipment                      = Equipamento de Proteção Coletiva (EPC)
+IndividualEquipment                      = Equipamento de Proteção Individual (EPI)
+Circumstances                            = Circunstâncias
+CurativeAction                           = Ações curativas
+CorrectiveAction                         = Ações corretivas
+PreventiveAction                         = Ações preventivas
+DigiriskActionType                       = Tipo de ação Digirisk
+Actions                                  = Ações
+ActionsTab                               = Ações
+CurativeActions                          = Ações curativas
+PreventiveActions                        = Ações preventivas
+TotalPlannedBudget                       = Orçamento previsto
+AccidentInvestigationDocumentPDF         = EA-A4-RETRATO
+PreventionPlanDocumentPDF                = PP-A4-RETRATO
+PreventionPlanDocumentPDFDescription     = Gerar o plano de prevenção em PDF
+AccidentInvestigationDocumentPDFDescription = Gerar a investigação de acidente em PDF
+AccidentInvestigationDocumentGeneratedAt = Gerado em
+CorrectiveActions                        = Ações corretivas
+AddCurativeAction                        = Adicionar uma ação curativa
+AddCorrectiveAction                      = Adicionar uma ação corretiva
+InvestigationNotValidatedYet             = Valide primeiro a investigação de acidente para poder criar ações
+ActionLabel                              = Designação da ação
+ActionDeadline                           = Prazo
+ActionAssignedTo                         = Atribuída a
+ActionProgress                           = Progresso
+MarkAsDone                               = Marcar como terminada
+XActionsOfY                              = %s / %s terminada(s)
+NoActionsYet                             = Nenhuma ação de momento
+ActionAdded                              = A ação foi criada
+ActionClosed                             = A ação foi encerrada
+ActionsAreProjectTasks                   = As ações são subtarefas do projeto Dolibarr
+SeeProjectTasksView                      = Ver a tarefa principal
+OpenTask                                 = Abrir a tarefa
+AccidentInvestigationValidated           = A investigação de acidente foi validada
+AccidentInvestigationReOpened            = A investigação de acidente foi reaberta
+AccidentInvestigationTaskCreated         = As tarefas da investigação de acidente foram criadas
+AccidentInvestigationTaskDeleted         = As tarefas da investigação de acidente foram eliminadas
+CausalityTree                            = Árvore de causas
+TaskWillBeCreatedAfterValidation         = As tarefas serão criadas após a validação da investigação de acidente
+AccidentInvestigationCreated             = Criação de uma investigação de acidente
+AccidentInvestigationModified            = Modificação de uma investigação de acidente
+AccidentInvestigationDeleted             = Eliminação de uma investigação de acidente
+AccidentInvestigationValidate            = Validação de uma investigação de acidente
+AccidentInvestigationUnValidate          = Reabertura de uma investigação de acidente
+AccidentInvestigationLock                = Bloqueio da investigação de acidente
+AccidentInvestigationSigned              = Assinatura de uma investigação de acidente
+CloneWorkStop                            = Clonar as baixas médicas?
+CloneMetadata                            = Clonar os dados complementares?
+CloneLesion                              = Clonar os dados complementares das lesões?
+CloneFrom                                = Clone de
+AccidentInvestigationRole                = Os papéis da investigação de acidente
+LesionsOrWorkStop                        = lesões ou baixas médicas
+AccidentsCategoriesArea                  = Área das etiquetas/categorias dos acidentes
+AddAccidentIntoCategory                  = Atribuir esta categoria ao acidente
+PreventionplansCategoriesArea            = Área das etiquetas/categorias dos planos de prevenção
+AddPreventionplanIntoCategory            = Atribuir esta categoria ao plano de prevenção
+FirepermitsCategoriesArea                = Área das etiquetas/categorias das licenças de fogo
+AddFirepermitIntoCategory                = Atribuir esta categoria à licença de fogo
+RisksCategoriesArea                      = Área das etiquetas/categorias dos riscos
+AddRiskIntoCategory                      = Atribuir esta categoria ao risco
+AddTicketIntoCategory                    = Atribuir esta categoria ao ticket
+StartDateInvestigate                     = Data de início da investigação
+EndDateInvestigate                       = Data de fim da investigação
+YearType                                 = Tipo de ano
+AllYears                                 = Todos os anos
+FiscalYear                               = Ano fiscal
+CalendarYear                             = Ano civil
+
+# AccidentTooltip - Ajudas dos acidentes
+VictimActivityTooltip              = Especifique a atividade ou a tarefa da vítima no momento do acidente, ou seja, o que a vítima estava a fazer
+AccidentNatureTooltip              = Descreva o evento que conduziu ao acidente, como o acidente ocorreu (problema elétrico, fuga de gás, rutura de material, escorregamento, queda, esforço físico, agressão...), ou como a vítima se feriu (embate, colisão, esmagamento, picada, afogamento, contacto com uma substância...)
+AccidentObjectTooltip              = Ou seja, com que a vítima se feriu: material, resíduo, ferramenta (chave de fendas, x-ato, berbequim...), máquina, veículo, empilhador, substância química, elemento de construção (porta, parede...), pavimento...
+AccidentNatureDoubtTooltip         = Indique, se for o caso, as reservas fundamentadas, que só poderão ser tidas em conta se disserem respeito às circunstâncias de tempo e de lugar do acidente ou à existência de uma causa totalmente alheia ao trabalho (art. R. 441-11 do Código da Segurança Social francês)
+VictimWorkHoursTooltip             = Indique as horas de trabalho efetuadas pelo seu trabalhador, ou as horas previstas, no dia do acidente
+ConsequenceTooltip                 = Se a vítima interrompeu o trabalho por prescrição médica, deve OBRIGATORIAMENTE preencher e enviar o formulário «attestation de salaire accident du travail ou maladie professionnelle» - referência S6202, à Caixa Primária do local de residência habitual da vítima. <br> Posteriormente, em caso de nova baixa após um período de cuidados ou uma retoma do trabalho, num mês diferente, deverá igualmente cumprir esta mesma formalidade
+FirstPersonNoticedIsWitnessTooltip = Indique o apelido, o nome e a morada da testemunha. <br> Na ausência de testemunha, indique a primeira pessoa da empresa que foi avisada do acidente
+ThirdPartyResponsabilityTooltip    = Quando tiver conhecimento do envolvimento de um terceiro, qualquer que seja a sua parte de responsabilidade, num acidente de trabalho ou in itinere, esta menção deve obrigatoriamente ser indicada nesta parte
+FrequencyIndexTooltip              = Número de acidentes por trabalhador x 1 000
+FrequencyRateTooltip               = Número de acidentes por horas trabalhadas x 1 000 000
+GravityRateTooltip                 = Número de dias de baixa médica por horas trabalhadas x 1 000
+NbWorkedHoursTooltip               = O número de horas trabalhadas foi introduzido manualmente
+DocumentGeneratedWithVersioning    = Documento gerado durante a criação de versão
+
+# Dicionário
+UsualWorkplace                  = Local de trabalho habitual
+OccasionalWorkplace             = Local de trabalho ocasional
+LocationOfTheMeal               = Local da refeição
+OnTheWayBetweenHomeAndWorkplace = Durante o trajeto entre o domicílio e o local de trabalho
+OnTheWayBetweenMealAndWorkplace = Durante o trajeto entre o trabalho e o local da refeição
+DuringATripForTheEmployer       = Durante uma deslocação por conta do empregador
+
+Trunk             = Tronco
+Hand              = Mão
+LowerLimbs        = Membros inferiores
+UpperLimbs        = Membros superiores
+MultipleLocations = Localizações múltiplas
+Foot              = Pé
+Head              = Cabeça
+Eyes              = Olhos
+InternalSeating   = Localizações internas
+Neck              = Pescoço
+Back              = Costas
+WholeBody         = Todo o corpo
+NotSpecified      = Não especificado
+
+PainEffortLumbago           = Dor por esforço, lumbago
+Contusion                   = Contusão
+Wounds                      = Feridas
+Sprain                      = Entorse
+FracturePitting             = Fratura ou fissura
+MultipleInjuries            = Lesões de natureza múltipla
+MuscleOrTendonTear          = Rutura muscular ou tendinosa
+PresenceOfForeignBody       = Presença de corpo estranho
+Burns                       = Queimadura
+UnspecifiedAndMiscellaneous = Não especificado e diversos
+Other                       = Outros
+CutOff                      = Corte
+
+Investigator = Investigador
+Rescuer      = Socorrista
+
+#
+# ListingRisksDocument - Listagem de riscos com documentos
+#
+
+# Permissão
+ListingRisksDocumentMin = listagens de riscos com documentos
+
+# Dados
+ListingRisksDocument            = Listagem de riscos
+Listingrisksdocument            = Listagem de riscos
+ListingRisksHeader              = Riscos - %s
+ListingRisksDocumentGenerated   = Geração da listagem de riscos com documentos
+listingrisksdocument.odt        = Listagem de riscos com documentos
+listingrisksdocument_custom.odt = Listagem de riscos com documentos personalizada
+
+#
+# ListingRisksPhoto - Listagem de riscos com fotos
+#
+
+# Permissão
+ListingRisksPhotosMin = listagens de riscos com fotos
+
+# Dados
+ListingRisksPhoto            = Listagem de riscos com fotos
+Listingrisksphoto            = Listagem de riscos com fotos
+ListingRisksPhotoGenerated   = Geração da listagem de riscos com fotos
+listingrisksphoto.odt        = Listagem de riscos com fotos
+listingrisksphoto_custom.odt = Listagem de riscos com fotos personalizada
+
+
+#
+# ListingRisksAction - Listagem de riscos com ações corretivas
+#
+
+# Permissão
+ListingRisksActionsMin = listagens de riscos com ações corretivas
+
+# Dados
+ListingRisksAction                        = Listagem de riscos com ações corretivas
+Listingrisksaction                        = Listagem de riscos com ações corretivas
+ListingRisksActionGenerated               = Geração da listagem de riscos com ações corretivas
+listingrisksaction.odt                    = Listagem de riscos com ações corretivas
+listingrisksaction_custom.odt             = Listagem de riscos com ações corretivas personalizada
+DigiriskListingRisksActionData            = Dados configuráveis das listagens de riscos com ações corretivas
+ShowTaskDoneListingRisksActionDescription = Permite mostrar ou ocultar as tarefas concluídas na listagem de riscos com ações corretivas
+
+
+#
+# RiskAssessmentDocument - Documento de avaliação de riscos
+#
+
+# Permissão
+
+RiskAssessmentDocumentsMin = Documentos de avaliação de riscos
+
+# Dados
+RiskAssessmentDocument                                    = Documento de avaliação de riscos
+Riskassessmentdocument                                    = Documento de avaliação de riscos
+RiskAssessmentDocumentGenerated                           = Geração do documento de avaliação de riscos
+AuditStartDate                                            = Data de início da auditoria
+AuditEndDate                                              = Data de fim da auditoria
+Recipient                                                 = Destinatário
+ImportantNote                                             = Observação importante
+SitePlans                                                 = Localização das plantas
+SetStartEndDateBeforeSendEmail                            = Defina a data de início e a data de fim da auditoria nesta página para enviar um email
+NoSitePlans                                               = Nenhuma planta da empresa preenchida
+riskassessmentdocument.odt                                = Documento de avaliação de riscos
+riskassessmentdocument_custom.odt                         = Documento de avaliação de riscos personalizado
+DigiriskRiskAssessmentDocumentData                        = Dados configuráveis do documento de avaliação de riscos
+ActionPreventionCompletedTaskDone                         = As ações concluídas não são apresentadas
+AppliedOn                                                 = Ativo em:
+RiskAssessmentDocumentMethod                              = * Etapa 1: Recolha das informações<br />- Visita às instalações<br />- Recolha dos dados do pessoal<br /><br />* Etapa 2: Definição da metodologia e do documento<br />- Validação das fichas de unidade de trabalho padrão<br />- Validação da estrutura das unidades<br /><br />* Etapa 3: Realização do estudo de riscos<br />- Sensibilização do pessoal para os riscos e os perigos<br />- Criação das unidades de trabalho com o pessoal e o(s) responsável(eis)<br />- Avaliação dos riscos por unidade de trabalho com o pessoal<br /><br />* Etapa 4<br />- Tratamento e redação do documento de avaliação de riscos
+RiskAssessmentDocumentSources                             = A sensibilização para os riscos está definida no ED840 editado pelo INRS.<br />Neste documento encontrará:<br />- A definição de um risco e de um perigo, com um esquema explicativo<br />- As explicações sobre os diferentes métodos de avaliação
+RiskAssessmentDocumentImportantNote                       = Notas importantes:<br />Pode consultar a documentação do DigiRisk aqui<br /><a href="https://wiki.dolibarr.org/index.php?title=Module_Digirisk" target="_blank">https://wiki.dolibarr.org/index.php?title=Module_Digirisk</a><br />Pode acompanhar o projeto aqui:<br /><a href="https://github.com/Evarisk/Digirisk/projects?type=classic" target="_blank">https://github.com/Evarisk/Digirisk/projects?type=classic</a><br />Comunique um erro aqui<br /><a href="https://github.com/Evarisk/Digirisk/issues" target="_blank">https://github.com/Evarisk/Digirisk/issues</a>
+GenerateZipArchiveWithDigiriskElementDocuments            = Geração de um arquivo ZIP com o documento de avaliação de riscos
+GenerateZipArchiveWithDigiriskElementDocumentsDescription = Geração automática de um arquivo ZIP com o documento de avaliação de riscos e todas as fichas de posto aquando da geração do documento de avaliação de riscos
+RiskAssessmentDocumentDescription                         = Plano de ação do documento de avaliação de riscos
+ErrorFailToFetchDigiriskElements                          = Erro: não foi possível obter os agrupamentos e unidades de trabalho a incluir no arquivo ZIP
+ErrorNoDocumentModelFound                                 = Erro: nenhum modelo de documento disponível para <b>%s</b>
+ErrorFailToGenerateDigiriskElementDocument                = Erro: a geração do documento de <b>%s</b> falhou, não consta do arquivo ZIP
+
+# Boxes - Widget
+NextGenerateDate  = Próxima geração
+LastGenerateDate  = Última geração
+DelayGenerateDate = Dias restantes
+NoDelay           = Sem atraso
+
+# Email
+RiskAssessmentDocumentLabel   = Resumo do documento de avaliação de riscos
+RiskAssessmentDocumentSubject = Email do documento de avaliação de riscos
+RiskAssessmentDocumentContent = Em anexo encontra o ZIP e o documento ODT do documento de avaliação de riscos.
+
+
+
+#
+# AuditReportDocument - Relatório de auditoria
+#
+
+# Dados
+AuditReportDocument     = Relatório de auditoria
+Auditreportdocument     = Relatório de auditoria
+AuditReportDocumentsMin = relatórios de auditoria
+auditreportdocument.odt = Relatório de auditoria
+
+
+
+#
+# GroupmentDocument - Ficha de agrupamento
+#
+
+# Permissão
+
+# Dados
+GroupmentDocument                        = Ficha de agrupamento
+Groupmentdocument                        = Ficha de agrupamento
+DocumentModelStandardPDF                 = Modelo PDF padrão
+GroupmentDocumentGenerated               = Geração da ficha de agrupamento
+groupmentdocument.odt                    = Ficha de agrupamento
+groupmentdocument_custom.odt             = Ficha de agrupamento personalizada
+groupmentdocumentinherited.odt           = Ficha de agrupamento - Riscos herdados
+groupmentdocumentinherited_custom.odt    = Ficha de agrupamento - Riscos herdados personalizada
+groupmentdocumentshared.odt              = Ficha de agrupamento - Riscos partilhados
+groupmentdocumentshared_custom.odt       = Ficha de agrupamento - Riscos partilhados personalizada
+DigiriskGroupmentDocumentData            = Dados configuráveis das fichas de agrupamento
+ShowTaskDoneGroupmentDocumentDescription = Permite mostrar ou ocultar as tarefas concluídas na ficha de agrupamento
+
+#
+# WorkUnitDocumment - Ficha de unidade de trabalho
+#
+
+# Permissão
+
+# Dados
+WorkUnitDocument                        = Ficha de unidade de trabalho
+Workunitdocument                        = Ficha de unidade de trabalho
+WorkUnitDocumentGenerated               = Geração da ficha de unidade de trabalho
+workunitdocument.odt                    = Ficha de unidade de trabalho
+workunitdocument_custom.odt             = Ficha de unidade de trabalho personalizada
+workunitdocumentinherited.odt           = Ficha de unidade de trabalho - Riscos herdados
+workunitdocumentinherited_custom.odt    = Ficha de unidade de trabalho - Riscos herdados personalizada
+workunitdocumentshared.odt              = Ficha de unidade de trabalho - Riscos partilhados
+workunitdocumentshared_custom.odt       = Ficha de unidade de trabalho - Riscos partilhados personalizada
+workunitdocumentcomplete.odt            = Ficha de unidade de trabalho - Todos os riscos (próprios, herdados, partilhados)
+workunitdocumentcomplete_custom.odt     = Ficha de unidade de trabalho - Todos os riscos personalizada
+DigiriskWorkUnitDocumentData            = Dados configuráveis das fichas de unidade de trabalho
+ShowTaskDoneWorkUnitDocumentDescription = Permite mostrar ou ocultar as tarefas concluídas na ficha de unidade de trabalho
+
+
+#
+# DigiriskElement - Elemento Digirisk
+#
+
+# Permissões
+DigiriskElementsMin = elementos Digirisk (agrupamento e unidade de trabalho)
+
+# Dados
+NewDigiriskElement                  = Novo elemento Digirisk
+Digiriskelement                     = Agrupamento / Unidade de trabalho
+GPUTOrganization                    = Organização dos GP/UT
+DigiriskElement                     = Elemento Digirisk
+HiddenElements                      = Reciclagem
+DigiriskElementCreated              = Criação de elemento Digirisk
+DigiriskElementModified             = Modificação de elemento Digirisk
+DigiriskElementDeleted              = Eliminação de elemento Digirisk
+ElementType                         = Tipo de elemento
+ParentElement                       = Elemento principal
+OrganizationSaved                   = A organização dos agrupamentos e das unidades de trabalho foi guardada
+OrganizationNotSaved                = Não foi possível guardar a organização dos agrupamentos e das unidades de trabalho
+UnsavedChanges                      = Modificações não guardadas
+SavingInProgress                    = A guardar...
+Saved                               = Guardado
+ErrorSaving                         = Erro ao guardar
+DigiriskElementOrganization         = Organização da estrutura
+ShareDigiriskelement                = Ativar a partilha dos agrupamentos e unidades de trabalho
+DIGIRISKELEMENTSharing              = Partilha dos agrupamentos e unidades de trabalho
+DIGIRISKELEMENTSharingDescription   = Seleção das entidades que partilharão os seus agrupamentos e unidades de trabalho com esta entidade.
+DigiriskElementSharedTooltip        = Esta opção permite partilhar os agrupamentos e unidades de trabalho. <br> INFO: se pretender apresentar as tarefas, deve ativar a opção de partilha dos projetos.
+PleaseSelectADigiriskElement        = Selecionar um agrupamento ou uma unidade de trabalho...
+Registers                           = Registos
+ShowInSelectOnPublicTicketInterface = Deve aparecer na lista de elementos da interface pública de tickets
+Organization                        = Organização GP/UT
+YouDontHaveOrganization             = Não criou agrupamentos nem unidades de trabalho, aceda a "Documento de avaliação de riscos" ou clique <b> aqui </b> para criar.
+
+
+#
+# Groupment - Agrupamento
+#
+
+# Dados
+Groupment                  = Agrupamento
+GroupmentManagement        = Gestão dos dados dos agrupamentos
+NewGroupment               = Novo agrupamento
+ModifyGroupment            = Modificar agrupamento
+TrashGroupment             = Agrupamento reciclagem
+DeletedElements            = Reciclagem
+DeletedDigiriskElement     = Agrupamentos / Unidades de trabalho colocados na reciclagem
+ShowDeletedDigiriskElement = Mostrar os agrupamentos / unidades de trabalho que se encontram na reciclagem
+
+#
+# WorkUnit - Unidade de trabalho
+#
+
+# Dados
+WorkUnit           = Unidade de trabalho
+Workunit           = Unidade de trabalho
+WorkUnitManagement = Gestão dos dados das unidades de trabalho
+NewWorkUnit        = Nova unidade de trabalho
+ModifyWorkUnit     = Modificar unidade de trabalho
+
+
+#
+# Evaluator - Avaliador
+#
+
+# Permissões
+EvaluatorsMin = avaliadores
+
+# Dados
+Evaluator                    = Avaliador
+Evaluators                   = Avaliadores
+EvaluatorCreated             = Criação de um avaliador
+EvaluatorModified            = Modificação de um avaliador
+EvaluatorDeleted             = Eliminação de um avaliador
+TheEvaluator                 = O avaliador
+EvaluatorWellCreated         = Avaliador criado
+EvaluatorNotCreated          = Erro ao criar o avaliador
+EvaluatorList                = Lista dos avaliadores
+AssignmentDate               = Data de afetação
+EvaluationDuration           = Duração
+UserAssigned                 = Utilizador atribuído
+AddEvaluatorTitle            = Adição de um avaliador
+AddEvaluatorButton           = Adicionar o avaliador
+EvaluatorConfig              = Configuração dos dados dos avaliadores
+DeleteEvaluatorMessage       = Eliminação do avaliador
+DigiriskEvaluatorData        = Dados configuráveis dos avaliadores
+EvaluatorDuration            = Duração da avaliação pelo avaliador
+EvaluatorDurationDescription = O tempo que o avaliador demora a realizar a sua avaliação de riscos
+NbEmployeesInvolved          = Trabalhadores envolvidos
+NbEmployees                  = Trabalhadores
+NbEmployeesInvolvedTooltip   = Trabalhadores (avaliadores) únicos
+NbEmployeesTooltip           = Se a gestão centralizada dos utilizadores e dos grupos na entidade principal estiver ativada.<br>O número de trabalhadores corresponde ao número de utilizadores partilhados/atribuídos a um grupo e também ao número de administradores da entidade principal
+NbEmployeesConfTooltip       = O número de trabalhadores foi introduzido manualmente
+
+
+#
+# DigiriskStandard - Padrão Digirisk
+#
+
+# Dados
+DigiriskStandardInformation = Informação
+Digiriskstandard            = Padrão Digirisk
+DigiriskStandardMin         = padrões Digirisk
+TheDigiriskstandard         = o padrão Digirisk
+
+
+#
+# RisksAnalysis - Análise de riscos
+#
+
+# Dados
+RiskAnalysis = Análise de riscos
+UpdateData   = Atualizar
+
+#
+# Risks - Riscos
+#
+
+# Permissões
+RisksMin = riscos
+
+# Dados
+Risks                                    = Riscos
+Risk                                     = Risco
+Riskprofessionals                        = Riscos profissionais
+RiskCreated                              = Criação de um risco
+RiskModified                             = Modificação de um risco
+RiskDeleted                              = Eliminação de um risco
+RiskConfig                               = Configuração dos dados dos riscos
+TheRisk                                  = O risco
+RiskWellCreated                          = Risco criado
+RiskNotCreated                           = Erro ao criar o risco
+RiskWellEdited                           = Risco editado
+RiskNotEdited                            = Erro ao editar o risco
+RiskList                                 = Listagem de riscos
+AddRiskTitle                             = Adição do risco
+AddRiskButton                            = Adicionar o risco
+EditRisk                                 = Edição do risco
+LinkedRisk                               = Risco associado
+RiskCategory                             = Cat.
+RiskCategoryEdit                         = Categoria de risco
+RiskCategoryEditDescription              = Ativar a modificação da categoria de um risco existente
+HowToEditRiskCategory                    = Para modificar a categoria do risco, clique no pictograma da categoria
+DigiriskElementRisksList                 = Lista dos riscos
+DigiriskElementRisk                      = Riscos
+RiskDescriptionNotEnabled                = O campo descrição do risco não está ativado
+HowToEnableRiskDescription               = Para ativar o campo descrição do risco, aceda a "Configuração do módulo -> Documento de avaliação de riscos"
+HowToEnableRiskCategoryEdit              = Para ativar a modificação da categoria de risco, aceda a "Configuração do módulo -> Documento de avaliação de riscos"
+SortRisksListingsByEvaluation            = Ordenar os riscos por avaliação
+SortRisksListingsByEvaluationDescription = Ativar a ordenação automática dos riscos por avaliação nas listagens
+ListingHeaderEvaluation                  = Lista das avaliações
+RiskDescription                          = Descrição do risco
+RiskDescriptionDescription               = Ativar o campo descrição do risco
+RiskDescriptionNotActivated              = Ative o campo descrição do risco em Configuração do módulo / Análise de riscos / Riscos
+AddRisk                                  = Adicionar um risco
+MoveRisk                                 = Mover o risco
+MoveRisks                                = Mover os riscos
+MoveRisksDescription                     = Permite mover os riscos de um agrupamento ou de uma unidade de trabalho para outro
+SetConfToMoveRisk                        = Deve primeiro autorizar a movimentação dos riscos em "Configuração do módulo -> Documento de avaliação de riscos"
+RiskDescriptionPrefill                   = Preencher previamente a descrição
+RiskDescriptionPrefillDescription        = Preencher previamente a descrição do risco com o nome da categoria
+DigiriskElementSharedRisksList           = Lista dos riscos partilhados
+ImportSharedRisks                        = Importar riscos partilhados
+SelectAllSharedRisksOfElement            = Selecionar todos os riscos deste elemento
+AlreadyImported                          = Já importado
+ShowSharedRisks                          = Riscos partilhados
+ShareRisk                                = Ativar a partilha dos riscos
+RISKSharing                              = Partilha dos riscos
+RISKSharingDescription                   = Seleção das entidades que partilharão os seus riscos com esta entidade.
+ShowSharedRisksDescription               = Mostrar os riscos partilhados nos documentos e nas listagens
+UnlinkSharedRisk                         = Desassociar o risco partilhado
+RiskWellUnlinkShared                     = Risco desassociado
+RiskNotUnlinkShared                      = Erro ao desassociar o risco
+HasBeenUnlinkSharedM                     = foi desassociado
+HasNotBeenUnlinkSharedM                  = não foi desassociado
+RiskSharedTooltip                        = Esta opção permite partilhar os riscos. <br> INFO: se pretender apresentar as tarefas, deve ativar a opção de partilha dos projetos.
+ShowInheritedRisksInListings             = Riscos herdados - Listagens <br> (provenientes dos níveis superiores)
+ShowInheritedRisksInListingsDescription  = Os riscos herdados são os definidos num nível superior (ex.: local ou GP) e aplicados automaticamente ao GP/UT. <br> Ative esta opção para os mostrar nas listagens
+ShowInheritedRisksInDocuments            = Riscos herdados - Documentos <br> (provenientes dos níveis superiores)
+ShowInheritedRisksInDocumentsDescription = Os riscos herdados são os definidos num nível superior (ex.: local ou GP) e aplicados automaticamente ao GP/UT. <br> Ative esta opção para os mostrar nos documentos
+DigiriskElementInheritedRisksList        = Lista dos riscos herdados
+ConfirmImportSharedRisks                 = Escolha os riscos partilhados a importar
+RisksRepartition                         = Distribuição dos riscos por avaliação
+ShowRiskOrigin                           = Mostrar a proveniência do risco
+ShowRiskOriginDescription                = Mostrar a proveniência dos riscos nos documentos (Documento de avaliação de riscos, Agrupamento, Unidades de trabalho, Listagem de riscos com ações e com fotos, etc.).
+SharedRiskImportWithSuccess              = Risco importado com êxito
+RiskImport                               = Importação de riscos
+RiskUnlink                               = Eliminação do risco partilhado
+RiskDeleted                              = O risco %s foi eliminado
+RiskSharedWithEntityRefLabel             = Partilha do risco %s com
+RiskUnlinkedFromEntityRefLabel           = Dissociação do risco %s de
+TheDigiriskelement                       = o elemento Digirisk
+DefaultProjectContactType                = Papel atribuído por predefinição ao projeto do documento de avaliação de riscos
+DefaultTaskContactType                   = Papel atribuído por predefinição às tarefas do projeto do documento de avaliação de riscos
+RiskListParentView                       = Mostrar todos os elementos principais
+RiskListParentViewDescription            = Mostrar todos os elementos principais de um risco na lista de riscos e nos documentos
+CategoryOnRisk                           = Mostrar as etiquetas/categorias nos riscos
+CategoryOnRiskDescription                = Permite atribuir etiquetas/categorias aos riscos e apresentá-las - a utilizar com precaução
+AddPsychosocialRisk                      = Adicionar um risco psicossocial
+AddPsychosocialRiskTitle                 = Adição de um risco psicossocial
+AddPsychosocialRiskButton                = Adicionar o risco psicossocial
+AddSelectedPsychosocialRisks             = Adicionar os riscos psicossociais selecionados
+SocialRelationsAtWork                    = Relações sociais no trabalho
+WorkIntensityAndTime                     = Intensidade e tempo de trabalho
+EmotionalRequirements                    = Exigências emocionais
+Autonomy                                 = Autonomia
+MeaningOfWork                            = Sentido do trabalho
+WorkSituationInsecurity                  = Insegurança da situação de trabalho
+PreventionContextInCompany               = Contexto de prevenção na empresa
+RPSImpactOnCompanyAndEmployees           = Impacto dos riscos psicossociais na empresa e nos trabalhadores
+PsychosocialRisksFactors                 = Fatores de riscos psicossociais
+CompanyPreventionInformations            = Informações sobre a prevenção na empresa
+Weak                                     = Fraco
+Moderate                                 = Moderado
+High                                     = Elevado
+Extreme                                  = Extremo
+HereIsTheWorkStationDescription          = Esta é a descrição do posto de trabalho
+ImageAnalysis                            = Análise da imagem
+TextAnalysis                             = Análise de texto
+AnalyzeText                              = Analisar o texto
+EnterTextForAnalysis                     = Introduza o texto a analisar
+AIRiskAnalysis                           = Análise de riscos por IA
+AnalysisInProgress                       = Análise em curso...
+
+# Estatísticas
+GreyRisk                                         = Risco fraco
+OrangeRisk                                       = Risco a planear
+RedRisk                                          = Risco a tratar
+BlackRisk                                        = Risco inaceitável
+RisksNotAssessed                                 = Riscos não avaliados
+RisksRepartitionByDangerCategories               = Distribuição dos riscos por categoria de perigo
+RiskListsByDangerCategories                      = Lista dos riscos por categoria de perigo
+DigiriskElementsRepartitionByDepth               = Distribuição da estrutura dos agrupamentos de nível %s
+RisksRepartitionByDangerCategoriesAndCriticality = Distribuição dos riscos por categoria de perigo e criticidade
+NumberOfRisks                                    = Número de riscos
+DangerCategories                                 = Categorias de perigo
+RisksRepartitionByDigiriskElement                = Distribuição dos riscos por agrupamento / unidade de trabalho %s
+
+
+
+#
+# RiskEnvironmentals - Riscos ambientais
+#
+
+# Dados
+Environment                                    = Ambiente
+Riskenvironmental                              = Risco ambiental
+RiskEnvironmentals                             = Riscos ambientais
+Riskenvironmentals                             = Riscos ambientais
+RiskEnvironmentalsMin                          = riscos ambientais
+AddRiskenvironmentalTitle                      = Adição do risco ambiental
+DigiriskElementRiskenvironmentalsList          = Lista dos riscos ambientais
+DigiriskElementInheritedRiskenvironmentalsList = Lista dos riscos ambientais herdados
+DigiriskElementSharedRiskenvironmentalsList    = Lista dos riscos ambientais partilhados
+ImportSharedRiskenvironmentals                 = Importar riscos ambientais partilhados
+SelectAllSharedRiskenvironmentalsOfElement     = Selecionar todos os riscos ambientais deste elemento
+ConfirmImportSharedRiskenvironmentals          = Escolha os riscos ambientais partilhados a importar
+EnvironmentDescription                         = Planeamento - Ações a implementar face aos riscos e oportunidades
+
+#
+# ListingRisksEnvironmentalAction - Listagem de riscos ambientais com ações corretivas
+#
+
+# Permissão
+ListingRisksEnvironmentalActionMin = Listagem de riscos ambientais com ações corretivas
+
+# Dados
+ListingRisksEnvironmentalAction            = Listagem de riscos ambientais com ações corretivas
+Listingrisksenvironmentalaction            = Listagem de riscos ambientais com ações corretivas
+ListingRisksEnvironmentalActionGenerated   = Geração da listagem de riscos ambientais com ações corretivas
+listingrisksenvironmentalaction.odt        = Listagem de riscos ambientais com ações corretivas
+listingrisksenvironmentalaction_custom.odt = Listagem de riscos ambientais com ações corretivas personalizada
+
+#
+# ListingRisksEnvironmentalDocument - Listagem de riscos ambientais com documentos
+#
+
+# Dados
+ListingRisksEnvironmentalDocument = Listagem de riscos ambientais
+
+
+
+#
+# RiskAssessment - Avaliação
+#
+
+# Dados
+RiskAssessment                              = Avaliação
+Riskassessment                              = Avaliação
+RiskAssessments                             = Avaliações
+RiskAssessmentCreated                       = Criação de uma avaliação
+RiskAssessmentModified                      = Modificação de uma avaliação
+RiskAssessmentDeleted                       = Eliminação de uma avaliação
+RiskAssessmentConfig                        = Configuração dos dados das avaliações
+TheRiskAssessment                           = A avaliação
+LastRiskAssessment                          = Última avaliação do risco
+RiskAssessmentWellCreated                   = Avaliação criada
+RiskAssessmentNotCreated                    = Erro ao criar a avaliação
+RiskAssessmentWellEdited                    = Avaliação editada
+RiskAssessmentNotEdited                     = Erro ao editar a avaliação
+RiskAssessmentWellDeleted                   = Avaliação eliminada
+RiskAssessmentNotDeleted                    = Erro ao eliminar a avaliação
+EvaluationCreate                            = Adição da avaliação
+EvaluationEdit                              = Edição da avaliação
+EvaluationMethod                            = Método de avaliação
+lastEvaluationOn                            = Última avaliação em
+DeleteEvaluation                            = Tem a certeza de que pretende eliminar a avaliação?
+DigiriskRiskAssessmentData                  = Dados configuráveis das avaliações
+MultipleRiskAssessmentMethodName            = Métodos de avaliação
+MultipleRiskAssessmentMethodDescription     = Ativar a alteração do método de avaliação
+AdvancedRiskAssessmentMethod                = Método de avaliação avançado
+AdvancedRiskAssessmentMethodDescription     = Ativar o método de avaliação avançado
+RiskAssessmentList                          = Lista das avaliações do risco
+EditRiskAssessment                          = Editar a avaliação
+ShowAllRiskAssessments                      = Ver todas as avaliações
+ShowAllRiskAssessmentsDescription           = Mostrar a lista completa das avaliações de risco na lista de riscos
+ParentRisk                                  = Risco principal
+RiskAssessmentDate                          = Data da avaliação
+SimpleEvaluation                            = Avaliação simples
+AdvancedEvaluation                          = Avaliação avançada
+CalculatedEvaluation                        = Avaliação calculada
+SelectEvaluation                            = Selecione as caixas para calcular a sua avaliação
+EvaluationList                              = Lista das avaliações do risco
+HowToSetMultipleRiskAssessmentMethod        = Para configurar a utilização múltipla dos métodos de avaliação, aceda a Configuração do módulo - Análise de riscos - Avaliação
+NoFileLinked                                = Nenhuma foto associada
+AddRiskAssessment                           = Adicionar uma avaliação do risco
+AddRiskAssessmentTask                       = Adicionar uma tarefa ao risco
+ListRiskAssessmentTask                      = Lista das tarefas do risco
+ShowRiskAssessmentDate                      = Data das avaliações
+ShowRiskAssessmentDateDescription           = Substitui a data de criação pela data de início das avaliações na ficha e nos documentos
+RiskAssessmentHideDateInDocument            = Ocultar a data da avaliação nos documentos
+RiskAssessmentHideDateInDocumentDescription = Ocultar a data da avaliação da coluna "Informações sobre a avaliação" nos documentos
+RiskTaskComplete                            = Tarefa %s concluída
+
+# Estatísticas
+TasksRepartition = Distribuição das tarefas por progresso real declarado
+TaskAt0Percent   = Tarefa a 0
+TaskInProgress   = Tarefa em curso
+TaskAt100Percent = Tarefa a 100
+
+
+#
+# RiskSign - Sinalização
+#
+
+# Permissões
+RiskSignsMin = sinalizações
+
+# Dados
+RiskSign                           = Sinalização
+RiskSignCreated                    = Criação de uma sinalização
+RiskSignModified                   = Modificação de uma sinalização
+RiskSignDeleted                    = Eliminação de uma sinalização
+TheRiskSign                        = A sinalização
+RiskSignConfig                     = Configuração dos dados das sinalizações
+RiskSignWellCreated                = Sinalização criada
+RiskSignNotCreated                 = Erro ao criar a sinalização
+RiskSignWellEdited                 = Sinalização editada
+RiskSignNotEdited                  = Erro ao editar a sinalização
+RiskSignWellDeleted                = Sinalização eliminada
+RiskSignNotDeleted                 = Erro ao eliminar a sinalização
+RiskSignCategory                   = Categoria
+RiskSignImport                     = Importação de sinalizações
+RiskSignUnlink                     = Eliminação da sinalização partilhada
+AddRiskSignTitle                   = Adição de uma sinalização
+AddRiskSignButton                  = Adicionar a sinalização
+EditRiskSign                       = Edição de uma sinalização
+DeleteRiskSignMessage              = Eliminação da sinalização
+DigiriskElementRiskSignList        = Lista das sinalizações
+RiskSigns                          = Sinalizações
+DigiriskElementSharedRiskSignsList = Lista das sinalizações partilhadas
+ImportSharedRiskSigns              = Importar sinalizações partilhadas
+SelectAllSharedRiskSignsOfElement  = Selecionar todas as sinalizações deste elemento
+AlreadyImportedF                   = Já importada
+ShowSharedRiskSigns                = Sinalizações partilhadas
+ShowSharedRiskSignsDescription     = Mostrar as sinalizações partilhadas nos documentos e nas listagens
+DigiriskElementSharedRiskSign      = Sinalizações partilhadas
+SharedRiskSigns                    = Sinalizações partilhadas
+ShareRisksign                      = Ativar a partilha das sinalizações
+RISKSIGNSharing                    = Partilha das sinalizações
+RISKSIGNSharingDescription         = Seleção das entidades que partilharão as suas sinalizações com esta entidade.
+UnlinkSharedRiskSign               = Desassociar a sinalização partilhada
+RiskSignWellUnlinkShared           = Sinalização desassociada
+RiskSignNotUnlinkShared            = Erro ao desassociar a sinalização
+HasBeenUnlinkSharedF               = foi desassociada
+HasNotBeenUnlinkSharedF            = não foi desassociada
+RiskSignSharedTooltip              = Esta opção permite partilhar as sinalizações. <br> INFO: se pretender apresentar as tarefas, deve ativar a opção de partilha dos projetos.
+ShowInheritedRiskSigns             = Sinalizações herdadas
+ShowInheritedRiskSignsDescription  = Mostrar as sinalizações herdadas nos documentos e nas listagens
+DigiriskElementInheritedRiskSignsList = Lista das sinalizações herdadas
+ConfirmImportSharedRiskSigns       = Escolha as sinalizações partilhadas a importar
+RiskSignSharedWithEntityRefLabel   = Partilha da sinalização %s com
+RiskSignUnlinkedFromEntityRefLabel = Dissociação da sinalização %s de
+
+#
+# Tasks - Tarefa
+#
+
+# Dados
+ActionPlan                               = Plano de ação
+Task                                     = Tarefa
+TaskCreatedEvent                         = Criação de uma tarefa
+TaskModifiedEvent                        = Modificação de uma tarefa
+TaskDeletedEvent                         = Eliminação de uma tarefa
+TheTask                                  = A tarefa
+TaskConfig                               = Configuração dos dados das tarefas
+TaskWellCreated                          = Tarefa criada
+TaskNotCreated                           = Erro ao criar a tarefa
+TaskWellEdited                           = Tarefa editada
+TaskNotEdited                            = Erro ao editar a tarefa
+TaskWellDeleted                          = Tarefa eliminada
+TaskNotDeleted                           = Erro ao eliminar a tarefa
+TasksManagement                          = Gestão das tarefas
+SelectProject                            = Escolha do projeto
+DUProject                                = Projeto associado às tarefas dos riscos
+EnvironmentProject                       = Projeto associado às tarefas dos riscos ambientais
+NoTaskLinked                             = Nenhuma tarefa em curso
+TaskList                                 = Lista das tarefas do risco
+TaskCreate                               = Adição da tarefa
+TaskEdit                                 = Edição da tarefa
+HowToSetDUProject                        = Para configurar a escolha do projeto, aceda a Configuração do módulo - Análise de riscos - Tarefa
+DeleteTask                               = Tem a certeza de que pretende eliminar a tarefa?
+ListingHeaderTask                        = Lista das tarefas
+ListingHeaderTaskTooltip                 = Ative a partilha dos projetos para apresentar as tarefas
+TasksManagementDescription               = Ativar a gestão das tarefas
+TaskManagementNotActivated               = Ative a gestão das tarefas em Configuração do módulo / Análise de riscos / Tarefa
+DigiriskProgress                         = Progresso
+ShowTaskStartDate                        = Data de início das tarefas
+ShowTaskStartDateDescription             = Substitui a data de criação pela data de início das tarefas na ficha e nos documentos
+ShowTaskEndDate                          = Data de fim das tarefas
+ShowTaskEndDateDescription               = Mostrar a data de fim das tarefas
+ShowTasksDone                            = Tarefas concluídas
+ShowTasksDoneDescription                 = Mostrar as tarefas concluídas a 100
+ShowTasksDoneDescriptionExtend           = nas listas de riscos
+ShowTaskCalculatedProgress               = Progresso da tarefa
+ShowTaskCalculatedProgressDescription    = Mostrar o progresso calculado da tarefa em vez do progresso declarado
+ShowAllTasks                             = Todas as tarefas de um risco nas listagens
+ShowAllTasksDescription                  = Mostrar todas as tarefas na lista de tarefas de um risco nas listagens
+DeleteTaskTimeSpent                      = Tem a certeza de que pretende eliminar %s min de tempo despendido na tarefa?
+TaskTimeSpentEdit                        = Edição do tempo despendido na tarefa
+TheTaskTimeSpent                         = O tempo despendido
+TaskTimeSpentCreated                     = Criação de tempo despendido
+TaskTimeSpentModified                    = Modificação de tempo despendido
+TaskTimeSpentDeleted                     = Eliminação de tempo despendido
+TaskTimeSpentWellCreated                 = Tempo despendido criado
+TaskTimeSpentNotCreated                  = Erro ao criar o tempo despendido
+TaskTimeSpentWellEdited                  = Tempo despendido editado
+TaskTimeSpentNotEdited                   = Erro ao editar o tempo despendido
+TaskTimeSpentWellDeleted                 = Tempo despendido eliminado
+TaskTimeSpentNotDeleted                  = Erro ao eliminar o tempo despendido
+OnTheTask                                = na tarefa
+TaskTimeSpentDuration                    = Duração do tempo despendido
+TaskTimeSpentDurationDescription         = O tempo despendido adicionado por predefinição a cada tarefa
+NoTaskShared                             = Nenhuma tarefa partilhada
+WarningTaskLabel                         = Atenção, ultrapassou o número máximo de carateres permitido (255)
+ErrorRecordHasSubTasks                   = A tarefa tem filhos
+TotalConsumedTime                        = Total do tempo despendido no projeto
+TotalConsumedTimeAmount                  = Custo do tempo despendido
+NbTasks                                  = Número de tarefas
+TotalProgress                            = Progresso real global das tarefas
+TotalBudget                              = Soma do orçamento das tarefas
+TaskTimeSpentDate                        = Data do tempo despendido
+StartDateCannotBeAfterEndDate            = A data de fim não pode ser anterior à data de início
+TasksFromProject                         = As tarefas apresentadas provêm do projeto definido como "Projeto do documento de avaliação de riscos"
+TaskHideRefInDocument                    = Ocultar a referência
+TaskHideRefInDocumentDescription         = Ocultar a referência da tarefa nos documentos
+TaskHideResponsibleInDocument            = Ocultar o responsável
+TaskHideResponsibleInDocumentDescription = Ocultar o responsável da tarefa nos documentos
+TaskHideDateInDocument                   = Ocultar a data
+TaskHideDateInDocumentDescription        = Ocultar a data de início e de fim da tarefa nos documentos
+TaskHideBudgetInDocument                 = Ocultar o orçamento
+TaskHideBudgetInDocumentDescription      = Ocultar o orçamento da tarefa nos documentos
+
+#
+# DigiAI - DigiAI
+#
+
+# Dados
+WelcomeToDigiAI = Bem-vindo ao DigiAI
+UploadAnImage = Carregar uma imagem
+OpenAIApiKey = Chave API OpenAI
+OpenAIApiKeyDescription = Para utilizar o DigiAI, deve dispor de uma chave API OpenAI. Pode obter uma criando uma conta em <a href="https://platform.openai.com/signup" target="_blank">https://platform.openai.com/signup</a>. Após o registo, poderá gerar uma chave API na secção "API Keys" do seu painel.
+
+#
+# Ticket - Interface pública de tickets
+#
+
+# Permissões
+TicketTagsConfig                         = Modificação dos registos de segurança e saúde no trabalho
+
+# Dados
+Register                                 = Registo
+Send                                     = Enviar
+TicketSent                               = Ticket enviado
+FilesLinked                              = Fotos / Anexos
+AddDocument                              = Adicionar documento
+LastnamePlaceholder                      = Exemplo: Silva
+FirstnamePlaceholder                     = Exemplo: João
+PhonePlaceholder                         = 00.00.00.00.00
+LocationPlaceholder                      = Exemplo: Gabinete A
+ServicePlaceholder                       = Exemplo: Cantoneiro
+Location                                 = Local
+CategoriesCreated                        = Criação das categorias de ticket
+ExtrafieldsCreated                       = Criação dos campos adicionais de ticket
+AnticipatedLeave                         = Saída antecipada
+DGI                                      = Perigo grave e iminente
+SST                                      = Segurança e saúde no trabalho
+PresquAccident                           = Quase acidente
+Accident                                 = Acidente
+EnhancementSuggestion                    = Sugestão de melhoria
+MaterialProblem                          = Problema material
+HumanProblem                             = Problema humano
+Others                                   = Outro
+AccidentWithoutDIAT                      = Acidente ligeiro
+AccidentWithDIAT                         = Acidente de trabalho
+Environment                              = Ambiente
+Quality                                  = Qualidade
+NonCompliance                            = Não conformidade
+FirstName                                = Nome
+LastName                                 = Apelido
+Phone                                    = Telefone
+DeclarationDate                          = Declaração
+DigiriskTicketPublicAccess               = Está disponível uma interface pública que não exige qualquer identificação no seguinte URL
+TicketActivatePublicInterface            = Ativar a interface pública
+GenerateExtrafields                      = Geração dos campos adicionais de ticket predefinidos
+GenerateTicketCategories                 = Geração das categorias de ticket predefinidas
+AlreadyGenerated                         = Já gerados
+NotGenerated                             = Ainda não gerado
+NotCreated                               = Ainda não criados
+ExtrafieldsGeneration                    = Esta opção permite gerar os campos adicionais predefinidos dos tickets. Os campos criados serão: <br> Apelido, Nome, Telefone, GP/UT, Local e Data
+CategoriesGeneration                     = Esta opção permite gerar as categorias predefinidas dos tickets. As categorias criadas serão: <br> - Registo <br> - - Acidente <br> - - - Quase acidente, Acidente ligeiro, Acidente de trabalho <br> - - Segurança e saúde no trabalho <br> - - - Saída antecipada, Outros, Problema humano, Problema material <br> - - Perigo grave e iminente <br> - - Qualidade <br> - - - Não conformidade, Sugestão de melhoria <br> - - Ambiente <br> - - - Não conformidade, Outros
+TicketSuccess                            = O seu registo foi transmitido ao serviço de prevenção com o número:
+TicketPublicAccess                       = Ligação de regresso à interface pública de tickets:
+TicketShowCompanyLogo                    = Mostrar o logótipo da empresa na interface pública
+TicketShowCompanyLogoHelp                = Ative esta opção para ocultar o logótipo da empresa nas páginas da interface pública
+YouMustNotifyYourHierarchy               = Tem a <b>obrigação</b> de avisar a sua hierarquia
+GoBackToTicketCreation                   = Ir para a página de acompanhamento dos tickets
+SendEmailOnTicketSubmit                  = Enviar emails na criação
+CatTicketsList                           = Lista das etiquetas/categorias dos tickets
+SendEmailTo                              = Endereço de email a notificar
+SendEmailOnTicketSubmitHelp              = Ativar o envio automático de email na criação de um ticket
+MultipleEmailsSeparator                  = Para atribuir vários endereços de email a notificar, separe-os com um ";". Por exemplo: "aaaa@bbb.cc;dddd@eee.ff"
+TicketCategories                         = Categorias dos tickets
+TicketDocumentsConfig                    = Documentos dos tickets
+TicketExtrafields                        = Campos adicionais dos tickets
+MainCategorySetting                      = Esta opção permite definir a categoria cujas subcategorias aparecerão na interface pública
+TicketCategoriesInDocumentsSetting       = Esta opção permite escolher as categorias de tickets apresentadas na lista de tickets dos documentos (Documento de avaliação de riscos, ficha de agrupamento, etc.). Se não for selecionada nenhuma categoria, são apresentadas todas as categorias
+ParentCategorySetting                    = Esta opção permite definir o título da categoria principal para a interface pública de tickets
+ChildCategorySetting                     = Esta opção permite definir o título da categoria secundária para a interface pública de tickets
+TicketManagement                         = Gestão dos tickets
+MainCategory                             = Escolha da categoria principal
+TicketCategoriesInDocuments              = Categorias apresentadas nos documentos
+ParentCategoryLabel                      = Título da categoria principal
+ChildCategoryLabel                       = Título da categoria secundária
+TicketPublicInterfaceEnabled             = A interface pública de tickets foi ativada
+TicketPublicInterfaceDisabled            = A interface pública de tickets foi desativada
+TicketPublicInterface                    = Interface pública
+EmailsToNotifySet                        = Os endereços de email a notificar foram registados
+MainCategorySet                          = A categoria principal foi definida
+TicketCategoriesInDocumentsSet           = As categorias apresentadas nos documentos foram definidas
+ParentCategoryLabelSet                   = O título da categoria principal foi definido
+ChildCategoryLabelSet                    = O título da categoria secundária foi definido
+TicketPublicInterfaceConfigDocumentation = Para configurar a interface pública de tickets, consulte a documentação
+ParentCategory                           = Categoria principal
+TSProject                                = Projeto associado aos tickets
+TicketDescription                        = Projeto dos tickets
+TicketProjectUpdated                     = O projeto predefinido dos tickets foi atualizado
+QRCodeAlreadyGenerated                   = Código QR gerado
+GenerateQRCode                           = Gerar o código QR
+CompanyQRCodeGeneration                  = Geração do código QR da entidade
+QRCodeGeneration                         = Geração do código QR
+MultiCompanyQRCodeGeneration             = Geração do código QR multientidade
+TicketCreationMailWellSent               = Email de confirmação de criação do ticket enviado
+TicketCreationMailSent                   = O email de criação do ticket foi enviado para %s
+HowToSetupTicketCategories               = Para configurar as categorias de ticket, clique nesta ligação:
+ConfigTicketCategories                   = Configuração das categorias de ticket
+NewTicketSubmitted                       = Foi submetido um ticket através da interface pública
+ANewTicketHasBeenSubmitted               = Novo registo de segurança criado para %s
+TicketCreationSubject                    = Criação de ticket através da interface pública do Digirisk
+TicketDocumentCustomDigiriskTemplate     = ODT personalizado das fichas de ticket
+HowToSetupDigiriskElement                = Para configurar os elementos do Digirisk (agrupamentos/unidades de trabalho), clique nesta ligação:
+ConfigDigiriskElement                    = Configuração dos elementos do Digirisk
+ErrorFieldEmail                          = Erro: o email deve corresponder ao seguinte formato: <b>'aaa@aaa.fr'</b>
+ErrorFieldPhone                          = Erro: o telefone deve corresponder ao seguinte formato: <b>'0XXXXXXXXXXX'</b> ou <b>'+33XXXXXXXXX'</b>
+TicketEmailRequired                      = Email obrigatório para criar um ticket
+TicketEmailRequiredHelp                  = Ative esta opção para tornar obrigatória a introdução de um email na criação de um ticket na interface pública
+WelcomeToPublicTicketInterface           = Bem-vindo à interface pública de tickets
+PleaseSelectAnEntity                     = Selecione uma entidade:
+ShowSelectorOnTicketPublicInterface      = Mostrar o seletor multientidade na interface pública de tickets em vez da lista de entidades
+ShowSelectorOnTicketPublicInterfaceHelp  = Mostrar o seletor multientidade na interface pública de tickets em vez da lista de entidades com o respetivo logótipo
+MultiEntityPublicInterface               = Interface pública de tickets multiempresa
+TicketCategoriesNotCreated               = Não criou categorias de tickets
+TicketPublicInterfaceQRCode              = Código QR da interface pública de tickets
+MultiEntityTicketPublicInterfaceQRCode   = Código QR da interface pública de tickets multiempresa
+PublicInterfaceConfiguration             = Campos visíveis / obrigatórios da interface pública
+TicketNumber                             = N.º do ticket
+FromAndDate                              = Proveniência e data
+AuthorRequest                            = Requerente
+DateCloture                              = Data de encerramento
+
+PublicInterfaceUseSignatory              = Assinatura obrigatória para declarar este registo
+ValidateText                             = Condições a aceitar para a assinatura
+TicketPublicInterfaceShowCategory        = Mostrar a descrição da categoria
+EmailTemplate                            = Modelo de email
+EmailTemplateDescription                 = Modelo de email
+
+OpenInNewTab                             = Abrir num novo separador
+TicketDigiriskElementRequired            = GP/UT obrigatório para criar um ticket
+TicketDigiriskElementRequiredHelp        = Ative esta opção para tornar obrigatória a seleção de um GP/UT na criação de um ticket na interface pública
+TicketDigiriskElementHideRef             = Ocultar a referência dos GP/UT no seletor de serviço da interface pública
+TicketDigiriskElementHideRefHelp         = Ative esta opção para ocultar a referência de um GP/UT na interface pública
+TicketDigiriskelementVisible             = Mostrar o campo GP/UT para criar um ticket
+TicketServiceVisible                     = Mostrar o campo GP/UT para criar um ticket
+TicketDigiriskelementVisibleHelp         = Ative esta opção para mostrar o campo GP/UT na interface pública e torná-lo obrigatório se necessário
+TicketServiceVisibleHelp                 = Ative esta opção para mostrar o campo GP/UT na interface pública e torná-lo obrigatório se necessário
+TicketPhotoVisible                       = Mostrar o campo Foto para criar um ticket
+TicketPhotoVisibleHelp                   = Ative esta opção para mostrar o campo Foto na interface pública
+TicketEmailVisible                       = Mostrar o campo Email para criar um ticket
+TicketEmailVisibleHelp                   = Ative esta opção para mostrar o campo Email na interface pública e torná-lo obrigatório se necessário
+TicketLastnameVisible                    = Mostrar o campo Apelido para criar um ticket
+TicketLastnameVisibleHelp                = Ative esta opção para mostrar o campo Apelido na interface pública e torná-lo obrigatório se necessário
+TicketFirstnameVisible                   = Mostrar o campo Nome para criar um ticket
+TicketFirstnameVisibleHelp               = Ative esta opção para mostrar o campo Nome na interface pública e torná-lo obrigatório se necessário
+TicketPhoneVisible                       = Mostrar o campo Telefone para criar um ticket
+TicketPhoneVisibleHelp                   = Ative esta opção para mostrar o campo Telefone na interface pública e torná-lo obrigatório se necessário
+TicketLocationVisible                    = Mostrar o campo Local para criar um ticket
+TicketLocationVisibleHelp                = Ative esta opção para mostrar o campo Local na interface pública e torná-lo obrigatório se necessário
+TicketDateVisible                        = Mostrar o campo Data para criar um ticket
+TicketDateVisibleHelp                    = Ative esta opção para mostrar o campo Data na interface pública e torná-lo obrigatório se necessário
+QRCodeGenerated                          = Código QR gerado
+FkTicket                                 = Ticket associado
+PublicTicket                             = Interface pública de tickets
+TicketPublicInterfaceForbidden           = Acesso proibido à interface pública de tickets
+DefaultUserGroup                         = Grupo predefinido
+DefaultUserGroupDescription              = Grupo predefinido nos seletores de grupos
+ConfigureDefaultUserGroup                = Configurar o grupo predefinido
+RegisterSigned                           = Registo assinado
+
+#Interface pública
+TicketPublicInterfaceShowCategoryDescription     = Mostrar a descrição das categorias de ticket na interface pública
+TicketPublicInterfaceShowCategoryDescriptionHelp = Ative esta opção para mostrar a descrição das categorias de ticket na interface pública
+
+
+# Estatísticas
+TicketStatistics    = Estatísticas dos tickets
+ExportCSV           = Exportação CSV
+GenerateCSV         = Gerar o ficheiro CSV
+SuccessGenerateCSV  = Ficheiro CSV %s gerado com êxito
+ErrorMissingData    = Erro: não foi possível gerar o ficheiro CSV, os dados enviados para o ficheiro estão incorretos. <br> Verifique se tem GP/UT atribuídos a tickets.
+CSVFileExport       = Exportação dos registos em formato CSV associados a GP/UT
+ThirdPartyHelp      = Se o filtro "Terceiro" estiver vazio, não é utilizado nenhum terceiro na pesquisa
+GP/UTHelp           = Por predefinição, o filtro considera todos os GP/UT
+CategoryTicketHelp  = Por predefinição, o filtro considera todas as categorias
+CreatedByHelp       = Se o filtro "Criado por" estiver vazio, não é utilizado nenhum utilizador na pesquisa
+AssignedToHelp      = Se o filtro "Atribuído a" estiver vazio, não é utilizado nenhum utilizador na pesquisa
+StatusHelp          = Por predefinição, o filtro considera todos os estados<br>
+ConcernedTimePeriod = Período considerado
+LessThan            = Menos de
+MoreThan            = Mais de
+Comparator          = Comparador
+RangeNumber         = Quantidade
+TimeRange           = Unidade de tempo
+RangeLabel          = Nome da restrição
+Inferior            = Inferior a
+Superior            = Superior a
+TimeRangeAdded      = Restrição adicionada
+TimeRangeDeleted    = Restrição eliminada
+
+NumberOfTicketsByMainCategorieAndDigiriskElement    = Número de registos por categoria e por GP
+NumberOfTicketsByMainSubCategorieAndDigiriskElement = Número de registos por subcategoria e por GP
+NumberOfTicketsByYear                           = Número de tickets por ano
+
+# Ticket Management Dashboard - Painel de gestão de tickets
+TicketManagementDashboard                 = Painel de gestão de tickets
+RunningTicket                             = Tickets em curso
+NbOfOpenedTicket                          = Número de tickets abertos
+OldestTicket                              = Ticket mais antigo
+OldestTicketDescription                   = Ticket mais antigo com o tempo decorrido desde a sua criação
+OldestMessageTicket                       = Ticket mais antigo com uma mensagem
+OldestMessageTicketDescription            = Ticket mais antigo com uma mensagem e o tempo decorrido desde a criação da mensagem
+MeanAnswerTime                            = Tempo médio de resposta
+MeanAnswerTimeDescription                 = Prazo médio entre a abertura e o encerramento, calculado apenas sobre os tickets encerrados
+MeanFirstResponseTime                     = Prazo médio da primeira resposta
+MeanFirstResponseTimeDescription          = Prazo médio entre a abertura do ticket e a primeira mensagem visível para o declarante. As notas internas não contam, e os tickets sem mensagem pública são excluídos do cálculo
+NbTicketPerUser                           = Número médio de tickets atribuídos por pessoa
+NbExchangePerTicket                       = Número de trocas por ticket
+TicketRepartitionPerUserAndMeanAnswerTime = Distribuição dos tickets por utilizador e tempo médio de resposta
+TopSocietyWithMostTickets                 = Top %s das empresas com mais tickets
+TicketsCreatedVersusClosedByMonth         = Tickets criados e encerrados nos últimos %s meses
+TicketsCreated                            = Criados
+TicketsClosed                             = Encerrados
+OpenTicketsByStatus                       = Distribuição dos tickets abertos por estado
+OpenTicketBacklogAge                      = Antiguidade dos tickets abertos (desde a criação)
+BacklogAgeUnderDays                       = Menos de %s dias
+BacklogAgeBetweenDays                     = De %s a %s dias
+BacklogAgeOverDays                        = Mais de %s dias
+ShowSelectedDateTypes                     = Selecione o tipo de data a apresentar
+
+# Email
+The                            = Em
+TicketMessage                  = Mensagem do registo
+SeeTicketUrl                   = Ver o ticket
+AutoNotificationTicket         = Notificação por email enviada automaticamente por
+TicketPublicInterfaceOtherName = Interface de gestão dos registos de segurança e saúde no trabalho e de perigo grave e iminente
+
+
+
+# Documento de ticket
+
+# Dados
+TicketDocument                 = Ficha do ticket
+Ticketdocument                 = Ficha do ticket
+ticketdocument.odt             = Ficha do ticket
+ticketdocument_custom.odt      = Ficha personalizada do ticket
+ticketdocument_events.odt      = Ficha do ticket com eventos
+ticketdocument_sign.odt        = Ficha do ticket com assinatura
+ticketdocument_event_sign.odt  = Ficha do ticket com evento e assinatura
+TicketSuccessMessage           = Mensagem de êxito do ticket
+TicketSuccessMessageSet        = A mensagem foi modificada
+TicketDocumentPDF              = FT-A4-PAISAGEM
+TicketDocumentPDFDescription   = Mostrar a ficha do ticket
+GeneratedTicketDocumentDate    = Data da exportação deste ticket
+
+
+# Documento de projeto
+
+# Modelo ODT
+DigiriskTemplateDocumentProject = Modelos de documento das fichas de projeto do Digirisk
+DocumentModelPapripactA3Paysage = Modelos de documento de relatório previsional sobre as tarefas dos projetos
+PapripactFullName               = Programa Anual de Prevenção dos Riscos Profissionais e de Melhoria das Condições de Trabalho
+
+# Documento de registo
+
+RegisterDocument     = Registo dos acidentes de trabalho ligeiros
+Registerdocument     = Registo dos acidentes de trabalho ligeiros
+RegisterDocumentsMin = registos dos acidentes de trabalho ligeiros
+registerdocument.odt = Registo dos acidentes de trabalho ligeiros
+
+#
+# Tools - Ferramentas
+#
+
+# Dados
+Tools                                        = Ferramentas
+DigiriskDataMigration                        = Gestão dos dados de migração
+DataMigrationImport                          = Importação dos dados da estrutura do Digirisk
+DataMigrationImportDescription               = Importação dos dados da estrutura do Digirisk WordPress em formato ZIP
+DataMigrationImportRisks                     = Importação dos dados dos riscos do Digirisk
+DataMigrationImportRisksDescription          = Importação dos dados dos riscos do Digirisk WordPress em formato ZIP
+ErrorFileNotWellFormatted                    = O ficheiro não tem o formato correto ou está vazio. Deve anexar um ficheiro de importação proveniente do Digirisk WordPress com o nome DATE_OBJET_export.json
+ErrorFileNotWellFormattedZIP                 = O ficheiro não tem o formato correto ou está vazio. Deve anexar um ficheiro de importação proveniente do Digirisk WordPress com o nome DATE_OBJET_export.zip
+ErrorJsonBadFormatted                        = O ficheiro JSON não está bem formatado
+SuccessImport                                = Importação dos dados efetuada com êxito
+DataMigrationImportRiskSigns                 = Importação dos dados das sinalizações do Digirisk
+DataMigrationImportRiskSignsDescription      = Importação dos dados das sinalizações do Digirisk WordPress em formato ZIP
+DataMigrationImportGlobal                    = Importação dos dados globais do Digirisk <br> (Estrutura, riscos e sinalizações)
+DataMigrationImportGlobalDescription         = Importação dos dados globais do Digirisk WordPress em formato ZIP <br> (Estrutura, riscos e sinalizações)
+DataMigrationExportGlobal                    = Exportação dos dados globais do Digirisk <br> (Estrutura, riscos e sinalizações)
+DataMigrationExportGlobalDescription         = Exportação dos dados globais do Digirisk Dolibarr em formato ZIP <br> (Estrutura, riscos e sinalizações)
+DataMigrationExportTree                      = Exportação da estrutura do Digirisk <br> (Apenas a estrutura)
+DataMigrationExportTreeDescription           = Exportação da estrutura do Digirisk Dolibarr em formato ZIP <br> (GP/UT visíveis da entidade atual, sem os riscos nem as sinalizações)
+DataMigrationImportGlobalDolibarrDescription = Importação dos dados globais do Digirisk Dolibarr em formato ZIP <br> (Estrutura, riscos e sinalizações)
+DataMigrationTreeAlreadyImported             = Importação dos dados da estrutura já efetuada
+DataMigrationRisksAlreadyImported            = Importação dos dados dos riscos já efetuada
+DataMigrationRiskSignsAlreadyImported        = Importação dos dados das sinalizações já efetuada
+DataMigrationGlobalAlreadyImported           = Importação dos dados globais (Estrutura, riscos e sinalizações) já efetuada
+AdvancedImport                               = Importação avançada
+AdvancedImportDescription                    = Permite importar cada elemento de forma independente (Estrutura, riscos e sinalizações)
+DataMigrationWordPressToDolibarr             = Migração dos dados do WordPress para o Dolibarr
+DataMigrationDolibarrToDolibarr              = Migração dos dados do Dolibarr para o Dolibarr
+RepairRisks                                  = Reparar os riscos
+NumberOfRisksCorrupted                       = Tem %s risco(s) cuja categoria está corrompida, aceda à página "Ferramentas" para o(s) reparar
+NoRiskToRepair                               = Nenhum risco a reparar
+DigiriskElementSuccessfullyRepaired          = Elementos Digirisk (GP/UT) reparados com êxito
+RiskSuccessfullyRepaired                     = Riscos reparados com êxito
+RiskAssessmentSuccessfullyRepaired           = Avaliações reparadas com êxito
+CorruptedCategoryOnRiskList                  = Lista dos riscos cuja categoria está corrompida
+
+# Clean - Limpar
+Clean                                          = Limpar
+CleanObject                                    = Limpar os dados
+CleanDigiriskElementExistParentDigiriskElement = %d elementos Digirisk (GP/UT) têm um elemento principal inválido
+CleanDigiriskElement                           = Limpar os elementos Digirisk (GP/UT)
+CleanRiskFkElement                             = %d riscos têm um GP/UT inválido
+CleanRiskStatus                                = %d riscos têm um estado inválido
+CleanRiskExistFkElement                        = %d riscos estão órfãos
+CleanRiskExistRiskAssessment                   = %d riscos não têm qualquer avaliação
+CleanRisk                                      = Limpar os riscos
+CleanRiskAssessmentStatus                      = %d avaliações têm um estado inválido
+CleanRiskAssessmentCotation                    = %d avaliações têm uma cotação vazia
+CleanRiskAssessmentExistFkRisk                 = %d avaliações estão órfãs
+CleanRiskAssessment                            = Limpar as avaliações
+NoDigiriskElementToClean                       = Nenhum elemento Digirisk (GP/UT) a limpar
+NoRiskToClean                                  = Nenhum risco a limpar
+NoRiskAssessmentToClean                        = Nenhuma avaliação a limpar
+
+
+#
+# Outros
+#
+
+# Dados
+AT = a
+
+LabourInspectorName                 = DREETS
+UrlLabourInspector                  = https://travail-emploi.gouv.fr/ministere/organisation/article/dreets-directions-regionales-de-l-economie-de-l-emploi-du-travail-et-des
+IDCCTooltip                         = Este campo provém do módulo Digirisk para Dolibarr <br> A nomenclatura das convenções coletivas provém de travail-emploi.gouv.fr
+NoEmailContact                      = Sem email neste contacto
+AddMedia                            = Adicionar um ficheiro multimédia
+NoMediaLinked                       = Nenhum ficheiro multimédia associado
+UserGroup                           = Grupo de utilizadores
+ReaderGroup                         = Grupo de leitores
+UserCreated                         = O utilizador foi criado
+GetAPI                              = Utilização das rotas API do Digirisk com o método GET
+PostAPI                             = Utilização das rotas API do Digirisk com o método POST
+MinimizeMenu                        = Reduzir o menu
+ActionsLine                         = Ações
+PhotoWellSent                       = A foto foi adicionada à biblioteca multimédia
+PhotoNotSent                        = A foto não foi enviada corretamente
+PhotoWellSaved                      = O(s) ficheiro(s) multimédia foi(foram) adicionado(s)
+PhotoNotSaved                       = O(s) ficheiro(s) multimédia não foi(foram) adicionado(s)
+UseCaptcha                          = Código gráfico (CAPTCHA)
+UseCaptchaDescription               = Utilização do código gráfico (CAPTCHA) nas páginas da interface pública
+GP/UTParticipation                  = Participação GP/UT
+LabourDoctorName                    = AMETRA
+LabourDoctorFirstName               = Médico do
+LabourDoctorLastName                = trabalho
+DashBoard                           = Painel
+Close                               = Fechar
+DateRange                           = Intervalo de datas
+UseDateRange                        = Utilizar o intervalo de datas
+SiretNumber                         = N.º de contribuinte
+Society                             = Empresa
+MulticompanyTransverseModeEnabled   = A gestão centralizada dos utilizadores e dos grupos na entidade principal está ativada.<br>Não pode, por isso, criar um utilizador ou um grupo nesta entidade.<br>Aceda à entidade principal para efetuar esta adição.
+ManuelInputNBEmployees              = Introduzir manualmente o número de trabalhadores
+ManuelInputNBEmployeesDescription   = Se a opção estiver ativada, pode introduzir manualmente o número de trabalhadores na configuração da empresa.<br>Caso contrário, o número de trabalhadores é calculado.<br>Consulte a documentação para mais informações.
+ManuelInputNBWorkedHours            = Introduzir manualmente o número de horas trabalhadas
+ManuelInputNBWorkedHoursDescription = Se a opção estiver ativada, pode introduzir manualmente o número de horas trabalhadas na configuração da empresa.<br>Caso contrário, o número de horas trabalhadas é calculado.<br>Consulte a documentação para mais informações.
+ShowPatchNoteAgain                  = Mostrar a nota de atualização
+ShowPatchNoteAgainDescription       = Se a opção estiver ativada, a nota de atualização da versão atual reaparece na página inicial do Digirisk.<br>(Exige que a opção «Mostrar as notas de atualização a partir do GitHub» esteja ativada para ser visível.)
+HowToConfigureSetupConf             = Para configurar os dados da empresa associados ao Digirisk,<br>aceda a Digirisk - Configuração - Definições
+LabourDoctorNameFull                = Associação de Médicos
+PermissionInheritedFromConfig       = As permissões são herdadas da configuração geral ou da configuração principal
+CategorieManagement                 = Gestão das categorias
+ShowSelectedRiskTypes               = Selecione os tipos de risco a apresentar
+CharRemaining                       = Carateres restantes
+NumberOfLinkedFiles                 = Número de ficheiros anexos
+ChooseAnImage                       = Escolher uma imagem
+
+# Action Plan - Gantt / Kanban
+ActionPlanGantt                     = Diagrama de Gantt
+ActionPlanKanban                    = Kanban
+ActionPlanView                      = Plano de ação
+ColumnDraft                         = Rascunho
+ColumnInProgress                    = Em curso
+ColumnInControl                     = A controlar
+ColumnDone                          = Terminado
+NoTasks                             = Nenhuma ação corretiva
+ActionPlanGlobalProgress            = Progresso global do PAPRIPACT
+ActionPlanGlobalProgressInfo        = Média do progresso de %s ação(ões) corretiva(s)
+KanbanLoadMore                      = Ver mais (%s)
+KanbanDisplay                       = Apresentação do Kanban
+KanbanPageSize                      = Número de cartões por coluna
+KanbanPageSizeDesc                  = Número de ações corretivas apresentadas de imediato em cada coluna; as seguintes são carregadas através do botão «Ver mais» (melhora o desempenho com grandes volumes)
+KanbanDraftMax                      = Limiar da coluna «Rascunho»
+KanbanDraftMaxDesc                  = Progresso máximo (%) para que uma ação permaneça na coluna «Rascunho»
+KanbanProgressMax                   = Limiar da coluna «Em curso»
+KanbanProgressMaxDesc               = Progresso máximo (%) para a coluna «Em curso»
+KanbanControlMax                    = Limiar da coluna «A controlar»
+KanbanControlMaxDesc                = Progresso máximo (%) para a coluna «A controlar»; acima disso, a ação passa a «Terminado»
+PlannedWorkload                     = Carga prevista
+TimeSpent                           = Tempo despendido
+LinkedRisk                          = Risco associado
+TaskMovedTo                         = Tarefa movida para %s
+
+AddCategory                        = Adicionar uma categoria
+SelectCategory                     = Escolher uma categoria
+DateEndBeforeStart                 = Data de fim anterior à de início
+InternalUsers                      = Utilizadores internos
+ExternalContacts                   = Contactos externos
+AddContributor                     = Adicionar um contribuidor
+RemoveContact                      = Retirar o contacto
+ColumnWidth                        = Largura
+ColumnGap                          = Espaçamento
+ActionPlanExportCsv                = Transferir o PAPRIPACT em formato CSV
+ActionPlanExportA3                 = Transferir o PAPRIPACT em PDF A3 paisagem
+ActionPlanExportGantt              = Transferir o diagrama de Gantt como imagem PNG
+ActionPlanDisplayedProject         = Projeto apresentado
+ActionPlanChangeProject            = Mudar de projeto
+ActionPlanDefaultProject           = Documento de avaliação de riscos (predefinição)
+ActionPlanNoProjectConfigured      = Nenhum projeto configurado
+
+# ActionPlan — Registo de eventos
+ActionPlanLogging                  = Plano de ação — Histórico das modificações
+ActionPlanLoggingDescription       = Ativar a criação de eventos aquando das modificações no Kanban
+ActionPlanLogLabel                 = Modificação da designação
+ActionPlanLogLabelDesc             = Criar um evento quando a designação de uma tarefa é modificada
+ActionPlanLogWorkload              = Modificação da carga
+ActionPlanLogWorkloadDesc          = Criar um evento quando a carga prevista é modificada
+ActionPlanLogBudget                = Modificação do orçamento
+ActionPlanLogBudgetDesc            = Criar um evento quando o orçamento é modificado
+ActionPlanLogContributorAdd        = Adição de um contribuidor
+ActionPlanLogContributorAddDesc    = Criar um evento quando um contribuidor é adicionado
+ActionPlanLogContributorRemove     = Retirada de um contribuidor
+ActionPlanLogContributorRemoveDesc = Criar um evento quando um contribuidor é retirado
+ActionPlanLogProgress              = Modificação do progresso
+ActionPlanLogProgressDesc          = Criar um evento quando o progresso é modificado
+ActionPlanLogTag                   = Modificação das etiquetas
+ActionPlanLogTagDesc               = Criar um evento quando uma etiqueta é adicionada ou retirada
+ActionPlanLogDateStart             = Modificação da data de início
+ActionPlanLogDateStartDesc         = Criar um evento quando a data de início é modificada
+ActionPlanLogDateEnd               = Modificação da data de fim
+ActionPlanLogDateEndDesc           = Criar um evento quando a data de fim é modificada
+ActionPlanTaskLabelChanged         = Designação modificada: "%s" → "%s"
+ActionPlanTaskWorkloadChanged      = Carga modificada: %s → %s
+ActionPlanTaskBudgetChanged        = Orçamento modificado: %s → %s
+ActionPlanTaskContributorAdded     = Contribuidor adicionado: %s
+ActionPlanTaskContributorRemoved   = Contribuidor retirado: ID %s
+ActionPlanTaskProgressChanged      = Progresso modificado: %s%% → %s%%
+ActionPlanTaskTagAdded             = Etiqueta adicionada: %s
+ActionPlanTaskTagRemoved           = Etiqueta retirada: ID %s
+ActionPlanTaskDateStartChanged     = Data de início modificada: %s → %s
+ActionPlanTaskDateEndChanged       = Data de fim modificada: %s → %s
+
+# ===========================================================================
+# Filtros do plano de ação — issue #4907 (GP/UT, nível de risco, etiquetas)
+# ===========================================================================
+ActionPlanElement                    = GP/UT
+ActionPlanFilterElementChildren      = Com os subelementos
+ActionPlanFilterElementChildrenHelp  = Incluir as ações corretivas dos GP/UT filhos do GP/UT selecionado
+ActionPlanFilterScale                = Nível de risco
+ActionPlanFilterAllScales            = Todos os níveis
+ActionPlanFilterTags                 = Etiquetas
+ActionPlanFilterCount                = %s ação(ões) corretiva(s) apresentada(s) em %s
+ActionPlanDictionaries               = Listas do Kanban
+ActionPlanDictionariesDesc           = Gerir os valores propostos nas listas do plano de ação e dos Kanban
+ActionPlanTagDictionary              = Etiquetas das ações corretivas
+ActionPlanTagDictionaryDesc          = Etiquetas (categorias de tarefas) propostas nos cartões e no filtro do Kanban do plano de ação
+ActionPlanTicketDictionaries         = Dicionários dos Kanban de tickets
+ActionPlanTicketDictionariesDesc     = Tipos, grupos e severidades que compõem as colunas dos Kanban de tickets
+ActionPlanManageDictionary           = Gerir
+
+# ===========================================================================
+# Cartão de ação de ticket — issue #4443 (interface de 1 clique)
+# ===========================================================================
+TicketActionCard                     = Ação de ticket
+TicketActionCardPickerIntro          = Selecione um ticket para efetuar uma ação rápida em 1 clique.
+TicketActionCardStatusSection        = Estado
+TicketActionCardAssignSection        = Atribuição
+TicketActionCardContentSection       = Conteúdo
+TicketActionCardDangerSection        = Zona sensível
+TicketActionMarkRead                 = Marcar como lido
+TicketActionInProgress               = Colocar em curso
+TicketActionWaiting                  = Colocar em espera
+TicketActionClose                    = Encerrar
+TicketActionCancel                   = Anular ticket
+TicketActionAssignSelf               = Atribuir a mim
+TicketActionAssignOther              = Atribuir a...
+TicketActionAddMessage               = Adicionar uma mensagem
+TicketActionLinkAccident             = Associar um acidente
+TicketActionOpenFull                 = Detalhes completos
+TicketActionMarkedRead               = Ticket marcado como lido
+TicketActionInProgressDone           = Ticket colocado em curso
+TicketActionWaitingDone              = Ticket colocado em espera
+TicketActionClosedDone               = Ticket encerrado
+TicketActionCancelledDone            = Ticket anulado
+TicketActionAssignedSelfDone         = Ticket atribuído a si
+TicketActionAssignedOtherDone        = Ticket atribuído
+TicketActionCloseConfirm             = Confirmar o encerramento
+TicketActionCancelConfirm            = Confirmar a anulação
+TicketActionCardRegistresSection      = Informações dos registos
+TicketMessageTitle                    = Título da mensagem
+TicketResponsibleAndProgress          = Responsável e progresso
+TicketActionCardClassificationSection = Classificação
+TicketActionCardDatesSection          = Datas-chave
+TicketActionCardIdentificationSection = Identificação
+TicketActionCardOtherFieldsSection    = Outras informações
+TicketActionCardEventsSection         = Eventos recentes
+TicketActionCardRelatedSection        = Objetos associados
+UnknownFieldToUpdate                  = Campo desconhecido: %s
+Saved                                 = Guardado
+SeeAll                                = Ver tudo
+LayoutCustomize                       = Personalizar
+LayoutDone                            = Terminado
+LayoutControls                        = Controlos de disposição
+LayoutWidthHalf                       = Meia coluna
+LayoutWidthFull                       = Coluna inteira
+LayoutWidthSpan                       = Largura total
+LayoutSaved                           = Disposição guardada
+LayoutReset                           = Repor
+LayoutResetTitle                      = Repor a disposição (voltar aos valores predefinidos)
+LayoutDensity                         = Densidade de apresentação
+LayoutDensityCompact                  = Compacto
+LayoutDensityCozy                     = Confortável
+LayoutDensitySpacious                 = Espaçoso
+AddTag                                = Adicionar uma etiqueta
+TagAdded                              = Etiqueta adicionada
+TagRemoved                            = Etiqueta retirada
+Preview                               = Pré-visualização
+OpenInNewTab                          = Abrir num novo separador
+FileDeleted                           = Ficheiro eliminado
+OtherTicket                           = outro ticket
+OtherTickets                          = outros tickets
+SeeOtherTicketsForThisCompany         = Ver o histórico de tickets deste cliente
+StatusTimeline                        = Cronologia do estado
+WatchTicket                           = Seguir este ticket
+UnwatchTicket                         = Deixar de seguir este ticket
+TicketWatched                         = Ticket seguido
+TicketUnwatched                       = Ticket retirado do seguimento
+WatchedTicket                         = Ticket seguido
+WatchedOnly                           = Apenas os seguidos
+AllTickets                            = Todos
+NoWatchedTicket                       = Nenhum ticket seguido
+FileUploaded                          = Ficheiro enviado
+UploadFile                            = Escolher um ficheiro
+OrDropAnywhere                        = ou arraste e largue no cartão
+Messages                              = Mensagens
+TypeYourReply                         = Escreva a sua resposta…
+PrivateMessage                        = Mensagem privada
+Send                                  = Enviar
+NoMessageYet                          = Nenhuma mensagem de momento
+BeFirstToReply                        = Seja o primeiro a responder
+MessagePosted                         = Mensagem enviada
+MessageEdited                         = Mensagem modificada
+MessageDeleted                        = Mensagem eliminada
+ConfirmDeleteMessage                  = Eliminar esta mensagem?
+ReplyByEmail                          = Enviar por email
+SentByMail                            = Enviado por email
+MailSentToNRecipients                 = email enviado a %d destinatário(s)
+MailNotSent                           = falha no envio do email
+NoRecipientFound                      = nenhum destinatário encontrado
+OriginalMessage                       = Mensagem original
+JustNow                               = agora mesmo
+NMinAgo                               = há %d min
+NHAgo                                 = há %d h
+NDAgo                                 = há %d d
+NAttachedFiles                        = %d ficheiro(s) anexo(s)
+Quote                                 = Citar
+NotAllowed                            = Ação não autorizada
+Private                               = Privado
+Unknown                               = Desconhecido
+LayoutTagsMode                        = Apresentação das etiquetas
+LayoutTagsModeChips                   = Lista completa (chips)
+LayoutTagsModeSelector                = Seletor pendente
+LayoutActionsMode                     = Apresentação das ações
+LayoutActionsModeBar                  = Barra de ações
+LayoutActionsModeMenu                 = Menu (⋮)
+Move                                  = Mover
+Hide                                  = Ocultar
+Show                                  = Mostrar
+
+# ===========================================================================
+# Kanban de tickets — configuração do registo de eventos — issue #4753
+# ===========================================================================
+TicketKanban                           = Kanban de tickets
+TicketKanbanLogging                    = Kanban de tickets — Histórico das modificações
+TicketKanbanLoggingDescription         = Ativar a criação de eventos aquando das modificações no kanban
+TicketKanbanLogStatus                  = Modificação do estado
+TicketKanbanLogStatusDesc              = Criar um evento quando o estado de um ticket é modificado através do kanban
+TicketKanbanLogAssignee                = Modificação do responsável
+TicketKanbanLogAssigneeDesc            = Criar um evento quando o responsável de um ticket é modificado através do kanban
+TicketKanbanLogCategoryAdd             = Adição de uma etiqueta
+TicketKanbanLogCategoryAddDesc         = Criar um evento quando uma etiqueta é adicionada a um ticket através do kanban
+TicketKanbanLogCategoryRemove          = Retirada de uma etiqueta
+TicketKanbanLogCategoryRemoveDesc      = Criar um evento quando uma etiqueta é retirada de um ticket através do kanban
+TicketKanbanLogType                    = Modificação do tipo
+TicketKanbanLogTypeDesc                = Criar um evento quando o tipo de um ticket é modificado através do kanban
+TicketKanbanLogGroup                   = Modificação do grupo
+TicketKanbanLogGroupDesc               = Criar um evento quando o grupo de um ticket é modificado através do kanban
+TicketKanbanLogSeverity                = Modificação da severidade
+TicketKanbanLogSeverityDesc            = Criar um evento quando a severidade de um ticket é modificada através do kanban
+TicketKanbanLogSubject                 = Modificação do assunto
+TicketKanbanLogSubjectDesc             = Criar um evento quando o assunto de um ticket é modificado através do kanban
+TicketKanbanLogDeadline                = Modificação da data limite
+TicketKanbanLogDeadlineDesc            = Criar um evento quando a data limite de um ticket é modificada através do kanban
+TicketKanbanClosedLimit                = Limite de tickets encerrados
+TicketKanbanClosedLimitDesc            = Número máximo de tickets encerrados/anulados apresentados no kanban (0 = ilimitado)
+
+# ===========================================================================
+# Ticket — rastreabilidade das modificações — issue #4885
+# ===========================================================================
+TicketLogModifications                 = Rastreabilidade das modificações
+TicketLogModificationsDesc             = Criar um evento para cada edição efetuada a partir da ficha do ticket (assunto, mensagem, registos, responsável, terceiro, projeto, progresso, estado, tarefas, documentos)
+TicketMessageEdited                    = Mensagem modificada
+TicketMessageDeleted                   = Mensagem eliminada
+TicketTaskCreated                      = Tarefa criada: %s
+TicketDocumentGenerated                = Documento gerado
+TicketFileDeleted                      = Ficheiro eliminado
+
+# Painel de criação rápida de ticket
+SelectNothing                          = — Selecionar —
+QuickCreateTicket                      = Criar rapidamente um ticket
+TicketSubjectPlaceholder               = Título do ticket...
+TicketInitialMessage                   = Mensagem inicial
+OptionalDescription                    = Descrição (opcional)...
+Unassigned                             = Não atribuído
+QuickCreateAttachments                 = Anexos
+QuickCreateDropzone                    = Arraste e largue ou clique para selecionar
+QuickCreateDropzoneActive              = Largue aqui…
+QuickCreateAttachmentHint              = Formatos aceites: imagens, PDF, documentos. Máx. 10 MB por ficheiro.
+QuickCreateTicketSuccess               = Ticket %s criado com êxito.
+
+# MeteoVigilance - Alerta meteorológico Météo-France
+MeteoVigilance = Alerta meteorológico Météo-France
+MeteoVigilancePanelTitle = Alerta %s
+MeteoVigilanceAdvice2 = Esteja atento
+MeteoVigilanceAdvice3 = Esteja muito vigilante
+MeteoVigilanceAdvice4 = Vigilância absoluta
+MeteoVigilanceUpdatedAt = Atualizado %s
+MeteoVigilanceEnabled = Ativar o alerta meteorológico
+MeteoVigilanceEnabledDescription = Mostra o widget de alerta meteorológico Météo-France no painel (e a faixa de alerta em caso de alerta laranja/vermelho).
+MeteoVigilanceLevel = Nível de alerta
+MeteoVigilanceActivePhenomena = Fenómenos ativos
+MeteoVigilanceNoAlert = Nenhum alerta em particular
+MeteoVigilanceSource = Fonte
+MeteoVigilanceSeeOnMeteoFrance = Ver em vigilance.meteofrance.fr
+MeteoVigilanceNotConfigured = Chave API Météo-France não configurada — clique para configurar
+MeteoVigilanceUnknownDepartment = Distrito da empresa não determinado
+MeteoVigilanceUnavailable = Dados de alerta momentaneamente indisponíveis
+MeteoVigilanceBannerTitle = Alerta %s em curso no distrito %s
+MeteoVigilanceLevel1 = Verde
+MeteoVigilanceLevel2 = Amarelo
+MeteoVigilanceLevel3 = Laranja
+MeteoVigilanceLevel4 = Vermelho
+MeteoVigilancePhenomenon1 = Vento forte
+MeteoVigilancePhenomenon2 = Chuva e inundação
+MeteoVigilancePhenomenon3 = Trovoadas
+MeteoVigilancePhenomenon4 = Cheias
+MeteoVigilancePhenomenon5 = Neve e gelo
+MeteoVigilancePhenomenon6 = Onda de calor
+MeteoVigilancePhenomenon7 = Frio intenso
+MeteoVigilancePhenomenon8 = Avalanches
+MeteoVigilancePhenomenon9 = Agitação marítima e galgamento costeiro
+MeteoVigilanceSetup = Configuração do alerta meteorológico
+MeteoVigilanceApiKey = Chave API Météo-France
+MeteoVigilanceApiKeyDescription = Chave API do portal Météo-France (crie uma conta e uma aplicação «Bulletin Vigilance» em <a href="https://portail-api.meteofrance.fr" target="_blank">portail-api.meteofrance.fr</a> para gerar a chave).
+MeteoVigilanceDepartment = Código de distrito (substituição)
+MeteoVigilanceDepartmentDescription = Deixe vazio para deduzir automaticamente o distrito a partir da morada da empresa. Caso contrário, introduza um código (ex.: 35, 2A).
+MeteoVigilanceCacheTTL = Duração da cache (segundos)
+MeteoVigilanceCacheTTLDescription = Período durante o qual os dados da API são colocados em cache antes de uma nova chamada (predefinição 3600).
+MeteoVigilanceSettings = Configuração do alerta meteorológico
+MeteoVigilanceRefreshNow = Atualizar agora
+MeteoVigilanceRefreshed = Dados atualizados: alerta %s no distrito %s
+
+# Sistema de conversação dos tickets
+Conversation = Conversação
+PublicMessage = Mensagem pública
+ConvTo = Para
+ConvCc = Cc
+
+SaveNote = Guardar a nota
+
+AddRecipient = Adicionar um destinatário
+NoRecipientFound = Nenhum destinatário
+
+AddFile = Adicionar um ficheiro
+
+MentionAgents = Mencionar agentes
+YouWereMentionedOnTicket = Foi mencionado no ticket %s
+YouWereMentionedOnTicketBody = %s mencionou-o no ticket %s:
+
+Mentioned = Mencionado
+
+# Criação rápida móvel do plano de prevenção
+MobileQuickCreation = Criação rápida móvel
+MobilePPInteriorCompany = Empresa utilizadora (interior)
+MobilePPResponsibleAutoSign = Responsável (assina automaticamente)
+MobilePPSignatureSaved = Assinatura guardada
+MobilePPEditSignature = Modificar a assinatura
+MobilePPDrawSignatureHint = Desenhe a sua assinatura abaixo e guarde-a. Será reutilizada nos seus próximos planos.
+MobilePPClearSignature = Apagar
+MobilePPSaveSignature = Guardar a minha assinatura
+MobilePPExteriorCompany = Empresa externa
+MobileSirenOrSiret = SIREN / SIRET
+MobileSirenOrSiretPlaceholder = 9 ou 14 algarismos
+MobilePPResponsibleToSign = Responsável que deve assinar
+MobilePPChooseExistingContact = Escolher um contacto existente
+MobilePPNewContact = Novo contacto
+MobilePPEmailForSignatureHelp = Este email receberá o pedido de assinatura.
+MobilePPPeriod = Período de intervenção
+MobilePPMaxOneYearHint = 1 ano no máximo entre a data de início e a data de fim.
+MobilePPSubmit = Criar o plano de prevenção
+MobilePPErrorNoSignature = Deve guardar a sua assinatura antes de criar o plano.
+MobilePPErrorEmptySignature = A assinatura está vazia.
+MobilePPErrorInvalidSiren = SIREN ou SIRET inválido (9 ou 14 algarismos esperados).
+MobilePPErrorEndBeforeStart = A data de fim deve ser posterior à data de início.
+MobilePPErrorMaxOneYear = A duração não pode exceder 1 ano.
+MobilePPErrorDatesRequired = Indique a data de início e a data de fim.
+MobilePPErrorStartRequired = Falta a data de início.
+MobilePPErrorEndRequired = Falta a data de fim.
+MobilePPErrorNoProject = Não está configurado nenhum projeto de plano de prevenção predefinido.
+MobilePPCompanyFound = Empresa encontrada:
+MobilePPCompanyNotFound = Nenhuma empresa encontrada na base de dados: será criada uma nova.
+MobilePPWarningEmailNotSent = O plano foi criado, mas não foi possível enviar o email de assinatura.
+MobilePPWarningEmailNotConfigured = O plano foi criado, mas o email não está configurado: pedido de assinatura não enviado.
+MobilePPCreated = Plano de prevenção %s criado.
+MobilePPUpdated = Plano de prevenção %s atualizado.
+MobilePPSignatureEmailSubject = Pedido de assinatura do plano de prevenção %s
+MobilePPSignatureEmailContent = Bom dia,<br><br>Está convidado a assinar o plano de prevenção relativo a %s.<br><br><a href="%s">Clique aqui para assinar</a><br><br>Com os melhores cumprimentos.
+MobilePPSuccessTitle = Plano de prevenção criado
+MobilePPSuccessText = O responsável interior assinou automaticamente. Foi enviado um pedido de assinatura à empresa externa.
+MobilePPViewPlan = Ver o plano
+MobilePPCreateAnother = Criar outro plano
+MobileSuccessInteriorSigned = Responsável interior: assinado
+MobileSuccessExteriorNotified = Empresa externa: pedido de assinatura enviado
+MobileSuccessExteriorNotSigned = Empresa externa: assinatura por recolher
+MobileSuccessExteriorNotNotified = Empresa externa: pedido de assinatura não enviado
+MobileSuccessExteriorSigned = Empresa externa: assinado
+MobileSuccessDocumentGenerated = Documento do plano gerado
+MobilePPWarningEmailNotSentDetail = Não foi possível enviar o email de assinatura: %s
+MobilePPWarningNoRecipientEmail = nenhum endereço de email válido para o responsável exterior
+MobilePPSignatureEmailSentTo = Pedido de assinatura enviado a %s
+MobilePPExtSignatureTitle = Assinatura da empresa externa
+MobilePPExtEmailSentOn = Pedido enviado a %s em %s
+MobilePPExtEmailNotSent = Pedido de assinatura não enviado: transmita a ligação ou solicite a assinatura agora
+MobilePPSpreadDefaultsTitle = Apresentação pública da difusão
+MobilePPSpreadShowCount = Mostrar o número de signatários
+MobilePPSpreadShowName = Mostrar o nome e o apelido
+MobilePPSpreadShowContact = Mostrar o telefone e o email
+MobilePPSpreadHidePublicNote = Não mostrar a nota pública
+MobilePPExtAlreadySigned = Assinado em %s
+MobilePPExtSignNow = Solicitar a assinatura agora
+MobilePPExtResendEmail = Reenviar o email
+MobilePPNoTagAvailable = Não está disponível nenhuma etiqueta de plano de prevenção.
+MobilePPCreateTag = Criar uma etiqueta
+MobileSpreadShareTitle = Partilhar a difusão
+MobileSpreadShareText = Peça às pessoas em causa que leiam este código. Sem conta nem ligação, indicam os seus contactos, entregam os seus documentos e assinam.
+MobileSpreadOpen = Abrir a difusão
+MobilePPRisks = Riscos
+MobilePPAddRisk = Adicionar um risco
+MobilePPRiskModalTitle = Escolher um risco
+MobilePPRiskComment = Comentário
+MobilePPRiskDescriptionPlaceholder = Descrever o risco no local
+MobilePPNoRiskYet = Nenhum risco adicionado de momento.
+MobilePPDeleteRiskTitle = Eliminar o risco
+MobilePPDeleteRiskConfirm = «%s» será retirado do plano, com a sua descrição, as suas fotos e as suas proteções.
+MobilePPUserCompany = Empresa utilizadora
+MobilePPUserCompanyShort = EU
+MobilePPConcernedCompanies = Diz respeito a
+MobilePPExteriorCompanyShort = EE
+MobilePPPriorFormalities = Formalidades prévias
+MobilePPPriorVisitDone = Inspeção conjunta prévia efetuada
+MobilePPPriorVisitTextPlaceholder = O que foi constatado durante a inspeção
+MobileRiskCompanies = Empresas em causa pelos riscos (móvel)
+CertificationDictionary = Certificações e habilitações
+MobilePPChooseExistingCompany = Escolher um terceiro existente
+MobilePPOrFillManually = ou introduzir as informações
+MobilePPProtections = Proteções
+MobilePPAddProtection = Adicionar uma proteção
+MobilePPProtectionModalTitle = Escolher uma proteção
+MobilePPMandatory = Obrigatório
+MobileProtections = Proteções (móvel)
+MobilePPCertifications = Certificações obrigatórias
+MobilePPAddCertification = Adicionar uma certificação
+MobileCertifications = Certificações (móvel)
+MobilePPUploadCertPhoto = Enviar uma foto
+MobilePPErrorCreatingThirdparty = Erro ao criar o terceiro.
+MobilePPErrorCreatingContact = Erro ao criar o contacto.
+MobilePPErrorUpdatingPlan = Erro ao atualizar o plano de prevenção.
+MobilePPErrorCreatingPlan = Erro ao criar o plano de prevenção.
+MobileSuccessViewDocument = Ver o documento
+MobileSuccessPlanSentByEmailOn = Plano de prevenção enviado por email em %s
+MobileSuccessExteriorSignedOn = Responsável da Empresa Externa (EE): Assinado em %s
+MobileSuccessExteriorPendingSignature = Responsável da Empresa Externa (EE): A aguardar assinatura
+MobilePPDefaultsTitle = Valores predefinidos (criação móvel)
+MobilePPDefaultDateStartToday = Data de início = data de hoje
+MobilePPDefaultDuration = Duração predefinida do período (dias)
+MobilePPEmailAutoSend = Enviar automaticamente o email de assinatura na criação
+
+# Criação rápida móvel da licença de fogo
+MobileFPPreventionPlanHelp = A empresa externa e o período do plano selecionado são retomados automaticamente.
+MobileFPPeriod = Local e período dos trabalhos
+MobileFPMaxOneMonthHint = Um mês no máximo entre o início e o fim dos trabalhos.
+MobileFPErrorMaxOneMonth = A duração não pode exceder um mês.
+MobileFPErrorNoProject = Não está configurado nenhum projeto de licença de fogo predefinido.
+MobileFPWorkTypes = Tipos de trabalhos
+MobileFPAddWorkType = Adicionar um tipo de trabalhos
+MobileFPWorkTypeModalTitle = Escolher um tipo de trabalhos
+MobileFPSubmit = Criar a licença de fogo
+MobileFPCreated = Licença de fogo %s criada.
+MobileFPUpdated = Licença de fogo %s atualizada.
+MobileFPSignatureEmailSubject = Pedido de assinatura da licença de fogo %s
+MobileFPSignatureEmailContent = Bom dia,<br><br>Está convidado a assinar a licença de fogo para %s.<br><br><a href="%s">Clique aqui para assinar</a><br><br>Com os melhores cumprimentos.
+MobileFPSuccessTitle = Licença de fogo criada
+MobileFPViewPermit = Ver a licença
+MobileFPCreateAnother = Criar outra licença
+
+# PWA Digirisk
+PwaApplication = Aplicação móvel
+PwaNavHome = Início
+PwaNavPreventionPlans = Planos
+PwaNavFirePermits = Licenças
+PwaNavMenu = Menu
+PwaNavFavoritesHint = Favoritos apresentados em baixo (máx. %s)
+PwaNavAddFavorite = Adicionar aos favoritos
+PwaNavRemoveFavorite = Retirar dos favoritos
+PwaHello = Bom dia %s
+PwaResultCount = %s resultado(s)
+AllStatus = Todos os estados
+PwaTilePreventionPlanInProgress = Planos em curso
+PwaTilePreventionPlanToSign = Planos a assinar
+PwaTileFirePermitInProgress = Licenças em curso
+PwaTileFirePermitToSign = Licenças a assinar
+
+# Ações em massa sobre as tarefas
+MassValidateTasks = Validar as tarefas
+MassChangeTasksProject = Mudar de projeto
+ConfirmMassValidateTasksQuestion = Tem a certeza de que pretende validar as %s tarefa(s) selecionada(s)? Apenas serão validadas as tarefas com o estado rascunho.
+ConfirmMassChangeTasksProjectQuestion = Tem a certeza de que pretende associar as %s tarefa(s) selecionada(s) ao projeto escolhido?
+MassValidateTasksSuccess = %s tarefa(s) validada(s) em %s selecionada(s)
+MassChangeTasksProjectSuccess = %s tarefa(s) associada(s) ao projeto %s
+
+# PDF do plano de prevenção
+PreventionPlanLegalNotice = O plano de prevenção é um documento obrigatório destinado a prevenir os riscos decorrentes da interferência entre as atividades de várias empresas num mesmo local, nos termos do artigo R4512-7 do Código do Trabalho francês.
+PreventionPlanUserCompany = Empresa Utilizadora - EU
+PreventionPlanExteriorCompany = Empresa Externa - EE
+PreventionPlanUserCompanyResponsible = Responsável da Empresa Utilizadora (EU)
+PreventionPlanExteriorCompanyResponsible = Responsável da Empresa Externa (EE)
+EmergencyNumbers = Números de emergência
+Firefighters = Bombeiros
+AnyEmergency = Qualquer emergência
+PriorVisitIntro = A empresa utilizadora procedeu, previamente à execução da operação, a uma inspeção conjunta prévia com data de %s. Durante esta visita, os seguintes pontos foram apresentados pela empresa utilizadora (art. R. 4512-2 e R. 4512-3 do Código do Trabalho francês):
+PriorVisitCheckList = Locais de trabalho|Instalações aí existentes|Materiais eventualmente disponibilizados às empresas externas|Delimitar o setor de intervenção das empresas externas|Assinalar as zonas deste setor que podem apresentar perigos para os trabalhadores|Indicar as vias de circulação que os trabalhadores poderão utilizar, bem como os veículos e máquinas de qualquer natureza pertencentes às empresas externas|Definir as vias de acesso dos trabalhadores às instalações destinadas às EE (nomeadamente as instalações sanitárias, vestiários coletivos e locais de refeição)
+PriorVisitComments = Foram registados os seguintes comentários:
+InterventionPeriodSentence = Este plano começa em %s e termina em %s. As intervenções decorrerão nos seguintes horários:
+RiskAnalysisIntro = Previu %s intervenção(ões) para este plano de prevenção: a seguir, o detalhe das ações previstas, os riscos gerados e os meios de prevenção implementados.
+PreventionPlanAttendants = Intervenientes: Empresa Externa (EE) e subcontratados
+Morning = Manhã
+Afternoon = Tarde
+Signatures = Assinaturas
+SignaturePending = A aguardar
+PreventionPlanRiskPhotos = Fotos do risco
+InterventionPeriodOnly = Este plano começa em %s e termina em %s.
+
+DigiRisk=DigiRisk
+DigiriskIdentification=DESCRIÇÃO E CARACTERÍSTICAS
+DigiriskSecurity=SEGURANÇA
+DigiriskUserManual=MODO DE UTILIZAÇÃO SIMPLIFICADO
+DigiriskQualification=QUALIFICAÇÃO E HABILITAÇÃO
+DigiriskHygiene=HIGIENE E LIMPEZA
+DigiriskMaintenance=MANUTENÇÃO E CONTROLOS
+DangerCategory=Família de risco
+SelectDangerCategory=Escolher uma família de risco
+DescribeRiskOnProduct=Descrever o risco neste produto...
+ConfirmDeleteProductRisk=Eliminar este risco?
+AddProductRisk=Adicionar um risco de produto
+ClickToAddContent=Clique para adicionar conteúdo...
+AddProtection=Adicionar uma proteção
+
+SelectProtection=Escolher uma proteção EPI
+TechnicalSheet=Ficha técnica
+DigiriskRisks=RISCOS E PROTEÇÕES
+MobileSuccessInteriorSignedOn=Responsável da Empresa Utilizadora (EU): Assinado em %s
+
+MobileSuccessPlanSentByEmailOn = Plano de prevenção enviado por email em %s
+MobileSuccessExteriorSignedOn = Responsável da Empresa Externa (EE): Assinado em %s
+MobileSuccessExteriorPendingSignature = Responsável da Empresa Externa (EE): A aguardar assinatura
+
+MobilePPErrorInvalidEmail = Respeite o formato do email.
+MobilePPErrorInvalidPhone = Respeite o formato do telefone.
+MobilePPExtSendEmail = Enviar o email
+MobilePPErrorMailServerNotConfigured = O seu servidor de email não está configurado, contacte o administrador.
+MobilePPDoliletterNotInstalled = O módulo Doliletter não está instalado. A difusão dos planos de prevenção e licenças de fogo não estará disponível (contacte o seu administrador)
+
+# Estados e tipos para as ajudas
+preventionplan = Plano de prevenção
+Locked = Bloqueado
+InProgress = Em curso
+ValidatePendingSignature = A aguardar assinatura
+Archived = Arquivado
+
+ProductFIChaptersManagement=Personalização dos capítulos da ficha de instrução
+ProductFIChaptersManagementSub=Personalização do separador "Ficha de instrução" e do separador "Riscos" na ficha do produto
+DefaultContent=Conteúdo predefinido
+CustomSvgUploaded=SVG personalizado
+DeleteCustomSvg=Eliminar
+DefaultSvgUsed=SVG predefinido
+
+PwaTilePreventionPlanLocked = Planos validados
+PwaTileFirePermitLocked = Licenças validadas
+
+# ===========================================================================
+# Dicionário das colunas do Kanban do plano de ação — issue #5017
+# ===========================================================================
+ActionPlanColumnDictionary           = Colunas do Kanban do plano de ação
+ActionPlanColumnDictionaryDesc       = Colunas apresentadas no Kanban do PAPRIPACT quando o modo dicionário está ativado: designação, intervalo de progresso, cor e ícone
+KanbanColumnSource                   = Origem das colunas
+KanbanColumnSourceDesc               = Dividir o Kanban com os limiares de percentagem abaixo (funcionamento histórico) ou com o dicionário das colunas
+KanbanColumnSourceThresholds         = Limiares de percentagem (predefinição)
+KanbanColumnSourceDictionary         = Dicionário das colunas
+ActionPlanColumnProgressHelp         = Limites de progresso abrangidos pela coluna, de 0 a 100
+ActionPlanColumnColorHelp            = Cor hexadecimal da coluna, por exemplo #3085d6
+ActionPlanColumnPictoHelp            = Nome de ícone Font Awesome, por exemplo fa-check
+Progress_min                         = Progresso mín.
+Progress_max                         = Progresso máx.
+Picto                                = Ícone
+
+# Acompanhamento do tempo despendido
+GenerateTimeSpentReport = Gerar o acompanhamento de tempo (PDF)
+TimeSpentReport = Acompanhamento do tempo despendido
+TimeSpentReportUsersHelp = Deixe vazio para incluir todas as pessoas que registaram tempo neste projeto.
+TimeSpentReportSummary = Resumo por utilizador
+TimeSpentReportGrandTotal = Total geral
+TimeSpentReportGeneratedAt = Gerado em
+TimeSpentReportWholePeriod = Desde o início do projeto
+TimeSpentReportNoData = Nenhum tempo despendido corresponde aos utilizadores e ao período selecionados.
+TimeSpentDocumentPDFDescription = Tempo despendido num projeto, agrupado por utilizador
+
+# Paridade da licença de fogo móvel com o plano de prevenção - issue #5042
+MobileProgress = Progresso
+MobileStepDone = FEITO
+MobileStepInProgress = EM CURSO
+MobileStepTodo = A FAZER
+MobileStepSignedOn = ASSINADO EM
+MobilePPStepCreated = PP criado
+MobileFPStepCreated = LF criada
+MobileStepUserCompanyResponsible = Resp. EU
+MobileStepExteriorCompanyResponsible = Resp. EE
+MobileStepLock = Bloquear
+MobileStepArchive = Arquivar
+MobileLock = Bloquear
+MobileResponsibleShort = Resp.
+MobileMailSentTo = Email enviado a
+MobilePPMotif = Motivo da intervenção
+MobilePPSchedules = Horários de intervenção
+MobilePPConfigHours = Configure aqui os seus horários
+MobilePPCopyCompanyHours = Copiar os horários da empresa
+FirePermitUserCompany = Empresa Utilizadora - EU
+FirePermitExteriorCompany = Empresa Externa - EE
+MobileFPMotif = Motivo dos trabalhos
+MobileFPMotifPlaceholder = Ex.: soldadura em estrutura
+MobileFPNoMotif = Nenhum motivo indicado
+MobileFPSchedules = Horários dos trabalhos
+MobileFPWorkTypeDescriptionPlaceholder = Descrever os trabalhos no local
+MobileFPNoWorkTypeYet = Nenhum tipo de trabalhos adicionado de momento.
+MobileFPDeleteWorkTypeTitle = Eliminar o tipo de trabalhos
+MobileFPDeleteWorkTypeConfirm = «%s» será retirado da licença, com a sua descrição, o seu material, as suas fotos e as suas proteções.
+MobileFPNoTagAvailable = Não está disponível nenhuma etiqueta de licença de fogo.
+MobileFPErrorUpdatingPermit = Erro ao atualizar a licença de fogo.
+MobileFPErrorCreatingPermit = Erro ao criar a licença de fogo.
+MobileFPLockNeedsSignature = A licença deve estar assinada antes de poder ser bloqueada.
+MobileFPSpreadAvailableOnceSignedAndLocked = A difusão estará disponível assim que a licença for assinada pelos responsáveis e bloqueada.
+MobileFPDefaultDateStartToday = Data de início = data de hoje
+MobileFPDefaultDuration = Duração predefinida do período (dias)
+firepermit = Licença de fogo
+ErrorRecordIsLocked = Este registo está bloqueado, já não pode ser modificado.
+MobilePPEmailTemplateExt = Modelo de email para o responsável da empresa externa
+MobilePPEmailTemplateInt = Modelo de email para os intervenientes da empresa externa
+
+#
+# ListingRisksDocument PDF - Listagem de riscos em formato PDF
+#
+
+ListingRisksDocumentPDF            = Listagem de riscos PDF
+ListingRisksDocumentPDFDescription = Listagem de riscos em PDF nativo, aberta no mini documento de avaliação de riscos do elemento
+ListingRisksDocumentPDFTitle       = AVALIAÇÃO DE RISCOS
+ListingRisksEstablishment          = Estabelecimento
+ListingRisksCoverContent           = Conteúdo
+ListingRisksCoverHierarchy         = Hierarquia
+ListingRisksCoverDuerpFollowUp     = Acompanhamento do documento de avaliação de riscos
+ListingRisksCoverEmergencyNumbers  = Números de emergência
+ListingRisksCoverReportIncident    = Comunicar um acidente ou um problema
+ListingRisksCoverRegisters         = Registos de segurança e saúde no trabalho e de perigo grave e iminente
+ListingRisksCoverIllustration      = Imagem de ilustração
+NoPreventionOfficerAssigned        = Nenhum responsável pela prevenção designado
+NoEmergencyNumberConfigured        = Nenhum número de emergência configurado
+NoResponsibleAssigned              = Nenhum responsável designado
+ListingRisksLegalTitle             = Enquadramento regulamentar
+RiskDefinitionTitle                = Definição de um risco
+RiskDefinitionText                 = Risco: n. masc. Perigo ou inconveniente a que alguém se expõe. Fazer algo por sua conta e risco, assumindo toda a responsabilidade pelas consequências. Um risco calculado. Correr riscos: expor-se a um perigo.
+DangerDefinitionTitle              = Definição de um perigo
+DangerDefinitionText               = Perigo: n. masc. (do latim popular dominiarium «poder», de dominus «senhor»; inicialmente o facto de estar à mercê de alguém). O que ameaça a segurança ou a vida de alguém; o que pode comprometer uma situação, um empreendimento, etc.
+SingleDocumentTitle                = O documento de avaliação de riscos
+SingleDocumentText                 = O documento de avaliação de riscos é regido pelos artigos R4121-1 a 4 do Código do Trabalho francês. Os princípios gerais de prevenção impõem a ordem de tratamento do risco.
+PreventionPrinciplesTitle          = Os princípios gerais de prevenção - Artigo L4121-2
+PreventionPrinciplesIntro          = O empregador aplica as medidas previstas no artigo L. 4121-1 com base nos seguintes princípios gerais de prevenção:
+PreventionPrinciple1               = Evitar os riscos.
+PreventionPrinciple2               = Avaliar os riscos que não podem ser evitados.
+PreventionPrinciple3               = Combater os riscos na origem.
+PreventionPrinciple4               = Adaptar o trabalho ao Homem, em especial no que respeita à conceção dos postos de trabalho, bem como à escolha dos equipamentos de trabalho e dos métodos de trabalho e de produção, tendo em vista, nomeadamente, limitar o trabalho monótono e o trabalho cadenciado e reduzir os seus efeitos sobre a saúde.
+PreventionPrinciple5               = Ter em conta o estado de evolução da técnica.
+PreventionPrinciple6               = Substituir o que é perigoso pelo que não é perigoso ou pelo que é menos perigoso.
+PreventionPrinciple7               = Planear a prevenção integrando, num conjunto coerente, a técnica, a organização do trabalho, as condições de trabalho, as relações sociais e a influência dos fatores ambientais, nomeadamente os riscos associados ao assédio moral e ao assédio sexual, bem como os associados a comportamentos sexistas.
+PreventionPrinciple8               = Adotar medidas de proteção coletiva dando-lhes prioridade sobre as medidas de proteção individual.
+PreventionPrinciple9               = Dar as instruções adequadas aos trabalhadores.
+ListingRisksCotationMethodTitle    = Método de cálculo das cotações
+ListingRisksCotationMethodText     = A cotação de um risco é uma pontuação de 0 a 100 atribuída durante a sua avaliação. O nível de risco indicado na listagem decorre diretamente dela, de acordo com a grelha abaixo.
+ListingRisksCotationLevel          = Nível
+ListingRisksCotationRange          = Cotação
+ListingRisksCotationMeaning        = Significado
+ListingRisksCotationAction         = Procedimento a adotar
+ListingRisksCotationAction1        = Manter os meios de prevenção existentes.
+ListingRisksCotationAction2        = Inscrever uma ação no programa anual de prevenção.
+ListingRisksCotationAction3        = Iniciar uma ação de prevenção a curto prazo.
+ListingRisksCotationAction4        = Agir imediatamente, a exposição deve cessar.
+ListingRisksListTitle              = Lista de riscos
+ListingRisksActionPlan             = Ações do programa anual de prevenção
+ListingRisksCotationColumn         = Cot.
+ListingRisksRiskColumn             = Risco
+ListingRisksAssessmentColumn       = Informações sobre a avaliação
+NoRiskAssessed                     = Nenhum risco avaliado neste perímetro

--- a/langs/pt_PT/index.php
+++ b/langs/pt_PT/index.php
@@ -1,0 +1,2 @@
+<?php
+//Silence is golden

--- a/langs/ro_RO/digiriskdolibarr.lang
+++ b/langs/ro_RO/digiriskdolibarr.lang
@@ -1,0 +1,2387 @@
+# Copyright (C) 2021-2023 EVARISK <technique@evarisk.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#
+# General
+#
+
+# Module label 'ModuleDigiriskdolibarrName'
+ModuleDigiriskdolibarrName = Digirisk
+
+# Module description 'ModuleDigiriskdolibarrDesc'
+ModuleDigiriskdolibarrDesc = Digirisk pentru Dolibarr
+
+# Modulul Saturne lipsește
+SaturneModuleMissing = Modulul Saturne este necesar pentru Digirisk. Descărcați-l gratuit de pe Dolistore (https://dolistore.com/en/modules/1906-Saturne.html) și instalați-l înainte de a activa Digirisk.
+
+# Coloana imaginilor tutorial din paginile de configurare
+TutoImage = Imagine
+
+#
+# Pagina de administrare
+#
+
+# Date
+DigiriskdolibarrSetup       = Configurarea modulului Digirisk
+DigiriskdolibarrSetupPage        = Pagina de configurare a modulului Digirisk
+AgendaModuleRequired        = Pentru a asigura trasabilitatea acțiunilor în Digirisk, asigurați-vă că modulul Agendă este activat
+DigiriskDolibarrDescription = Digirisk pentru Dolibarr
+HowToSetupOtherModules      = Pentru mai multe funcționalități în Digirisk, puteți activa numeroase module (gestiunea furnizorilor, a facturilor etc.) la acest link:
+ConfigMyModules             = Configurarea modulelor
+AvoidLogoProblems              = Pentru a evita orice problemă legată de logouri în documentele generate, consultați aceste recomandări de configurare:
+LogoHelpLink                = https://wiki.dolibarr.org/index.php?title=Premiers_paramétrages
+SecurityConfiguration       = Configurarea datelor de securitate
+SocialConfiguration          = Configurarea datelor sociale
+Uncompleted                     = Necompletat
+DigiriskData                 = Date configurabile ale Digirisk
+DigiriskManagement          = Redirecționare după conectarea la site
+DigiriskDescription          = Redirecționare implicită către pagina de întâmpinare Digirisk în locul celei Dolibarr.
+HowToSetupIHM                   = Pentru mai multe opțiuni privind afișarea Dolibarr (configurarea imaginii de fundal etc.), puteți accesa acest link:
+ConfigIHM                    = Configurarea afișării
+ConfigDico                     = Accesați pagina de configurare a dicționarelor
+LinkedProject               = Proiect asociat
+DigiriskUpdate                  = Actualizarea Digirisk:
+Security                       = Securitate
+HowToSharedElement          = Pentru mai multe informații despre configurarea elementelor partajate, accesați acest link:
+
+HowToSharedElementLink        = https://wiki.dolibarr.org/index.php?title=Module_Digirisk#Configuration
+ConfigSharedElement         = Configurarea elementelor partajate (riscuri/semnalizări)
+DisabledSharedElement       = Opțiune dezactivată deoarece Multi-company nu este activat sau configurarea elementelor partajate (riscuri/semnalizări) nu a fost efectuată
+DigiriskEventAutoDesc       = Definiți aici evenimentele pentru care Digirisk va crea automat o intrare în agendă. Fiecare eveniment conține informațiile referitoare la acțiunea efectuată.
+DigiriskActionsEvents       = Evenimente pentru care Digirisk trebuie să insereze automat un eveniment în agendă.
+DigiriskDolibarr            = Digirisk
+Create                      = Creare
+
+# Ticket
+MultiCompanyTicketPublicInterfaceConfig = Configurarea interfeței publice a tichetelor multi-companie
+Subtitle                                = Subtitlu
+
+# DigiriskElement
+DigiriskElementDepthGraph            = Nivelul de profunzime în graficele elementelor Digirisk
+DigiriskElementDepthGraphDescription = Această opțiune permite alegerea nivelului de profunzime în graficele elementelor Digirisk <br> Implicit: nivelul 1
+
+# WHSRegister = Registru de securitate și sănătate în muncă
+TicketsPublicInterfaceConfig         = Configurarea interfeței publice a tichetelor
+WHSRegister                          = Registru de securitate și sănătate în muncă
+CurrentTicketPublicInterfaceURL      = URL-ul interfeței publice a tichetelor
+MulticompanyTicketPublicInterfaceURL = URL-ul interfeței publice a tichetelor multi-companie
+OriginURL                            = URL de origine
+ShortURL                             = URL scurtat
+ExternalURL                          = URL extern
+AddExtraField                        = Creați un câmp suplimentar
+IfEmptyVisibleAllCategories          = Dacă este gol, vizibil în toate categoriile
+
+# DigiQuali Sheet - Modele
+LinkDigiriskdolibarr_digiriskstandard                 = Activați legătura cu entitățile principale Digirisk Standard
+LinkDigiriskdolibarr_digiriskstandardDescription      = Permite legătura dintre entitățile standard Digirisk și modele
+LinkDigiriskdolibarr_digiriskelement                  = Activați legătura cu grupările și unitățile de lucru
+LinkDigiriskdolibarr_digiriskelementDescription       = Permite legătura dintre grupări și unitățile de lucru și modele
+LinkDigiriskdolibarr_risk                             = Activați legătura cu riscurile
+LinkDigiriskdolibarr_riskDescription                  = Permite legătura dintre riscuri și modele
+LinkDigiriskdolibarr_riskassessment                   = Activați legătura cu evaluările
+LinkDigiriskdolibarr_riskassessmentDescription        = Permite legătura dintre evaluări și modele
+LinkDigiriskdolibarr_evaluator                        = Activați legătura cu evaluatorii
+LinkDigiriskdolibarr_evaluatorDescription             = Permite legătura dintre evaluatori și modele
+LinkDigiriskdolibarr_risksign                         = Activați legătura cu semnalizările
+LinkDigiriskdolibarr_risksignDescription              = Permite legătura dintre semnalizări și modele
+LinkDigiriskdolibarr_preventionplan                   = Activați legătura cu planurile de prevenire
+LinkDigiriskdolibarr_preventionplanDescription        = Permite legătura dintre planurile de prevenire și modele
+LinkDigiriskdolibarr_firepermit                       = Activați legătura cu permisele de lucru cu foc
+LinkDigiriskdolibarr_firepermitDescription            = Permite legătura dintre permisele de lucru cu foc și modele
+LinkDigiriskdolibarr_accident                         = Activați legătura cu accidentele
+LinkDigiriskdolibarr_accidentDescription              = Permite legătura dintre accidente și modele
+LinkDigiriskdolibarr_accidentinvestigation            = Activați legătura cu anchetele de accident
+LinkDigiriskdolibarr_accidentinvestigationDescription = Permite legătura dintre anchete și modele
+
+#
+# DigiriskDolibarr
+#
+
+# Drept
+LireDigirisk                 = Consultarea tabloului de bord Digirisk
+ReadDigirisk                 = Consultarea tabloului de bord Digirisk (citire)
+YouDontHaveTheRightToSeeThis = Nu aveți dreptul să vedeți grupările și unitățile de lucru
+CanNotDoThis                 = Nu aveți dreptul să faceți acest lucru
+EnableDigiriskdolibarr       = Activați modulul DigiriskDolibarr pentru a accesa această pagină
+
+# Date
+DigiriskMenu          = Adăugați informații despre compania/organizația dumneavoastră. Faceți clic pe butonul "Salvare" din partea de jos a paginii pentru a le păstra
+DigiriskConfigSociety = Configurarea companiei
+PermissionDenied      = Permisiune refuzată
+AddUser               = Creați un utilizator
+StartDate             = Data de început
+EndDate               = Data de sfârșit
+NoPhoneNumber         = Fără număr de telefon
+HasBeenCreatedF       = a fost creată
+HasBeenCreatedM       = a fost creat
+HasNotBeenCreatedF    = nu a fost creată
+HasNotBeenCreatedM    = nu a fost creat
+YourDocuments         = Documente
+NoData                = N/A
+HasBeenEditedF        = a fost editată
+HasBeenEditedM        = a fost editat
+HasNotBeenEditedF     = nu a fost editată
+HasNotBeenEditedM     = nu a fost editat
+
+HasBeenDeletedF    = a fost ștearsă
+HasBeenDeletedM    = a fost șters
+HasNotBeenDeletedF = nu a fost ștearsă
+HasNotBeenDeletedM = nu a fost șters
+
+DigiriskUserGroup                 = Digirisk - Utilizatori
+DigiriskUserGroupDescription      = Grupul de utilizatori DigiRisk are dreptul de a consulta și modifica obiectele legate de DigiRisk
+DigiriskAdminUserGroup            = DigiRisk - Administratori
+DigiriskAdminUserGroupDescription = Grupul de administratori are toate drepturile asupra DigiRisk și a modulelor necesare
+DigiriskReaderGroup               = DigiRisk - Cititori
+DigiriskReaderGroupDescription    = Grupul de cititori are toate drepturile de citire asupra DigiRisk și a modulelor necesare
+
+ContractType              = Tip de contract
+Apprentice/Student        = Ucenic/Elev
+Interim                   = Lucrător temporar
+ProfessionalQualification = Calificare profesională
+DigiriskDocumentation     = Documentația Digirisk
+
+SelectUser               = Selectați un utilizator
+LabourInspectorFirstName = Inspector de
+LabourInspectorLastName  = muncă
+LabourInspector          = Inspector de muncă
+LabourInspectorSociety   = Terț Inspector de muncă
+LabourInspectorAssigned  = Inspector de muncă
+
+SocieteSchedules = Programul companiei
+weekDayDefault   = Vezi site-ul web
+weekEndDefault   = Închis Închis
+
+#
+# DigriskDocuments - Documente Digirisk
+#
+
+# Date
+DigiriskDocuments              = Document Digirisk
+Responsible                    = Responsabil
+ContactsAction                 = Contacte ale acțiunii
+PERCOTooltip                   = Dacă societatea dumneavoastră dispune de un plan de economii pentru pensie (PERCO), bifați această căsuță
+PEETooltip                     = Dacă societatea dumneavoastră dispune de un plan de economii al întreprinderii (PEE), bifați această căsuță
+ShowPictoName                  = Afișați numele pictogramei de pericol
+ShowPictoNameDescription       = Afișați numele pictogramei de pericol a riscului în documente <br> Util dacă doriți să transferați tabelul într-un program de calcul tabelar
+RiskAssessmentColor            = Culoarea evaluărilor
+RiskAssessmentColorDescription = Afișează culoarea evaluărilor în documentul Papripact-A3-Peisaj
+
+#
+# LegalDisplay - Afișaj legal
+#
+
+# Drept
+LegalDisplaysMin = Afișaje legale
+
+# Date
+LegalDisplay             = Afișaj legal
+Legaldisplay             = Afișaj legal
+HowToSetDataLegalDisplay = Pentru a configura datele afișajului legal, accesați Acasă - Configurare - Companie/Organizație - Securitate
+
+LegalDisplayDocumentGenerated       = Generarea afișajului legal
+LabourDoctor                        = Medic de medicina muncii
+LabourInspector                     = Inspector de muncă
+FireBrigade                         = Pompieri
+AllEmergencies                      = Orice urgență
+RightsDefender                      = Avocatul Poporului
+PoisonControlCenter                 = Centrul de Toxicologie
+Police                              = Poliția de urgență
+SafetyInstructions                  = Instrucțiuni de securitate
+ResponsibleToNotify                 = Responsabil de anunțat
+PreventionOfficers                  = Responsabili cu prevenirea
+PreventionOfficer                   = Responsabil cu prevenirea
+LocationOfDetailedInstructions      = Amplasarea instrucțiunii detaliate
+LocationOfDetailedInstructionsValue = Nicio instrucțiune detaliată la acest amplasament
+FirstAid                            = Primul ajutor
+FirstAidValue                       = <h2>Lista salvatorilor prezenți la fața locului (Nume, Companie, Telefon)</h2><br><br>Fiecare echipă trebuie constituită astfel încât, în orice împrejurare, să se poată acorda primul ajutor oricărui membru al echipei.<br />Salvatorii de la locul de muncă trebuie identificați clar și cunoscuți de toți.<h2>Cum se procedează în caz de accident</h2><br><br><h3>Accident ușor</h3><br><ul><li> - Îngrijiri acordate de salvatori</li><br><li> - Existența unei truse de prim ajutor</li></ul><br><br>Fiecare mașină este dotată cu cel puțin o trusă de prim ajutor care permite acordarea de îngrijiri pentru răni ușoare.<br><br><h3>Accident grav</h3><br><ul><li> - Anunțați salvatorul prezent la fața locului</li><br><li> - Declanșați procedura de urgență</li><br><li> - Informați responsabilul întreprinderii utilizatoare, serviciul de permanență 24/24</li><br><li> - Contactați în caz de accident</li></ul><br><br>Întreprinderea utilizatoare reamintește în anexă numerele de urgență. <br />
+AddPhoneNumber                      = Adăugați un număr de telefon utilizatorului
+ConfigureLabourInspector            = Configurați un inspector de muncă
+SocietyAdditionalDetails            = Informații suplimentare despre companie
+GeneralMeansAtDisposal              = Mijloace generale puse la dispoziție
+GeneralMeansAtDisposalValue         = <h2>Mijloace de prim ajutor puse la dispoziție</h2><br><ul><li> - Infirmerie</li><br><li> - Personalul nostru salvator este identificat pe căști și pe echipamentul de lucru cu ecusonul de salvator</li><br><li> - Truse de prim ajutor pentru accidente ușoare disponibile la fiecare amplasament</li></ul><br><br><h2>Instrucțiuni în caz de accident ușor</h2><br><ul><li> - Contactați salvatorul cel mai apropiat</li><br><li> - Îngrijiri cu trusa de prim ajutor pusă la dispoziție</li><br><li> - Declarație la fața locului:</li></ul><br><br><h2>Instrucțiuni în caz de accident</h2><br><ul><li> - Apel pompieri: 18</li><br><li> - Serviciul medical de urgență: 15</li><br><li> - Poliție și Jandarmerie: 17</li><br><li> - Nr. de urgență european: 112</li></ul><br><br><h2>Instrucțiuni în caz de incendiu</h2><br>În caz de incendiu, procedați în această ordine:<br><ol><li> - Declanșați semnalul de alarmă.</li><br><li> - Atacați focul (dacă nu este prea mare) cu un stingător.</li><br><li> - Dacă focul nu s-a stins după utilizarea unui singur stingător sau dacă focul este deja prea mare, anunțați pompierii.</li><br><li> - Închideți ușile și ferestrele înainte de a părăsi spațiile.</li><br><li> - Solicitați ajutorul echipelor instruite.</li><br></ol>
+GeneralInstructions                 = Instrucțiuni generale
+GeneralInstructionsValue            = <h2>Toate instalațiile</h2><br><br><p>Este strict interzis să fumați, să faceți foc sau să utilizați flacără deschisă în și pe instalații.<br />Dacă intervenția necesită utilizarea unei flăcări deschise (lucrări de sudură etc.), este obligatoriu să se emită un permis de lucru cu foc (a se vedea exemplul din anexa 9.5).<br />În general, accesul la instalații este interzis persoanelor neautorizate.<br />Fiecare lucrător trebuie să dețină autorizațiile și certificatele de formare. Trebuie să le poată prezenta la fața locului la cererea întreprinderii utilizatoare.</p><br><br><h2>Autorizări</h2><br>Orice persoană participantă trebuie să dispună de o copie a următoarelor autorizări:<br><ul><li> - Autorizare electrică în funcție de lucrările de realizat</li><br><li> - Certificat de formare sau autorizare pentru lucrul la înălțime și salvarea de la înălțime</li></ul><br>Și să fie în măsură să o prezinte la simpla cerere a întreprinderii utilizatoare, a responsabilului de intervenție/de lucrări sau a oricărui inspector autorizat<br><br><h2>Protecții individuale</h2><br>Orice persoană participantă trebuie să poată dispune de următoarele echipamente individuale de protecție, în funcție de tipurile de lucrări efectuate și de măsurile de protecție definite în analiza riscurilor.<br><br><h3>Lucrări diverse</h3><br><ul><li> - Cască concepută pentru lucrul la înălțime (EN397) cu curea de bărbie și/sau care asigură izolarea electrică (mediu electric)</li><br><li> - Încălțăminte de protecție</li><br><li> - Protecții auditive, dacă este necesar</li><br><li> - Altele (de precizat): în funcție de lucrările realizate și de riscurile asociate.</li></ul><br><br><h3>Lucrări electrice</h3><br><ul><li> - Covor izolant sau scaun izolant</li><br><li> - Mănuși adaptate domeniului de tensiune</li><br><li> - Căști pentru lucrări electrice cu vizieră facială (EN166)</li><br><li> - EIP reglementare pentru intervenția la medie tensiune (UTE C 18-510)</li></ul><br><br><h3>Altele</h3><br>Notă: întreprinderile externe trebuie să furnizeze lucrătorilor lor EIP menționate mai sus. Un scaun și o prăjină se află în posturile de transformare.<br><br><h3>Lucrări la înălțime</h3><br><ul><li> - EIP reglementare (ham, cască, 2 corzi cu absorbant sau coardă dublă în Y, carabiniere, opritor de cădere etc.) cu verificarea la zi</li><br><li> - Sistem de evacuare automată:</li><br><li> - Cantitate: 1 kit de evacuare (prevăzut pentru 2 persoane)</li><li>Amplasare: în nacelă</li><br><li> - Nu uitați să luați un kit de evacuare suplimentar dacă sunt mai mult de două persoane în nacelă</li><br><li> - Altul (de precizat): opritor de cădere utilizat: HACA cu referința 0529 7103 (prindere sternală pe ham)</li></ul><br><br>Opritoarele de cădere trebuie să fie compatibile cu sistemul de asigurare rigid cu care sunt echipate mașinile. Opritoarele de cădere trebuie să fie conforme cu ultima normă și să fi trecut cu succes încercările suplimentare (teste adiționale CNB/P/11.073 din 13.10.2010) devenite obligatorii prin Avizul Ministerului Muncii din Franța din 28 septembrie 2010, pentru a garanta conformitatea cu cerințele directivei 89/686/CEE.
+RulesOfProcedure                    = Regulament intern
+RulesOfProcedureValue               = Disponibil la afișajul obligatoriu din sala de pauză
+CollectiveAgreement                 = Contracte colective de muncă
+CollectiveAgreementValue            = Disponibil pe site-ul guvernului:<br /><a href="https://www.service-public.fr/particuliers/vosdroits/F78" target="_blank">https://www.service-public.fr/particuliers/vosdroits/F78</a>
+legaldisplay.odt                    = Afișaj legal
+legaldisplay_custom.odt             = Afișaj legal personalizat
+
+#
+# InformationsSharing - Difuzarea informațiilor
+#
+
+# Drept
+InformationsSharingsMin = Difuzări de informații
+
+# Date
+InformationsSharing                  = Difuzarea informațiilor
+Informationssharing                  = Difuzarea informațiilor
+InformationsSharingDocumentGenerated = Generarea difuzării informațiilor
+HowToSetDataInformationsSharing      = Pentru a configura datele privind difuzarea informațiilor, accesați Acasă - Configurare - Companie/Organizație - Social
+ConfigureSecurityAndSocialData       = Configurați datele companiei
+LastMainDoc                          = Ultimul document generat
+
+ParticipationAgreement      = Acorduri de participare la profit
+ParticipationAgreementValue = Da, toți colaboratorii care au un contract de muncă pe durată nedeterminată sau determinată în curs cu întreprinderea, indiferent de natura acestuia, vor putea beneficia de participarea la profit.<br />Este însă necesară o condiție de vechime: 6 luni în întreprindere.<br />Pentru determinarea vechimii necesare sunt luate în considerare toate contractele de muncă executate în perioada de calcul și în cele 12 luni precedente.<br />Vechimea se apreciază la data încheierii exercițiului în cauză sau la data plecării în cazul încetării contractului în cursul exercițiului.
+TermsAndConditions          = Modalități
+
+ESC                  = Comitetul Social și Economic
+StaffRepresentatives = Reprezentanții personalului
+ElectionDate         = Data alegerilor
+ElectionDateCSE      = Data alegerilor Comitetului Social și Economic
+ElectionDateDP       = Data alegerilor reprezentanților personalului
+
+Titulars                       = Titulari
+Alternates                     = Supleanți
+informationssharing.odt        = Difuzarea informațiilor
+informationssharing_custom.odt = Difuzarea informațiilor personalizată
+ActionOnUser                   = Utilizator vizat
+HarassmentOfficer              = Responsabil pentru hărțuire
+HarassmentOfficerCSE           = Responsabil pentru hărțuire al Comitetului Social și Economic
+ExceptionsToWorkingHours       = Derogări de la programul de lucru
+PermanentDerogation            = Derogare permanentă
+PermanentDerogationValue       = Nu
+OccasionalDerogation           = Derogare ocazională
+OccasionalDerogationValue      = Da
+
+
+#
+# PreventionPlan - Plan de prevenire
+#
+
+# Drept
+PreventionPlansMin = planuri de prevenire
+
+# Date
+
+PreventionPlan                                        = Plan de prevenire
+Preventionplan                                        = Plan de prevenire
+ThePreventionplan                                     = planul de prevenire
+PreventionPlanDocument                                = Plan de prevenire
+Preventionplandocument                                = Plan de prevenire
+PreventionPlanDocumentGenerated                       = Generarea planului de prevenire
+PreventionPlanList                                    = Lista planurilor de prevenire
+PreventionPlanLine                                    = risc(uri)
+PreventionPlanLineCreated                             = Crearea unui risc în planul de prevenire
+PreventionPlanLineModified                            = Modificarea unui risc în planul de prevenire
+PreventionPlanLineDeleted                             = Ștergerea unui risc din planul de prevenire
+NewPreventionPlan                                     = Plan de prevenire nou
+PriorVisit                                            = Inspecție comună prealabilă
+PriorVisitYesNo                                       = Vizită preliminară efectuată
+PriorVisitText                                        = Nota inspecției
+CSSCTIntervention                                     = Intervenția CSSCT
+CSSCTInterventionText                                 = Intervenția CSSCT?
+MasterWorker                                          = Responsabilul întreprinderii utilizatoare
+MasterWorker                                          = Responsabilul întreprinderii utilizatoare
+ExtSociety                                            = Întreprindere externă
+ExtSocietyResponsible                                 = Responsabilul întreprinderii externe
+ExtSocietyResponsible                                 = Responsabilul întreprinderii externe
+ExtSocietyAttendant                                   = Lucrător al întreprinderii externe
+ActionsDescription                                    = Descrierea acțiunilor
+INRSRisk                                              = Risc (INRS)
+PreventionMethod                                      = Mijloace de prevenire
+PreventionplanSchedules                               = Programul planului de prevenire
+Attendants                                            = Participanți
+ModifyPreventionPlan                                  = Modificați planul de prevenire
+ActionsDescriptionTooltip                             = Descrierea acțiunilor realizate de lucrător
+INRSRiskTooltip                                       = Lista categoriilor de riscuri propuse în referențialul INRS
+PreventionMethodTooltip                               = Mijloc de prevenire de implementat pentru limitarea riscului
+LockPreventionPlan                                    = Blocați planul de prevenire
+ConfirmLockPreventionPlan                             = Sigur doriți să blocați planul de prevenire?<br>Această blocare permite fixarea datelor și a generării documentului.
+AllSignatoriesMustHaveSigned                          = Toți participanții trebuie să fi semnat pentru a bloca obiectul
+ValidatePreventionPlan                                = Validați planul de prevenire
+ConfirmValidatePreventionPlan                         = Sigur doriți să validați planul de prevenire? <br> Validarea permite participanților să semneze documentul, dar <b> împiedică adăugarea de noi participanți sau modificarea planului de prevenire </b>.
+ReOpenPreventionPlan                                  = Redeschideți planul de prevenire
+ConfirmReOpenPreventionPlan                           = Sigur doriți să redeschideți planul de prevenire? Redeschiderea permite modificarea planului de prevenire și adăugarea de noi participanți, dar <b>toate semnăturile documentului vor fi pierdute</b>.
+PreventionPlanRiskList                                = Lista riscurilor planului de prevenire
+ActionsPreventionPlanRisk                             = Acțiuni
+PreventionPlanDescription                             = Proiectul planurilor de prevenire
+PriorVisitDate                                        = Data inspecției comune prealabile
+AddPreventionPlanLine                                 = Adăugarea riscului
+UpdatePreventionPlanLine                              = Actualizarea riscului
+DeletePreventionPlanLine                              = Ștergerea riscului
+PreventionPlanDet                                     = Risc al planului de prevenire
+Preventionplandet                                     = Risc al planului de prevenire
+PreventionPlanMessage                                 = la planul de prevenire
+PreventionPlanMustBeValidated                         = Planul de prevenire trebuie să fie validat pentru a putea fi redeschis
+PreventionPlanMustBeInProgress                        = Planul de prevenire trebuie să fie în curs pentru a accesa această funcționalitate
+PreventionPlanMustBeInProgressToValidate              = Planul de prevenire este deja validat
+CSEMustBeAlerted3DaysBeforeVisit                      = CSE trebuie anunțat cu 3 zile înainte de inspecția comună prealabilă (art. R. 4514-1 1°, R. 4514-3 și R. 4514-9 din Codul muncii francez)
+PreventionPlanData                                    = Datele planului de prevenire
+MasterWorkerDescription                               = Utilizatorul folosit implicit ca responsabil al întreprinderii utilizatoare
+NoPreventionPlanRisk                                  = Niciun risc în planul de prevenire
+NoPreventionPlanLinked                                = Niciun plan de prevenire asociat
+PreventionPlanLinked                                  = Plan de prevenire asociat
+PreventionPlanManagement                              = Gestiunea planurilor de prevenire
+PPRProject                                            = Proiect asociat planurilor de prevenire
+NewLabelForClonePreventionPlan                        = Denumirea noului plan de prevenire
+ClonePreventionPlanRisk                               = Clonați riscurile planului de prevenire
+CloneAttendantsPreventionPlan                         = Clonați participanții planului de prevenire
+CloneSchedulePreventionPlan                           = Clonați programul planului de prevenire
+ConfirmClonePreventionPlan                            = Sigur doriți să clonați planul de prevenire <b> %s </b>?
+preventionplandocument.odt                            = Plan de prevenire
+preventionplandocument_custom.odt                     = Plan de prevenire personalizat
+ErrorThirdPartyHasAtLeastOneChildOfTypePreventionPlan = Terțul este asociat cu cel puțin un element subordonat de tip plan de prevenire:
+ErrorContactHasAtLeastOneChildOfTypePreventionPlan    = Contactul este asociat cu cel puțin un element subordonat de tip plan de prevenire:
+ConfirmDeletePreventionPlan                           = Sigur doriți să ștergeți acest plan de prevenire?
+PreventionPlanRole                                    = Rolurile planului de prevenire
+
+# Email
+PreventionPlanLabel   = Rezumatul planului de prevenire
+PreventionPlanSubject = Email plan de prevenire
+PreventionPlanContent = Atașat găsiți documentul ODT al planului de prevenire.
+
+# Declanșatoare
+PreventionPlanCreated          = Crearea unui plan de prevenire
+PreventionPlanModified         = Modificarea unui plan de prevenire
+PreventionPlanDeleted          = Ștergerea unui plan de prevenire
+PreventionPlanInProgress       = Redeschiderea planului de prevenire
+PreventionPlanPendingSignature = Punerea planului de prevenire în așteptarea semnăturii
+PreventionPlanLocked           = Blocarea planului de prevenire
+PreventionPlanArchived         = Arhivarea planului de prevenire
+PreventionPlanSentByMail       = Trimiterea planului de prevenire prin email
+
+#
+# FirePermit - Permis de lucru cu foc
+#
+
+# Drept
+FirePermitMin  = permis de lucru cu foc
+FirePermitsMin = permise de lucru cu foc
+
+# Date
+NewFirePermit                                     = Permis de lucru cu foc nou
+ModifyFirePermit                                  = Modificați permisul de lucru cu foc
+FirePermitList                                    = Lista permiselor de lucru cu foc
+FirePermit                                        = Permis de lucru cu foc
+Firepermit                                        = Permis de lucru cu foc
+TheFirepermit                                     = permisul de lucru cu foc
+FirePermitDocument                                = Permis de lucru cu foc
+Firepermitdocument                                = Permis de lucru cu foc
+FirePermitDocumentGenerated                       = Generarea permisului de lucru cu foc
+FirePermitCreated                                 = Crearea unui permis de lucru cu foc
+FirePermitModified                                = Modificarea unui permis de lucru cu foc
+FirePermitDeleted                                 = Ștergerea unui permis de lucru cu foc
+FirePermitInProgress                              = Redeschiderea permisului de lucru cu foc
+FirePermitPendingSignature                        = Punerea permisului de lucru cu foc în așteptarea semnăturii
+FirePermitLocked                                  = Blocarea permisului de lucru cu foc
+FirePermitArchived                                = Arhivarea permisului de lucru cu foc
+FirePermitSignatureAddAttendant                   = Adăugarea unui participant la permisul de lucru cu foc
+FirePermitSentByMail                              = Trimiterea permisului de lucru cu foc prin email
+FirePermitLine                                    = risc(uri)
+FirePermitDet                                     = Risc al permisului de lucru cu foc
+Firepermitdet                                     = Risc al permisului de lucru cu foc
+FirePermitLineCreated                             = Crearea unui risc în permisul de lucru cu foc
+FirePermitLineModified                            = Modificarea unui risc în permisul de lucru cu foc
+FirePermitLineDeleted                             = Ștergerea unui risc din permisul de lucru cu foc
+FirePermitRiskList                                = Lista riscurilor permisului de lucru cu foc
+AddFirePermitLine                                 = Adăugarea riscului
+UpdateFirePermitLine                              = Actualizarea riscului
+DeleteFirePermitLine                              = Ștergerea riscului
+FirePermitMessage                                 = la permisul de lucru cu foc
+UsedMaterialTooltip                               = Material de utilizat pentru limitarea riscului
+ActionsFirePermitRisk                             = Acțiuni
+ConfirmValidateFirePermit                         = Sigur doriți să validați permisul de lucru cu foc? <br> Validarea permite participanților să semneze documentul, dar <b> împiedică adăugarea de noi participanți sau modificarea permisului de lucru cu foc </b>.
+ConfirmReOpenFirePermit                           = Sigur doriți să redeschideți permisul de lucru cu foc? Redeschiderea permite modificarea permisului de lucru cu foc și adăugarea de noi participanți, dar <b>toate semnăturile documentului vor fi pierdute</b>.
+ConfirmLockFirePermit                             = Sigur doriți să blocați permisul de lucru cu foc?<br>Această blocare permite fixarea datelor și a generării documentului.
+FirePermitMustBeInProgress                        = Permisul de lucru cu foc trebuie să fie în curs pentru a accesa această funcționalitate
+NewLabelForCloneFirePermit                        = Denumirea noului permis de lucru cu foc
+CloneFirePermitRisk                               = Clonați riscurile permisului de lucru cu foc
+CloneAttendantsFirePermit                         = Clonați participanții permisului de lucru cu foc
+CloneScheduleFirePermit                           = Clonați programul permisului de lucru cu foc
+ConfirmCloneFirePermit                            = Sigur doriți să clonați permisul de lucru cu foc <b> %s </b>?
+FirePermitDescription                             = Proiectul permiselor de lucru cu foc
+FirePermitData                                    = Datele permisului de lucru cu foc
+FirePermitManagement                              = Gestiunea permiselor de lucru cu foc
+FPRProject                                        = Proiect asociat permiselor de lucru cu foc
+firepermitdocument.odt                            = Permis de lucru cu foc
+firepermitdocument_custom.odt                     = Permis de lucru cu foc personalizat
+UsedEquipment                                     = Material utilizat
+ErrorThirdPartyHasAtLeastOneChildOfTypeFirePermit = Terțul este asociat cu cel puțin un element subordonat de tip permis de lucru cu foc:
+ErrorContactHasAtLeastOneChildOfTypeFirePermit    = Contactul este asociat cu cel puțin un element subordonat de tip permis de lucru cu foc:
+ConfirmDeleteFirePermit                           = Sigur doriți să ștergeți acest permis de lucru cu foc?
+FirePermitRole                                    = Rolurile permisului de lucru cu foc
+FirepermitSchedules                               = Programul permisului de lucru cu foc
+
+# Email
+FirePermitLabel   = Rezumatul permisului de lucru cu foc
+FirePermitSubject = Email permis de lucru cu foc
+FirePermitContent = Atașat găsiți documentul ODT al permisului de lucru cu foc.
+
+
+#
+# Accident - Accident
+#
+
+# Drept
+AccidentsMin = accidente
+
+# Declanșator
+AccidentCreateTrigger         = Accidentul %s a fost creat
+ActionsOnAccident             = Evenimente asociate accidentului
+AccidentGeneratedWithDolibarr = Accident generat cu Dolibarr
+AccidentWorkStopCreateTrigger = Concediul medical %s a fost adăugat la accident
+AccidentWorkStopModifyTrigger = Concediul medical %s a fost modificat la accident
+AccidentWorkStopDeleteTrigger = Concediul medical %s a fost șters din accident
+AccidentModifyTrigger         = Accidentul %s a fost modificat
+AccidentDeleteTrigger         = Accidentul %s a fost șters
+AccidentMetaDataCreateTrigger = Înregistrarea datelor suplimentare ale accidentului
+AccidentLesionCreateTrigger   = Leziunea %s a fost adăugată la accident
+AccidentLesionModifyTrigger   = Leziunea %s a fost modificată la accident
+AccidentLesionDeleteTrigger   = Leziunea %s a fost ștearsă din accident
+ACC_USER_EMPLOYERSigned       = Semnătura responsabilului companiei
+VictimAndCaregivers           = Victimă și persoana care acordă îngrijiri
+Victim                        = Victimă
+Caregiver                     = Persoana care acordă îngrijiri
+
+# Model de numerotare
+DigiriskAccidentNumberingModule         = Model de numerotare a accidentelor Digirisk
+DigiriskAccidentStandardModel           = Returnează numărul sub forma ACCn, unde n este un contor secvențial fără întrerupere și fără resetare la 0.
+DigiriskAccidentWorkStopNumberingModule = Model de numerotare a concediilor medicale asociate accidentului
+DigiriskAccidentWorkStopStandardModel   = Returnează numărul sub forma ACCWn, unde n este un contor secvențial fără întrerupere și fără resetare la 0.
+DigiriskAccidentLesionNumberingModule   = Model de numerotare a leziunilor asociate accidentului
+DigiriskAccidentLesionStandardModel     = Returnează numărul sub forma ACCLn, unde n este un contor secvențial fără întrerupere și fără resetare la 0.
+DigiriskAccidentDocumentNumberingModule = Model de numerotare a fișelor de accident Digirisk
+DigiriskAccidentDocumentStandardModel   = Returnează numărul sub forma ACCDn, unde n este un contor secvențial fără întrerupere și fără resetare la 0.
+
+# Șablon ODT
+DigiriskTemplateDocumentAccident       = Modele de documente pentru accidentele Digirisk
+AccidentDocumentCustomDigiriskTemplate = ODT personalizat pentru accidente
+AccidentDocumentDigiriskTemplate       = ODT implicit pentru accidente
+AccidentDocument                       = Fișă de accident
+AccidentDocumentGeneratedWithDolibarr  = Accident generat cu Dolibarr
+
+# Date
+NewAccident                              = Accident nou
+ModifyAccident                           = Modificați accidentul
+AccidentList                             = Lista accidentelor
+Accident                                 = Accident
+AccidentCreated                          = Crearea unui accident
+DeleteAccident                           = Ștergeți accidentul?
+AccidentModified                         = Modificarea unui accident
+AccidentDeleted                          = Ștergerea unui accident
+AccidentLine                             = risc(uri)
+AccidentDate                             = Data accidentului
+AccidentSchedule                         = Programul accidentului
+AccidentRiskList                         = Lista informațiilor suplimentare despre accident
+Accidentworkstop                         = Concediu medical
+AccidentWorkStopCreated                  = Crearea unui concediu medical
+AccidentWorkStopModified                 = Modificarea unui concediu medical
+AccidentWorkStopDeleted                  = Ștergerea unui concediu medical
+AddAccidentWorkStop                      = Adăugarea unui concediu medical la accident
+UpdateAccidentWorkStop                   = Actualizarea unui concediu medical la accident
+DeleteAccidentWorkStop                   = Ștergerea unui concediu medical din accident
+Accidentlesion                           = Leziune
+AccidentLesionCreated                    = Crearea unei leziuni
+AccidentLesionModified                   = Modificarea unei leziuni
+AccidentLesionDeleted                    = Ștergerea unei leziuni
+AddAccidentLesion                        = Adăugarea unei leziuni la accident
+UpdateAccidentLesion                     = Actualizarea unei leziuni la accident
+DeleteAccidentLesion                     = Ștergerea unei leziuni din accident
+AccidentDescription                      = Proiectul accidentelor
+AccidentManagement                       = Gestiunea accidentelor
+AccidentWorkstopManagement               = Gestiunea concediilor medicale
+AccidentLesionManagement                 = Gestiunea leziunilor
+AccidentInvestigationManagement          = Gestiunea anchetelor de accident
+ACCProject                               = Proiect asociat accidentelor
+UserVictim                               = Victima accidentului
+AccidentType                             = Tipul accidentului
+WorkAccidentStatement                    = Accident de muncă
+CommutingAccident                        = Accident de traseu
+AccidentMetaData                         = Date suplimentare
+RelativeLocation                         = Precizări suplimentare privind locul accidentului
+VictimActivity                           = Activitatea victimei în momentul accidentului
+AccidentNature                           = Natura accidentului
+AccidentObject                           = Obiectul al cărui contact a rănit victima
+AccidentNatureDoubt                      = Eventuale rezerve motivate (atașați, dacă este necesar, o scrisoare de însoțire)
+AccidentNatureDoubtLink                  = Link către scrisoarea de însoțire
+VictimTransportedTo                      = Victima a fost transportată la
+VictimWorkHours                          = Programul de lucru al victimei în ziua accidentului
+WorkHoursMorningDateStart                = Începutul programului de lucru al victimei (dimineața)
+WorkHoursMorningDateEnd                  = Sfârșitul programului de lucru al victimei (dimineața)
+WorkHoursAfternoonDateStart              = Începutul programului de lucru al victimei (după-amiaza)
+WorkHoursAfternoonDateEnd                = Sfârșitul programului de lucru al victimei (după-amiaza)
+AccidentNoticed                          = Informarea despre accident
+Found                                    = Constatat
+Known                                    = Cunoscut
+AccidentNoticeDate                       = Data luării la cunoștință a accidentului
+AccidentNoticeBy                         = Persoana care a informat despre accident
+ByEmployer                               = De către angajator
+ByEmployees                              = De către prepușii săi
+AccidentDescribedByVictim                = Accidentul a fost descris de victimă
+RegisteredInAccidentRegister             = Accidentul este înscris în registrul accidentelor de muncă ușoare
+RegisterDate                             = Data înscrierii în registrul accidentelor de muncă ușoare
+RegisterNumber                           = Numărul de înscriere în registrul accidentelor de muncă ușoare
+Consequence                              = Consecințe
+WithoutWorkStop                          = Fără concediu medical
+LessThanFourDays                         = Mai puțin de 4 zile
+LessThanTwentyOneDays                    = Mai puțin de 21 de zile
+LessThanThreeMonth                       = Mai puțin de 3 luni
+LessThanSixMonths                        = Mai puțin de 6 luni
+LongTimeWorkStop                         = Mai mult de 6 luni
+WithWorkStop                             = Cu concediu medical
+Fatal                                    = Deces
+PoliceReport                             = Raport de poliție
+PoliceReportBy                           = Persoana care a întocmit raportul de poliție
+FirstPersonNoticedIsWitness              = Persoană înștiințată
+Witness                                  = Martor
+FirstPersonNoticed                       = Prima persoană înștiințată
+ThirdPartyResponsability                 = Accidentul a fost cauzat de un terț?
+FkSocResponsible                         = Compania terțului responsabil
+FkSocResponsibleInsuranceSociety         = Compania de asigurări a terțului
+LesionLocalization                       = Localizarea leziunilor
+LesionNature                             = Natura leziunilor
+AccidentInvestigation                    = Anchetă de accident
+Accidentinvestigation                    = Anchetă de accident
+AccidentInvestigationLink                = Link către ancheta de accident
+AccidentLocation                         = Locul accidentului
+DigiriskDolibarrActionTrigger            = Declanșatorul evenimentelor Digirisk
+CollateralVictim                         = Victimă colaterală
+FromDigirisk                             = De la
+At                                       = La
+AndFrom                                  = Și de la
+ExternalAccident                         = Accidentul a avut loc într-o altă unitate decât cea de care aparține victima?
+AccidentAttendants                       = Accident - Participanți
+UserEmployer                             = Responsabilul companiei
+SignatureUserEmployer                    = Semnătura responsabilului companiei
+CerfaLink                                = Link către formularul Cerfa
+WorkStopDays                             = Numărul de zile de concediu medical
+AccidentLesionList                       = Lista leziunilor asociate accidentului
+DocumentsMetaData                        = Fișiere atașate suplimentare
+WorkStopDocument                         = Declarație de concediu medical
+AccidentMetaDataSave                     = Datele suplimentare ale accidentului au fost înregistrate
+ErrorFieldNotEmpty                       = Eroare: câmpul <b>'%s'</b> nu poate fi gol
+ErrorFieldMustBeGreaterOrEqualZero       = Eroare: câmpul <b>'%s'</b> trebuie să fie mai mare sau egal cu 0
+ConfirmDeleteAccidentWorkStop            = Sigur doriți să ștergeți concediul medical <b>%s</b> de la accident?
+AccidentMetaDataLesion                   = Date suplimentare ale leziunilor
+TotalWorkStopDays                        = Numărul total de zile de concediu medical
+RegisterAccident                         = Accident ușor
+AccidentsLinked                          = Accident(e) asociat(e)
+GaugeCounter                             = Acest câmp este utilizat în contorul indicatorului
+DateStartWorkStop                        = Data de început a concediului medical
+DateEndWorkStop                          = Data de sfârșit a concediului medical
+ReturnWorkDate                           = Data reluării activității
+DayWithoutAccident                       = Zile fără accident(e)
+AccidentRepartition                      = Repartizarea accidentelor pe tipuri
+AccidentByYear                           = Repartizarea accidentelor pe ani
+NbAccidentsByEmployees                   = Numărul de accidente per angajat
+AccidentRegister                         = Accident pe registru
+AccidentWithoutRegister                  = Accidente fără registru
+AccidentWithRegister                     = Accidente cu registru
+WorkStopDurationDistribution             = Repartizarea timpului pe concediu medical
+WorkStopDurationDistributionDigiriskElem = Repartizarea timpului de concediu medical pe GP/UT
+WorkStopDuration                         = Durata concediului medical
+NoAbsence                                = Niciun concediu
+UpTo4Days                                = Până la 4 zile
+UpTo21Days                               = Până la 21 de zile
+UpTo3Months                              = Până la 3 luni
+UpTo6Months                              = Până la 6 luni
+MoreThan6Months                          = Mai mult de 6 luni
+FrequencyIndex                           = Indice de frecvență
+FrequencyRate                            = Rata de frecvență
+GravityIndex                             = Indice de gravitate
+GravityRate                              = Rata de gravitate
+AccidentRateIndicator                    = Rate și indici ai indicatorilor de performanță privind accidentele
+NbPresquAccidents                        = Numărul de incidente periculoase
+NbAccidentInvestigations                 = Numărul de anchete de accident
+AccidentInvestigationsMin                = anchete de accident
+NbWorkedHours                            = Numărul de ore lucrate
+ConfirmDeleteAccident                    = Sigur doriți să ștergeți accidentul?
+TheAccident                              = accidentul
+AccidentInvestigation                    = Anchetă de accident
+Accident_investigation                   = Anchetă de accident
+AccidentInvestigationDocument            = Document de anchetă de accident
+Accidentinvestigationdocument            = Document de anchetă de accident
+accidentinvestigationdocument.odt        = Anchetă de accident
+NewAccidentInvestigation                 = Anchetă de accident nouă
+UpdateAccidentInvestigation              = Modificați o anchetă de accident
+AccidentInvestigationList                = Lista anchetelor de accident
+TheAccidentinvestigation                 = ancheta de accident
+SeniorityInPosition                      = Vechimea în post
+VictimSkills                             = Competențele accidentatului
+CollectiveEquipment                      = Echipament de Protecție Colectivă (EPC)
+IndividualEquipment                      = Echipament Individual de Protecție (EIP)
+Circumstances                            = Împrejurări
+CurativeAction                           = Acțiuni curative
+CorrectiveAction                         = Acțiuni corective
+PreventiveAction                         = Acțiuni preventive
+DigiriskActionType                       = Tip de acțiune Digirisk
+Actions                                  = Acțiuni
+ActionsTab                               = Acțiuni
+CurativeActions                          = Acțiuni curative
+PreventiveActions                        = Acțiuni preventive
+TotalPlannedBudget                       = Buget prevăzut
+AccidentInvestigationDocumentPDF         = EA-A4-PORTRET
+PreventionPlanDocumentPDF                = PP-A4-PORTRET
+PreventionPlanDocumentPDFDescription     = Generați planul de prevenire în PDF
+AccidentInvestigationDocumentPDFDescription = Generați ancheta de accident în PDF
+AccidentInvestigationDocumentGeneratedAt = Generat la
+CorrectiveActions                        = Acțiuni corective
+AddCurativeAction                        = Adăugați o acțiune curativă
+AddCorrectiveAction                      = Adăugați o acțiune corectivă
+InvestigationNotValidatedYet             = Validați mai întâi ancheta de accident pentru a putea crea acțiuni
+ActionLabel                              = Denumirea acțiunii
+ActionDeadline                           = Termen
+ActionAssignedTo                         = Atribuită lui
+ActionProgress                           = Progres
+MarkAsDone                               = Marcați ca finalizată
+XActionsOfY                              = %s / %s finalizată(e)
+NoActionsYet                             = Nicio acțiune deocamdată
+ActionAdded                              = Acțiunea a fost creată
+ActionClosed                             = Acțiunea a fost închisă
+ActionsAreProjectTasks                   = Acțiunile sunt subsarcini ale proiectului Dolibarr
+SeeProjectTasksView                      = Vedeți sarcina părinte
+OpenTask                                 = Deschideți sarcina
+AccidentInvestigationValidated           = Ancheta de accident a fost validată
+AccidentInvestigationReOpened            = Ancheta de accident a fost redeschisă
+AccidentInvestigationTaskCreated         = Sarcinile anchetei de accident au fost create
+AccidentInvestigationTaskDeleted         = Sarcinile anchetei de accident au fost șterse
+CausalityTree                            = Arborele cauzelor
+TaskWillBeCreatedAfterValidation         = Sarcinile vor fi create după validarea anchetei de accident
+AccidentInvestigationCreated             = Crearea unei anchete de accident
+AccidentInvestigationModified            = Modificarea unei anchete de accident
+AccidentInvestigationDeleted             = Ștergerea unei anchete de accident
+AccidentInvestigationValidate            = Validarea unei anchete de accident
+AccidentInvestigationUnValidate          = Redeschiderea unei anchete de accident
+AccidentInvestigationLock                = Blocarea anchetei de accident
+AccidentInvestigationSigned              = Semnarea unei anchete de accident
+CloneWorkStop                            = Clonați concediile medicale?
+CloneMetadata                            = Clonați datele suplimentare?
+CloneLesion                              = Clonați datele suplimentare ale leziunilor?
+CloneFrom                                = Clonă a
+AccidentInvestigationRole                = Rolurile anchetei de accident
+LesionsOrWorkStop                        = leziuni sau concedii medicale
+AccidentsCategoriesArea                  = Spațiul etichetelor/categoriilor accidentelor
+AddAccidentIntoCategory                  = Atribuiți această categorie accidentului
+PreventionplansCategoriesArea            = Spațiul etichetelor/categoriilor planurilor de prevenire
+AddPreventionplanIntoCategory            = Atribuiți această categorie planului de prevenire
+FirepermitsCategoriesArea                = Spațiul etichetelor/categoriilor permiselor de lucru cu foc
+AddFirepermitIntoCategory                = Atribuiți această categorie permisului de lucru cu foc
+RisksCategoriesArea                      = Spațiul etichetelor/categoriilor riscurilor
+AddRiskIntoCategory                      = Atribuiți această categorie riscului
+AddTicketIntoCategory                    = Atribuiți această categorie tichetului
+StartDateInvestigate                     = Data de început a anchetei
+EndDateInvestigate                       = Data de sfârșit a anchetei
+YearType                                 = Tipul de an
+AllYears                                 = Toți anii
+FiscalYear                               = An fiscal
+CalendarYear                             = An calendaristic
+
+# AccidentTooltip - Indicii pentru accidente
+VictimActivityTooltip              = Precizați activitatea sau sarcina victimei în momentul accidentului, adică ce făcea victima
+AccidentNatureTooltip              = Descrieți evenimentul care a condus la accident, cum s-a produs accidentul (problemă electrică, scurgere de gaz, rupere de material, alunecare, cădere, efort fizic, agresiune...) sau cum s-a rănit victima (lovire, coliziune, strivire, înțepare, înec, contact cu o substanță...)
+AccidentObjectTooltip              = Adică cu ce s-a rănit victima: material, deșeu, unealtă (șurubelniță, cutter, mașină de găurit...), mașină, vehicul, motostivuitor, substanță chimică, element de construcție (ușă, perete...), pardoseală...
+AccidentNatureDoubtTooltip         = Indicați, dacă este cazul, rezervele motivate, care nu vor putea fi luate în considerare decât dacă privesc împrejurările de timp și de loc ale accidentului sau existența unei cauze complet străine de muncă (art. R. 441-11 din Codul securității sociale francez)
+VictimWorkHoursTooltip             = Indicați orele de lucru efectuate de angajatul dumneavoastră sau orele prevăzute în ziua accidentului
+ConsequenceTooltip                 = Dacă victima și-a întrerupt activitatea la recomandarea unui medic, trebuie OBLIGATORIU să întocmiți și să trimiteți formularul «attestation de salaire accident du travail ou maladie professionnelle» - referința S6202, la Casa primară de la locul de reședință obișnuită a victimei. <br> Ulterior, în cazul unui nou concediu după o perioadă de îngrijiri sau o reluare a activității, într-o lună diferită, va trebui să îndepliniți de asemenea aceeași formalitate
+FirstPersonNoticedIsWitnessTooltip = Indicați numele, prenumele și adresa martorului. <br> În lipsa unui martor, indicați prima persoană din întreprindere care a fost înștiințată despre accident
+ThirdPartyResponsabilityTooltip    = Atunci când aveți cunoștință de implicarea unui terț, indiferent de partea sa de răspundere, într-un accident de muncă sau de traseu, această mențiune trebuie obligatoriu consemnată în această parte
+FrequencyIndexTooltip              = Numărul de accidente per angajat x 1 000
+FrequencyRateTooltip               = Numărul de accidente per ore lucrate x 1 000 000
+GravityRateTooltip                 = Numărul de zile de concediu medical per ore lucrate x 1 000
+NbWorkedHoursTooltip               = Numărul de ore lucrate a fost introdus manual
+DocumentGeneratedWithVersioning    = Document generat la crearea versiunii
+
+# Dicționar
+UsualWorkplace                  = Loc de muncă obișnuit
+OccasionalWorkplace             = Loc de muncă ocazional
+LocationOfTheMeal               = Locul mesei
+OnTheWayBetweenHomeAndWorkplace = În timpul deplasării între domiciliu și locul de muncă
+OnTheWayBetweenMealAndWorkplace = În timpul deplasării între locul de muncă și locul mesei
+DuringATripForTheEmployer       = În timpul unei deplasări în interesul angajatorului
+
+Trunk             = Trunchi
+Hand              = Mână
+LowerLimbs        = Membre inferioare
+UpperLimbs        = Membre superioare
+MultipleLocations = Localizări multiple
+Foot              = Picior
+Head              = Cap
+Eyes              = Ochi
+InternalSeating   = Localizări interne
+Neck              = Gât
+Back              = Spate
+WholeBody         = Întregul corp
+NotSpecified      = Neprecizat
+
+PainEffortLumbago           = Durere de efort, lumbago
+Contusion                   = Contuzie
+Wounds                      = Plăgi
+Sprain                      = Entorsă
+FracturePitting             = Fractură sau fisură
+MultipleInjuries            = Leziuni de natură multiplă
+MuscleOrTendonTear          = Ruptură musculară sau tendinoasă
+PresenceOfForeignBody       = Prezența unui corp străin
+Burns                       = Arsură
+UnspecifiedAndMiscellaneous = Neprecizat și diverse
+Other                       = Altele
+CutOff                      = Tăietură
+
+Investigator = Anchetator
+Rescuer      = Salvator
+
+#
+# ListingRisksDocument - Listă de riscuri cu documente
+#
+
+# Drept
+ListingRisksDocumentMin = liste de riscuri cu documente
+
+# Date
+ListingRisksDocument            = Listă de riscuri
+Listingrisksdocument            = Listă de riscuri
+ListingRisksHeader              = Riscuri - %s
+ListingRisksDocumentGenerated   = Generarea listei de riscuri cu documente
+listingrisksdocument.odt        = Listă de riscuri cu documente
+listingrisksdocument_custom.odt = Listă de riscuri cu documente personalizată
+
+#
+# ListingRisksPhoto - Listă de riscuri cu fotografii
+#
+
+# Drept
+ListingRisksPhotosMin = liste de riscuri cu fotografii
+
+# Date
+ListingRisksPhoto            = Listă de riscuri cu fotografii
+Listingrisksphoto            = Listă de riscuri cu fotografii
+ListingRisksPhotoGenerated   = Generarea listei de riscuri cu fotografii
+listingrisksphoto.odt        = Listă de riscuri cu fotografii
+listingrisksphoto_custom.odt = Listă de riscuri cu fotografii personalizată
+
+
+#
+# ListingRisksAction - Listă de riscuri cu acțiuni corective
+#
+
+# Drept
+ListingRisksActionsMin = liste de riscuri cu acțiuni corective
+
+# Date
+ListingRisksAction                        = Listă de riscuri cu acțiuni corective
+Listingrisksaction                        = Listă de riscuri cu acțiuni corective
+ListingRisksActionGenerated               = Generarea listei de riscuri cu acțiuni corective
+listingrisksaction.odt                    = Listă de riscuri cu acțiuni corective
+listingrisksaction_custom.odt             = Listă de riscuri cu acțiuni corective personalizată
+DigiriskListingRisksActionData            = Date configurabile ale listelor de riscuri cu acțiuni corective
+ShowTaskDoneListingRisksActionDescription = Permite afișarea sau ascunderea sarcinilor finalizate în lista de riscuri cu acțiuni corective
+
+
+#
+# RiskAssessmentDocument - Document de evaluare a riscurilor
+#
+
+# Drept
+
+RiskAssessmentDocumentsMin = Documente de evaluare a riscurilor
+
+# Date
+RiskAssessmentDocument                                    = Document de evaluare a riscurilor
+Riskassessmentdocument                                    = Document de evaluare a riscurilor
+RiskAssessmentDocumentGenerated                           = Generarea documentului de evaluare a riscurilor
+AuditStartDate                                            = Data de început a auditului
+AuditEndDate                                              = Data de sfârșit a auditului
+Recipient                                                 = Destinatar
+ImportantNote                                             = Observație importantă
+SitePlans                                                 = Amplasarea planurilor
+SetStartEndDateBeforeSendEmail                            = Definiți data de început și data de sfârșit a auditului pe această pagină pentru a trimite un email
+NoSitePlans                                               = Niciun plan al companiei completat
+riskassessmentdocument.odt                                = Document de evaluare a riscurilor
+riskassessmentdocument_custom.odt                         = Document de evaluare a riscurilor personalizat
+DigiriskRiskAssessmentDocumentData                        = Date configurabile ale documentului de evaluare a riscurilor
+ActionPreventionCompletedTaskDone                         = Acțiunile finalizate nu sunt afișate
+AppliedOn                                                 = Activ pe:
+RiskAssessmentDocumentMethod                              = * Etapa 1: Colectarea informațiilor<br />- Vizitarea spațiilor<br />- Colectarea datelor despre personal<br /><br />* Etapa 2: Definirea metodologiei și a documentului<br />- Validarea fișelor standard de unitate de lucru<br />- Validarea structurii unităților<br /><br />* Etapa 3: Realizarea studiului de riscuri<br />- Conștientizarea personalului privind riscurile și pericolele<br />- Crearea unităților de lucru împreună cu personalul și responsabilul/responsabilii<br />- Evaluarea riscurilor pe unități de lucru împreună cu personalul<br /><br />* Etapa 4<br />- Prelucrarea și redactarea documentului de evaluare a riscurilor
+RiskAssessmentDocumentSources                             = Conștientizarea riscurilor este definită în ED840 editat de INRS.<br />În acest document veți găsi:<br />- Definiția unui risc și a unui pericol, cu o schemă explicativă<br />- Explicațiile privind diferitele metode de evaluare
+RiskAssessmentDocumentImportantNote                       = Note importante:<br />Puteți citi documentația DigiRisk aici<br /><a href="https://wiki.dolibarr.org/index.php?title=Module_Digirisk" target="_blank">https://wiki.dolibarr.org/index.php?title=Module_Digirisk</a><br />Puteți urmări proiectul aici:<br /><a href="https://github.com/Evarisk/Digirisk/projects?type=classic" target="_blank">https://github.com/Evarisk/Digirisk/projects?type=classic</a><br />Raportați o eroare aici<br /><a href="https://github.com/Evarisk/Digirisk/issues" target="_blank">https://github.com/Evarisk/Digirisk/issues</a>
+GenerateZipArchiveWithDigiriskElementDocuments            = Generarea unei arhive ZIP cu documentul de evaluare a riscurilor
+GenerateZipArchiveWithDigiriskElementDocumentsDescription = Generarea automată a unei arhive ZIP care conține documentul de evaluare a riscurilor și toate fișele de post la generarea documentului de evaluare a riscurilor
+RiskAssessmentDocumentDescription                         = Planul de acțiune al documentului de evaluare a riscurilor
+ErrorFailToFetchDigiriskElements                          = Eroare: nu s-au putut prelua grupările și unitățile de lucru care trebuie incluse în arhiva ZIP
+ErrorNoDocumentModelFound                                 = Eroare: niciun model de document disponibil pentru <b>%s</b>
+ErrorFailToGenerateDigiriskElementDocument                = Eroare: generarea documentului pentru <b>%s</b> a eșuat, acesta lipsește din arhiva ZIP
+
+# Boxes - Widget
+NextGenerateDate  = Următoarea generare
+LastGenerateDate  = Ultima generare
+DelayGenerateDate = Zile rămase
+NoDelay           = Fără întârziere
+
+# Email
+RiskAssessmentDocumentLabel   = Rezumatul documentului de evaluare a riscurilor
+RiskAssessmentDocumentSubject = Email document de evaluare a riscurilor
+RiskAssessmentDocumentContent = Atașat găsiți arhiva ZIP și documentul ODT al documentului de evaluare a riscurilor.
+
+
+
+#
+# AuditReportDocument - Raport de audit
+#
+
+# Date
+AuditReportDocument     = Raport de audit
+Auditreportdocument     = Raport de audit
+AuditReportDocumentsMin = rapoarte de audit
+auditreportdocument.odt = Raport de audit
+
+
+
+#
+# GroupmentDocument - Fișă de grupare
+#
+
+# Drept
+
+# Date
+GroupmentDocument                        = Fișă de grupare
+Groupmentdocument                        = Fișă de grupare
+DocumentModelStandardPDF                 = Model PDF standard
+GroupmentDocumentGenerated               = Generarea fișei de grupare
+groupmentdocument.odt                    = Fișă de grupare
+groupmentdocument_custom.odt             = Fișă de grupare personalizată
+groupmentdocumentinherited.odt           = Fișă de grupare - Riscuri moștenite
+groupmentdocumentinherited_custom.odt    = Fișă de grupare - Riscuri moștenite personalizată
+groupmentdocumentshared.odt              = Fișă de grupare - Riscuri partajate
+groupmentdocumentshared_custom.odt       = Fișă de grupare - Riscuri partajate personalizată
+DigiriskGroupmentDocumentData            = Date configurabile ale fișelor de grupare
+ShowTaskDoneGroupmentDocumentDescription = Permite afișarea sau ascunderea sarcinilor finalizate în fișa de grupare
+
+#
+# WorkUnitDocumment - Fișă de unitate de lucru
+#
+
+# Drept
+
+# Date
+WorkUnitDocument                        = Fișă de unitate de lucru
+Workunitdocument                        = Fișă de unitate de lucru
+WorkUnitDocumentGenerated               = Generarea fișei de unitate de lucru
+workunitdocument.odt                    = Fișă de unitate de lucru
+workunitdocument_custom.odt             = Fișă de unitate de lucru personalizată
+workunitdocumentinherited.odt           = Fișă de unitate de lucru - Riscuri moștenite
+workunitdocumentinherited_custom.odt    = Fișă de unitate de lucru - Riscuri moștenite personalizată
+workunitdocumentshared.odt              = Fișă de unitate de lucru - Riscuri partajate
+workunitdocumentshared_custom.odt       = Fișă de unitate de lucru - Riscuri partajate personalizată
+workunitdocumentcomplete.odt            = Fișă de unitate de lucru - Toate riscurile (proprii, moștenite, partajate)
+workunitdocumentcomplete_custom.odt     = Fișă de unitate de lucru - Toate riscurile personalizată
+DigiriskWorkUnitDocumentData            = Date configurabile ale fișelor de unitate de lucru
+ShowTaskDoneWorkUnitDocumentDescription = Permite afișarea sau ascunderea sarcinilor finalizate în fișa de unitate de lucru
+
+
+#
+# DigiriskElement - Element Digirisk
+#
+
+# Drepturi
+DigiriskElementsMin = elemente Digirisk (grupare și unitate de lucru)
+
+# Date
+NewDigiriskElement                  = Element Digirisk nou
+Digiriskelement                     = Grupare / Unitate de lucru
+GPUTOrganization                    = Organizarea GP/UT
+DigiriskElement                     = Element Digirisk
+HiddenElements                      = Coș de gunoi
+DigiriskElementCreated              = Crearea unui element Digirisk
+DigiriskElementModified             = Modificarea unui element Digirisk
+DigiriskElementDeleted              = Ștergerea unui element Digirisk
+ElementType                         = Tip de element
+ParentElement                       = Element părinte
+OrganizationSaved                   = Organizarea grupărilor și a unităților de lucru a fost salvată
+OrganizationNotSaved                = Organizarea grupărilor și a unităților de lucru nu a putut fi salvată
+UnsavedChanges                      = Modificări nesalvate
+SavingInProgress                    = Salvare în curs...
+Saved                               = Salvat
+ErrorSaving                         = Eroare la salvare
+DigiriskElementOrganization         = Organizarea structurii
+ShareDigiriskelement                = Activați partajarea grupărilor și a unităților de lucru
+DIGIRISKELEMENTSharing              = Partajarea grupărilor și a unităților de lucru
+DIGIRISKELEMENTSharingDescription   = Selectarea entităților care își vor partaja grupările și unitățile de lucru cu această entitate.
+DigiriskElementSharedTooltip        = Această opțiune permite partajarea grupărilor și a unităților de lucru. <br> INFO: dacă doriți să afișați sarcinile, trebuie să activați opțiunea de partajare a proiectelor.
+PleaseSelectADigiriskElement        = Selectați o grupare sau o unitate de lucru...
+Registers                           = Registre
+ShowInSelectOnPublicTicketInterface = Trebuie să apară în lista elementelor din interfața publică a tichetelor
+Organization                        = Organizare GP/UT
+YouDontHaveOrganization             = Nu ați creat grupări sau unități de lucru, accesați "Document de evaluare a riscurilor" sau faceți clic <b> aici </b> pentru a crea.
+
+
+#
+# Groupment - Grupare
+#
+
+# Date
+Groupment                  = Grupare
+GroupmentManagement        = Gestiunea datelor grupărilor
+NewGroupment               = Grupare nouă
+ModifyGroupment            = Modificați gruparea
+TrashGroupment             = Grupare coș de gunoi
+DeletedElements            = Coș de gunoi
+DeletedDigiriskElement     = Grupări / Unități de lucru mutate în coșul de gunoi
+ShowDeletedDigiriskElement = Afișați grupările / unitățile de lucru care se află în coșul de gunoi
+
+#
+# WorkUnit - Unitate de lucru
+#
+
+# Date
+WorkUnit           = Unitate de lucru
+Workunit           = Unitate de lucru
+WorkUnitManagement = Gestiunea datelor unităților de lucru
+NewWorkUnit        = Unitate de lucru nouă
+ModifyWorkUnit     = Modificați unitatea de lucru
+
+
+#
+# Evaluator - Evaluator
+#
+
+# Drepturi
+EvaluatorsMin = evaluatori
+
+# Date
+Evaluator                    = Evaluator
+Evaluators                   = Evaluatori
+EvaluatorCreated             = Crearea unui evaluator
+EvaluatorModified            = Modificarea unui evaluator
+EvaluatorDeleted             = Ștergerea unui evaluator
+TheEvaluator                 = Evaluatorul
+EvaluatorWellCreated         = Evaluator creat
+EvaluatorNotCreated          = Eroare la crearea evaluatorului
+EvaluatorList                = Lista evaluatorilor
+AssignmentDate               = Data atribuirii
+EvaluationDuration           = Durată
+UserAssigned                 = Utilizator atribuit
+AddEvaluatorTitle            = Adăugarea unui evaluator
+AddEvaluatorButton           = Adăugați evaluatorul
+EvaluatorConfig              = Configurarea datelor evaluatorilor
+DeleteEvaluatorMessage       = Ștergerea evaluatorului
+DigiriskEvaluatorData        = Date configurabile ale evaluatorilor
+EvaluatorDuration            = Durata evaluării de către evaluator
+EvaluatorDurationDescription = Timpul necesar evaluatorului pentru a realiza evaluarea riscurilor
+NbEmployeesInvolved          = Angajați implicați
+NbEmployees                  = Angajați
+NbEmployeesInvolvedTooltip   = Angajați (evaluatori) unici
+NbEmployeesTooltip           = Dacă gestiunea centralizată a utilizatorilor și a grupurilor pe entitatea principală este activată.<br>Numărul de angajați corespunde numărului de utilizatori partajați/atribuiți unui grup, precum și numărului de administratori ai entității principale
+NbEmployeesConfTooltip       = Numărul de angajați a fost introdus manual
+
+
+#
+# DigiriskStandard - Standard Digirisk
+#
+
+# Date
+DigiriskStandardInformation = Informație
+Digiriskstandard            = Standard Digirisk
+DigiriskStandardMin         = standarde Digirisk
+TheDigiriskstandard         = standardul Digirisk
+
+
+#
+# RisksAnalysis - Analiza riscurilor
+#
+
+# Date
+RiskAnalysis = Analiza riscurilor
+UpdateData   = Actualizați
+
+#
+# Risks - Riscuri
+#
+
+# Drepturi
+RisksMin = riscuri
+
+# Date
+Risks                                    = Riscuri
+Risk                                     = Risc
+Riskprofessionals                        = Riscuri profesionale
+RiskCreated                              = Crearea unui risc
+RiskModified                             = Modificarea unui risc
+RiskDeleted                              = Ștergerea unui risc
+RiskConfig                               = Configurarea datelor riscurilor
+TheRisk                                  = Riscul
+RiskWellCreated                          = Risc creat
+RiskNotCreated                           = Eroare la crearea riscului
+RiskWellEdited                           = Risc editat
+RiskNotEdited                            = Eroare la editarea riscului
+RiskList                                 = Listă de riscuri
+AddRiskTitle                             = Adăugarea riscului
+AddRiskButton                            = Adăugați riscul
+EditRisk                                 = Editarea riscului
+LinkedRisk                               = Risc asociat
+RiskCategory                             = Cat.
+RiskCategoryEdit                         = Categorie de risc
+RiskCategoryEditDescription              = Activați modificarea categoriei unui risc existent
+HowToEditRiskCategory                    = Pentru a modifica categoria riscului, faceți clic pe pictograma categoriei
+DigiriskElementRisksList                 = Lista riscurilor
+DigiriskElementRisk                      = Riscuri
+RiskDescriptionNotEnabled                = Câmpul descriere a riscului nu este activat
+HowToEnableRiskDescription               = Pentru a activa câmpul descriere a riscului, accesați "Configurarea modulului -> Document de evaluare a riscurilor"
+HowToEnableRiskCategoryEdit              = Pentru a activa modificarea categoriei de risc, accesați "Configurarea modulului -> Document de evaluare a riscurilor"
+SortRisksListingsByEvaluation            = Sortați riscurile după evaluare
+SortRisksListingsByEvaluationDescription = Activați sortarea automată a riscurilor după evaluare în liste
+ListingHeaderEvaluation                  = Lista evaluărilor
+RiskDescription                          = Descrierea riscului
+RiskDescriptionDescription               = Activați câmpul descriere a riscului
+RiskDescriptionNotActivated              = Activați câmpul descriere a riscului în Configurarea modulului / Analiza riscurilor / Riscuri
+AddRisk                                  = Adăugați un risc
+MoveRisk                                 = Mutați riscul
+MoveRisks                                = Mutați riscurile
+MoveRisksDescription                     = Permite mutarea riscurilor de la o grupare sau o unitate de lucru la alta
+SetConfToMoveRisk                        = Trebuie mai întâi să permiteți mutarea riscurilor în "Configurarea modulului -> Document de evaluare a riscurilor"
+RiskDescriptionPrefill                   = Precompletați descrierea
+RiskDescriptionPrefillDescription        = Precompletați descrierea riscului cu numele categoriei
+DigiriskElementSharedRisksList           = Lista riscurilor partajate
+ImportSharedRisks                        = Importați riscuri partajate
+SelectAllSharedRisksOfElement            = Selectați toate riscurile acestui element
+AlreadyImported                          = Deja importat
+ShowSharedRisks                          = Riscuri partajate
+ShareRisk                                = Activați partajarea riscurilor
+RISKSharing                              = Partajarea riscurilor
+RISKSharingDescription                   = Selectarea entităților care își vor partaja riscurile cu această entitate.
+ShowSharedRisksDescription               = Afișați riscurile partajate în documente și în liste
+UnlinkSharedRisk                         = Dezasociați riscul partajat
+RiskWellUnlinkShared                     = Risc dezasociat
+RiskNotUnlinkShared                      = Eroare la dezasocierea riscului
+HasBeenUnlinkSharedM                     = a fost dezasociat
+HasNotBeenUnlinkSharedM                  = nu a fost dezasociat
+RiskSharedTooltip                        = Această opțiune permite partajarea riscurilor. <br> INFO: dacă doriți să afișați sarcinile, trebuie să activați opțiunea de partajare a proiectelor.
+ShowInheritedRisksInListings             = Riscuri moștenite - Liste <br> (provenind de la nivelurile superioare)
+ShowInheritedRisksInListingsDescription  = Riscurile moștenite sunt cele definite la un nivel superior (ex.: amplasament sau GP) și aplicate automat GP/UT. <br> Activați această opțiune pentru a le afișa în liste
+ShowInheritedRisksInDocuments            = Riscuri moștenite - Documente <br> (provenind de la nivelurile superioare)
+ShowInheritedRisksInDocumentsDescription = Riscurile moștenite sunt cele definite la un nivel superior (ex.: amplasament sau GP) și aplicate automat GP/UT. <br> Activați această opțiune pentru a le afișa în documente
+DigiriskElementInheritedRisksList        = Lista riscurilor moștenite
+ConfirmImportSharedRisks                 = Alegeți riscurile partajate de importat
+RisksRepartition                         = Repartizarea riscurilor după evaluare
+ShowRiskOrigin                           = Afișați proveniența riscului
+ShowRiskOriginDescription                = Afișați proveniența riscurilor în documente (Document de evaluare a riscurilor, Grupare, Unități de lucru, Listă de riscuri cu acțiuni și cu fotografii etc.).
+SharedRiskImportWithSuccess              = Risc importat cu succes
+RiskImport                               = Import de riscuri
+RiskUnlink                               = Ștergerea riscului partajat
+RiskDeleted                              = Riscul %s a fost șters
+RiskSharedWithEntityRefLabel             = Partajarea riscului %s cu
+RiskUnlinkedFromEntityRefLabel           = Disocierea riscului %s de
+TheDigiriskelement                       = elementul Digirisk
+DefaultProjectContactType                = Rol atribuit implicit proiectului documentului de evaluare a riscurilor
+DefaultTaskContactType                   = Rol atribuit implicit sarcinilor proiectului documentului de evaluare a riscurilor
+RiskListParentView                       = Afișați toate elementele părinte
+RiskListParentViewDescription            = Afișați toate elementele părinte ale unui risc în lista riscurilor și în documente
+CategoryOnRisk                           = Afișați etichetele/categoriile pe riscuri
+CategoryOnRiskDescription                = Permite atribuirea de etichete/categorii riscurilor și afișarea lor - a se utiliza cu prudență
+AddPsychosocialRisk                      = Adăugați un risc psihosocial
+AddPsychosocialRiskTitle                 = Adăugarea unui risc psihosocial
+AddPsychosocialRiskButton                = Adăugați riscul psihosocial
+AddSelectedPsychosocialRisks             = Adăugați riscurile psihosociale selectate
+SocialRelationsAtWork                    = Relații sociale la locul de muncă
+WorkIntensityAndTime                     = Intensitatea și timpul de lucru
+EmotionalRequirements                    = Cerințe emoționale
+Autonomy                                 = Autonomie
+MeaningOfWork                            = Sensul muncii
+WorkSituationInsecurity                  = Nesiguranța situației de lucru
+PreventionContextInCompany               = Contextul prevenirii în întreprindere
+RPSImpactOnCompanyAndEmployees           = Impactul riscurilor psihosociale asupra întreprinderii și a angajaților
+PsychosocialRisksFactors                 = Factori de riscuri psihosociale
+CompanyPreventionInformations            = Informații despre prevenirea în întreprindere
+Weak                                     = Scăzut
+Moderate                                 = Moderat
+High                                     = Ridicat
+Extreme                                  = Extrem
+HereIsTheWorkStationDescription          = Aceasta este descrierea postului de lucru
+ImageAnalysis                            = Analiza imaginii
+TextAnalysis                             = Analiza textului
+AnalyzeText                              = Analizați textul
+EnterTextForAnalysis                     = Introduceți textul de analizat
+AIRiskAnalysis                           = Analiza riscurilor prin IA
+AnalysisInProgress                       = Analiză în curs...
+
+# Statistici
+GreyRisk                                         = Risc scăzut
+OrangeRisk                                       = Risc de planificat
+RedRisk                                          = Risc de tratat
+BlackRisk                                        = Risc inacceptabil
+RisksNotAssessed                                 = Riscuri neevaluate
+RisksRepartitionByDangerCategories               = Repartizarea riscurilor pe categorii de pericol
+RiskListsByDangerCategories                      = Lista riscurilor pe categorii de pericol
+DigiriskElementsRepartitionByDepth               = Repartizarea structurii grupărilor de nivel %s
+RisksRepartitionByDangerCategoriesAndCriticality = Repartizarea riscurilor pe categorii de pericol și criticitate
+NumberOfRisks                                    = Numărul de riscuri
+DangerCategories                                 = Categorii de pericol
+RisksRepartitionByDigiriskElement                = Repartizarea riscurilor pe grupare / unitate de lucru %s
+
+
+
+#
+# RiskEnvironmentals - Riscuri de mediu
+#
+
+# Date
+Environment                                    = Mediu
+Riskenvironmental                              = Risc de mediu
+RiskEnvironmentals                             = Riscuri de mediu
+Riskenvironmentals                             = Riscuri de mediu
+RiskEnvironmentalsMin                          = riscuri de mediu
+AddRiskenvironmentalTitle                      = Adăugarea riscului de mediu
+DigiriskElementRiskenvironmentalsList          = Lista riscurilor de mediu
+DigiriskElementInheritedRiskenvironmentalsList = Lista riscurilor de mediu moștenite
+DigiriskElementSharedRiskenvironmentalsList    = Lista riscurilor de mediu partajate
+ImportSharedRiskenvironmentals                 = Importați riscuri de mediu partajate
+SelectAllSharedRiskenvironmentalsOfElement     = Selectați toate riscurile de mediu ale acestui element
+ConfirmImportSharedRiskenvironmentals          = Alegeți riscurile de mediu partajate de importat
+EnvironmentDescription                         = Planificare - Acțiuni de implementat față de riscuri și oportunități
+
+#
+# ListingRisksEnvironmentalAction - Listă de riscuri de mediu cu acțiuni corective
+#
+
+# Drept
+ListingRisksEnvironmentalActionMin = Listă de riscuri de mediu cu acțiuni corective
+
+# Date
+ListingRisksEnvironmentalAction            = Listă de riscuri de mediu cu acțiuni corective
+Listingrisksenvironmentalaction            = Listă de riscuri de mediu cu acțiuni corective
+ListingRisksEnvironmentalActionGenerated   = Generarea listei de riscuri de mediu cu acțiuni corective
+listingrisksenvironmentalaction.odt        = Listă de riscuri de mediu cu acțiuni corective
+listingrisksenvironmentalaction_custom.odt = Listă de riscuri de mediu cu acțiuni corective personalizată
+
+#
+# ListingRisksEnvironmentalDocument - Listă de riscuri de mediu cu documente
+#
+
+# Date
+ListingRisksEnvironmentalDocument = Listă de riscuri de mediu
+
+
+
+#
+# RiskAssessment - Evaluare
+#
+
+# Date
+RiskAssessment                              = Evaluare
+Riskassessment                              = Evaluare
+RiskAssessments                             = Evaluări
+RiskAssessmentCreated                       = Crearea unei evaluări
+RiskAssessmentModified                      = Modificarea unei evaluări
+RiskAssessmentDeleted                       = Ștergerea unei evaluări
+RiskAssessmentConfig                        = Configurarea datelor evaluărilor
+TheRiskAssessment                           = Evaluarea
+LastRiskAssessment                          = Ultima evaluare a riscului
+RiskAssessmentWellCreated                   = Evaluare creată
+RiskAssessmentNotCreated                    = Eroare la crearea evaluării
+RiskAssessmentWellEdited                    = Evaluare editată
+RiskAssessmentNotEdited                     = Eroare la editarea evaluării
+RiskAssessmentWellDeleted                   = Evaluare ștearsă
+RiskAssessmentNotDeleted                    = Eroare la ștergerea evaluării
+EvaluationCreate                            = Adăugarea evaluării
+EvaluationEdit                              = Editarea evaluării
+EvaluationMethod                            = Metodă de evaluare
+lastEvaluationOn                            = Ultima evaluare la
+DeleteEvaluation                            = Sigur doriți să ștergeți evaluarea?
+DigiriskRiskAssessmentData                  = Date configurabile ale evaluărilor
+MultipleRiskAssessmentMethodName            = Metode de evaluare
+MultipleRiskAssessmentMethodDescription     = Activați schimbarea metodei de evaluare
+AdvancedRiskAssessmentMethod                = Metodă de evaluare avansată
+AdvancedRiskAssessmentMethodDescription     = Activați metoda de evaluare avansată
+RiskAssessmentList                          = Lista evaluărilor riscului
+EditRiskAssessment                          = Editați evaluarea
+ShowAllRiskAssessments                      = Vedeți toate evaluările
+ShowAllRiskAssessmentsDescription           = Afișați lista completă a evaluărilor riscurilor în lista riscurilor
+ParentRisk                                  = Risc părinte
+RiskAssessmentDate                          = Data evaluării
+SimpleEvaluation                            = Evaluare simplă
+AdvancedEvaluation                          = Evaluare avansată
+CalculatedEvaluation                        = Evaluare calculată
+SelectEvaluation                            = Bifați casetele pentru a calcula evaluarea dumneavoastră
+EvaluationList                              = Lista evaluărilor riscului
+HowToSetMultipleRiskAssessmentMethod        = Pentru a configura utilizarea multiplă a metodelor de evaluare, accesați Configurarea modulului - Analiza riscurilor - Evaluare
+NoFileLinked                                = Nicio fotografie asociată
+AddRiskAssessment                           = Adăugați o evaluare a riscului
+AddRiskAssessmentTask                       = Adăugați o sarcină la risc
+ListRiskAssessmentTask                      = Lista sarcinilor riscului
+ShowRiskAssessmentDate                      = Data evaluărilor
+ShowRiskAssessmentDateDescription           = Înlocuiește data creării cu data de început a evaluărilor în fișă și în documente
+RiskAssessmentHideDateInDocument            = Ascundeți data evaluării în documente
+RiskAssessmentHideDateInDocumentDescription = Ascundeți data evaluării din coloana "Informații despre evaluare" în documente
+RiskTaskComplete                            = Sarcina %s finalizată
+
+# Statistici
+TasksRepartition = Repartizarea sarcinilor după progresul real declarat
+TaskAt0Percent   = Sarcină la 0
+TaskInProgress   = Sarcină în curs
+TaskAt100Percent = Sarcină la 100
+
+
+#
+# RiskSign - Semnalizare
+#
+
+# Drepturi
+RiskSignsMin = semnalizări
+
+# Date
+RiskSign                           = Semnalizare
+RiskSignCreated                    = Crearea unei semnalizări
+RiskSignModified                   = Modificarea unei semnalizări
+RiskSignDeleted                    = Ștergerea unei semnalizări
+TheRiskSign                        = Semnalizarea
+RiskSignConfig                     = Configurarea datelor semnalizărilor
+RiskSignWellCreated                = Semnalizare creată
+RiskSignNotCreated                 = Eroare la crearea semnalizării
+RiskSignWellEdited                 = Semnalizare editată
+RiskSignNotEdited                  = Eroare la editarea semnalizării
+RiskSignWellDeleted                = Semnalizare ștearsă
+RiskSignNotDeleted                 = Eroare la ștergerea semnalizării
+RiskSignCategory                   = Categorie
+RiskSignImport                     = Import de semnalizări
+RiskSignUnlink                     = Ștergerea semnalizării partajate
+AddRiskSignTitle                   = Adăugarea unei semnalizări
+AddRiskSignButton                  = Adăugați semnalizarea
+EditRiskSign                       = Editarea unei semnalizări
+DeleteRiskSignMessage              = Ștergerea semnalizării
+DigiriskElementRiskSignList        = Lista semnalizărilor
+RiskSigns                          = Semnalizări
+DigiriskElementSharedRiskSignsList = Lista semnalizărilor partajate
+ImportSharedRiskSigns              = Importați semnalizări partajate
+SelectAllSharedRiskSignsOfElement  = Selectați toate semnalizările acestui element
+AlreadyImportedF                   = Deja importată
+ShowSharedRiskSigns                = Semnalizări partajate
+ShowSharedRiskSignsDescription     = Afișați semnalizările partajate în documente și în liste
+DigiriskElementSharedRiskSign      = Semnalizări partajate
+SharedRiskSigns                    = Semnalizări partajate
+ShareRisksign                      = Activați partajarea semnalizărilor
+RISKSIGNSharing                    = Partajarea semnalizărilor
+RISKSIGNSharingDescription         = Selectarea entităților care își vor partaja semnalizările cu această entitate.
+UnlinkSharedRiskSign               = Dezasociați semnalizarea partajată
+RiskSignWellUnlinkShared           = Semnalizare dezasociată
+RiskSignNotUnlinkShared            = Eroare la dezasocierea semnalizării
+HasBeenUnlinkSharedF               = a fost dezasociată
+HasNotBeenUnlinkSharedF            = nu a fost dezasociată
+RiskSignSharedTooltip              = Această opțiune permite partajarea semnalizărilor. <br> INFO: dacă doriți să afișați sarcinile, trebuie să activați opțiunea de partajare a proiectelor.
+ShowInheritedRiskSigns             = Semnalizări moștenite
+ShowInheritedRiskSignsDescription  = Afișați semnalizările moștenite în documente și în liste
+DigiriskElementInheritedRiskSignsList = Lista semnalizărilor moștenite
+ConfirmImportSharedRiskSigns       = Alegeți semnalizările partajate de importat
+RiskSignSharedWithEntityRefLabel   = Partajarea semnalizării %s cu
+RiskSignUnlinkedFromEntityRefLabel = Disocierea semnalizării %s de
+
+#
+# Tasks - Sarcină
+#
+
+# Date
+ActionPlan                               = Plan de acțiune
+Task                                     = Sarcină
+TaskCreatedEvent                         = Crearea unei sarcini
+TaskModifiedEvent                        = Modificarea unei sarcini
+TaskDeletedEvent                         = Ștergerea unei sarcini
+TheTask                                  = Sarcina
+TaskConfig                               = Configurarea datelor sarcinilor
+TaskWellCreated                          = Sarcină creată
+TaskNotCreated                           = Eroare la crearea sarcinii
+TaskWellEdited                           = Sarcină editată
+TaskNotEdited                            = Eroare la editarea sarcinii
+TaskWellDeleted                          = Sarcină ștearsă
+TaskNotDeleted                           = Eroare la ștergerea sarcinii
+TasksManagement                          = Gestiunea sarcinilor
+SelectProject                            = Alegerea proiectului
+DUProject                                = Proiect asociat sarcinilor riscurilor
+EnvironmentProject                       = Proiect asociat sarcinilor riscurilor de mediu
+NoTaskLinked                             = Nicio sarcină în curs
+TaskList                                 = Lista sarcinilor riscului
+TaskCreate                               = Adăugarea sarcinii
+TaskEdit                                 = Editarea sarcinii
+HowToSetDUProject                        = Pentru a configura alegerea proiectului, accesați Configurarea modulului - Analiza riscurilor - Sarcină
+DeleteTask                               = Sigur doriți să ștergeți sarcina?
+ListingHeaderTask                        = Lista sarcinilor
+ListingHeaderTaskTooltip                 = Activați partajarea proiectelor pentru a afișa sarcinile
+TasksManagementDescription               = Activați gestiunea sarcinilor
+TaskManagementNotActivated               = Activați gestiunea sarcinilor în Configurarea modulului / Analiza riscurilor / Sarcină
+DigiriskProgress                         = Progres
+ShowTaskStartDate                        = Data de început a sarcinilor
+ShowTaskStartDateDescription             = Înlocuiește data creării cu data de început a sarcinilor în fișă și în documente
+ShowTaskEndDate                          = Data de sfârșit a sarcinilor
+ShowTaskEndDateDescription               = Afișați data de sfârșit a sarcinilor
+ShowTasksDone                            = Sarcini finalizate
+ShowTasksDoneDescription                 = Afișați sarcinile finalizate la 100
+ShowTasksDoneDescriptionExtend           = în listele de riscuri
+ShowTaskCalculatedProgress               = Progresul sarcinii
+ShowTaskCalculatedProgressDescription    = Afișați progresul calculat al sarcinii în locul progresului declarat
+ShowAllTasks                             = Toate sarcinile unui risc în liste
+ShowAllTasksDescription                  = Afișați toate sarcinile în lista sarcinilor unui risc în liste
+DeleteTaskTimeSpent                      = Sigur doriți să ștergeți %s min de timp consumat din sarcină?
+TaskTimeSpentEdit                        = Editarea timpului consumat al sarcinii
+TheTaskTimeSpent                         = Timpul consumat
+TaskTimeSpentCreated                     = Crearea de timp consumat
+TaskTimeSpentModified                    = Modificarea timpului consumat
+TaskTimeSpentDeleted                     = Ștergerea timpului consumat
+TaskTimeSpentWellCreated                 = Timp consumat creat
+TaskTimeSpentNotCreated                  = Eroare la crearea timpului consumat
+TaskTimeSpentWellEdited                  = Timp consumat editat
+TaskTimeSpentNotEdited                   = Eroare la editarea timpului consumat
+TaskTimeSpentWellDeleted                 = Timp consumat șters
+TaskTimeSpentNotDeleted                  = Eroare la ștergerea timpului consumat
+OnTheTask                                = la sarcină
+TaskTimeSpentDuration                    = Durata timpului consumat
+TaskTimeSpentDurationDescription         = Timpul consumat adăugat implicit fiecărei sarcini
+NoTaskShared                             = Nicio sarcină partajată
+WarningTaskLabel                         = Atenție, ați depășit numărul maxim de caractere permis (255)
+ErrorRecordHasSubTasks                   = Sarcina are elemente subordonate
+TotalConsumedTime                        = Total timp consumat pe proiect
+TotalConsumedTimeAmount                  = Costul timpului consumat
+NbTasks                                  = Numărul de sarcini
+TotalProgress                            = Progresul real global al sarcinilor
+TotalBudget                              = Suma bugetului sarcinilor
+TaskTimeSpentDate                        = Data timpului consumat
+StartDateCannotBeAfterEndDate            = Data de sfârșit nu poate fi anterioară datei de început
+TasksFromProject                         = Sarcinile afișate provin din proiectul definit ca "Proiectul documentului de evaluare a riscurilor"
+TaskHideRefInDocument                    = Ascundeți referința
+TaskHideRefInDocumentDescription         = Ascundeți referința sarcinii în documente
+TaskHideResponsibleInDocument            = Ascundeți responsabilul
+TaskHideResponsibleInDocumentDescription = Ascundeți responsabilul sarcinii în documente
+TaskHideDateInDocument                   = Ascundeți data
+TaskHideDateInDocumentDescription        = Ascundeți data de început și de sfârșit a sarcinii în documente
+TaskHideBudgetInDocument                 = Ascundeți bugetul
+TaskHideBudgetInDocumentDescription      = Ascundeți bugetul sarcinii în documente
+
+#
+# DigiAI - DigiAI
+#
+
+# Date
+WelcomeToDigiAI = Bine ați venit la DigiAI
+UploadAnImage = Încărcați o imagine
+OpenAIApiKey = Cheie API OpenAI
+OpenAIApiKeyDescription = Pentru a utiliza DigiAI, trebuie să dispuneți de o cheie API OpenAI. Puteți obține una creând un cont pe <a href="https://platform.openai.com/signup" target="_blank">https://platform.openai.com/signup</a>. După înregistrare, veți putea genera o cheie API în secțiunea "API Keys" a tabloului dumneavoastră de bord.
+
+#
+# Ticket - Interfața publică a tichetelor
+#
+
+# Drepturi
+TicketTagsConfig                         = Modificarea registrelor de securitate și sănătate în muncă
+
+# Date
+Register                                 = Registru
+Send                                     = Trimiteți
+TicketSent                               = Tichet trimis
+FilesLinked                              = Fotografii / Atașamente
+AddDocument                              = Adăugați document
+LastnamePlaceholder                      = Exemplu: Popescu
+FirstnamePlaceholder                     = Exemplu: Ion
+PhonePlaceholder                         = 00.00.00.00.00
+LocationPlaceholder                      = Exemplu: Biroul A
+ServicePlaceholder                       = Exemplu: Lucrător salubritate
+Location                                 = Loc
+CategoriesCreated                        = Crearea categoriilor de tichete
+ExtrafieldsCreated                       = Crearea câmpurilor suplimentare pentru tichete
+AnticipatedLeave                         = Plecare anticipată
+DGI                                      = Pericol grav și iminent
+SST                                      = Securitate și sănătate în muncă
+PresquAccident                           = Incident periculos
+Accident                                 = Accident
+EnhancementSuggestion                    = Sugestie de îmbunătățire
+MaterialProblem                          = Problemă materială
+HumanProblem                             = Problemă umană
+Others                                   = Altele
+AccidentWithoutDIAT                      = Accident ușor
+AccidentWithDIAT                         = Accident de muncă
+Environment                              = Mediu
+Quality                                  = Calitate
+NonCompliance                            = Neconformitate
+FirstName                                = Prenume
+LastName                                 = Nume
+Phone                                    = Telefon
+DeclarationDate                          = Declarație
+DigiriskTicketPublicAccess               = O interfață publică ce nu necesită nicio identificare este disponibilă la următorul URL
+TicketActivatePublicInterface            = Activați interfața publică
+GenerateExtrafields                      = Generarea câmpurilor suplimentare implicite pentru tichete
+GenerateTicketCategories                 = Generarea categoriilor implicite de tichete
+AlreadyGenerated                         = Deja generate
+NotGenerated                             = Încă negenerat
+NotCreated                               = Încă necreate
+ExtrafieldsGeneration                    = Această opțiune permite generarea câmpurilor suplimentare implicite ale tichetelor. Câmpurile create vor fi: <br> Nume, Prenume, Telefon, GP/UT, Loc și Dată
+CategoriesGeneration                     = Această opțiune permite generarea categoriilor implicite ale tichetelor. Categoriile create vor fi: <br> - Registru <br> - - Accident <br> - - - Incident periculos, Accident ușor, Accident de muncă <br> - - Securitate și sănătate în muncă <br> - - - Plecare anticipată, Altele, Problemă umană, Problemă materială <br> - - Pericol grav și iminent <br> - - Calitate <br> - - - Neconformitate, Sugestie de îmbunătățire <br> - - Mediu <br> - - - Neconformitate, Altele
+TicketSuccess                            = Registrul dumneavoastră a fost transmis serviciului de prevenire cu numărul:
+TicketPublicAccess                       = Link de întoarcere la interfața publică a tichetelor:
+TicketShowCompanyLogo                    = Afișați logoul companiei în interfața publică
+TicketShowCompanyLogoHelp                = Activați această opțiune pentru a ascunde logoul companiei în paginile interfeței publice
+YouMustNotifyYourHierarchy               = Aveți <b>obligația</b> de a vă anunța superiorii ierarhici
+GoBackToTicketCreation                   = Accesați pagina de urmărire a tichetelor
+SendEmailOnTicketSubmit                  = Trimiteți emailuri la creare
+CatTicketsList                           = Lista etichetelor/categoriilor tichetelor
+SendEmailTo                              = Adresă de email de notificat
+SendEmailOnTicketSubmitHelp              = Activați trimiterea automată a unui email la crearea unui tichet
+MultipleEmailsSeparator                  = Pentru a atribui mai multe adrese de email de notificat, separați-le cu ";". De exemplu: "aaaa@bbb.cc;dddd@eee.ff"
+TicketCategories                         = Categoriile tichetelor
+TicketDocumentsConfig                    = Documentele tichetelor
+TicketExtrafields                        = Câmpurile suplimentare ale tichetelor
+MainCategorySetting                      = Această opțiune permite definirea categoriei ale cărei subcategorii vor apărea în interfața publică
+TicketCategoriesInDocumentsSetting       = Această opțiune permite alegerea categoriilor de tichete afișate în lista tichetelor din documente (Document de evaluare a riscurilor, fișă de grupare etc.). Dacă nu este selectată nicio categorie, se afișează toate categoriile
+ParentCategorySetting                    = Această opțiune permite definirea titlului categoriei părinte pentru interfața publică a tichetelor
+ChildCategorySetting                     = Această opțiune permite definirea titlului categoriei subordonate pentru interfața publică a tichetelor
+TicketManagement                         = Gestiunea tichetelor
+MainCategory                             = Alegerea categoriei principale
+TicketCategoriesInDocuments              = Categorii afișate în documente
+ParentCategoryLabel                      = Titlul categoriei părinte
+ChildCategoryLabel                       = Titlul categoriei subordonate
+TicketPublicInterfaceEnabled             = Interfața publică a tichetelor a fost activată
+TicketPublicInterfaceDisabled            = Interfața publică a tichetelor a fost dezactivată
+TicketPublicInterface                    = Interfață publică
+EmailsToNotifySet                        = Adresele de email de notificat au fost înregistrate
+MainCategorySet                          = Categoria principală a fost definită
+TicketCategoriesInDocumentsSet           = Categoriile afișate în documente au fost definite
+ParentCategoryLabelSet                   = Titlul categoriei părinte a fost definit
+ChildCategoryLabelSet                    = Titlul categoriei subordonate a fost definit
+TicketPublicInterfaceConfigDocumentation = Pentru a configura interfața publică a tichetelor, consultați documentația
+ParentCategory                           = Categorie părinte
+TSProject                                = Proiect asociat tichetelor
+TicketDescription                        = Proiectul tichetelor
+TicketProjectUpdated                     = Proiectul implicit al tichetelor a fost actualizat
+QRCodeAlreadyGenerated                   = Cod QR generat
+GenerateQRCode                           = Generați codul QR
+CompanyQRCodeGeneration                  = Generarea codului QR al entității
+QRCodeGeneration                         = Generarea codului QR
+MultiCompanyQRCodeGeneration             = Generarea codului QR multi-entitate
+TicketCreationMailWellSent               = Email de confirmare a creării tichetului trimis
+TicketCreationMailSent                   = Emailul de creare a tichetului a fost trimis către %s
+HowToSetupTicketCategories               = Pentru a configura categoriile de tichete, faceți clic pe acest link:
+ConfigTicketCategories                   = Configurarea categoriilor de tichete
+NewTicketSubmitted                       = Un tichet a fost trimis prin interfața publică
+ANewTicketHasBeenSubmitted               = Registru de securitate nou creat pentru %s
+TicketCreationSubject                    = Crearea unui tichet prin interfața publică Digirisk
+TicketDocumentCustomDigiriskTemplate     = ODT personalizat pentru fișele de tichet
+HowToSetupDigiriskElement                = Pentru a configura elementele Digirisk (grupări/unități de lucru), faceți clic pe acest link:
+ConfigDigiriskElement                    = Configurarea elementelor Digirisk
+ErrorFieldEmail                          = Eroare: emailul trebuie să corespundă următorului format: <b>'aaa@aaa.fr'</b>
+ErrorFieldPhone                          = Eroare: telefonul trebuie să corespundă următorului format: <b>'0XXXXXXXXXXX'</b> sau <b>'+33XXXXXXXXX'</b>
+TicketEmailRequired                      = Email obligatoriu pentru crearea unui tichet
+TicketEmailRequiredHelp                  = Activați această opțiune pentru a face obligatorie introducerea unui email la crearea unui tichet în interfața publică
+WelcomeToPublicTicketInterface           = Bine ați venit în interfața publică a tichetelor
+PleaseSelectAnEntity                     = Selectați o entitate:
+ShowSelectorOnTicketPublicInterface      = Afișați selectorul multi-entitate în interfața publică a tichetelor în locul listei entităților
+ShowSelectorOnTicketPublicInterfaceHelp  = Afișați selectorul multi-entitate în interfața publică a tichetelor în locul listei entităților cu logoul lor
+MultiEntityPublicInterface               = Interfața publică a tichetelor multi-companie
+TicketCategoriesNotCreated               = Nu ați creat categorii de tichete
+TicketPublicInterfaceQRCode              = Codul QR al interfeței publice a tichetelor
+MultiEntityTicketPublicInterfaceQRCode   = Codul QR al interfeței publice a tichetelor multi-companie
+PublicInterfaceConfiguration             = Câmpuri vizibile / obligatorii ale interfeței publice
+TicketNumber                             = Nr. tichetului
+FromAndDate                              = Proveniență și dată
+AuthorRequest                            = Solicitant
+DateCloture                              = Data închiderii
+
+PublicInterfaceUseSignatory              = Semnătură obligatorie pentru declararea acestui registru
+ValidateText                             = Condiții de acceptat pentru semnătură
+TicketPublicInterfaceShowCategory        = Afișați descrierea categoriei
+EmailTemplate                            = Șablon de email
+EmailTemplateDescription                 = Șablon de email
+
+OpenInNewTab                             = Deschideți într-o filă nouă
+TicketDigiriskElementRequired            = GP/UT obligatoriu pentru crearea unui tichet
+TicketDigiriskElementRequiredHelp        = Activați această opțiune pentru a face obligatorie selectarea unui GP/UT la crearea unui tichet în interfața publică
+TicketDigiriskElementHideRef             = Ascundeți referința GP/UT în selectorul de serviciu al interfeței publice
+TicketDigiriskElementHideRefHelp         = Activați această opțiune pentru a ascunde referința unui GP/UT în interfața publică
+TicketDigiriskelementVisible             = Afișați câmpul GP/UT pentru crearea unui tichet
+TicketServiceVisible                     = Afișați câmpul GP/UT pentru crearea unui tichet
+TicketDigiriskelementVisibleHelp         = Activați această opțiune pentru a afișa câmpul GP/UT în interfața publică și pentru a-l face obligatoriu dacă este necesar
+TicketServiceVisibleHelp                 = Activați această opțiune pentru a afișa câmpul GP/UT în interfața publică și pentru a-l face obligatoriu dacă este necesar
+TicketPhotoVisible                       = Afișați câmpul Fotografie pentru crearea unui tichet
+TicketPhotoVisibleHelp                   = Activați această opțiune pentru a afișa câmpul Fotografie în interfața publică
+TicketEmailVisible                       = Afișați câmpul Email pentru crearea unui tichet
+TicketEmailVisibleHelp                   = Activați această opțiune pentru a afișa câmpul Email în interfața publică și pentru a-l face obligatoriu dacă este necesar
+TicketLastnameVisible                    = Afișați câmpul Nume pentru crearea unui tichet
+TicketLastnameVisibleHelp                = Activați această opțiune pentru a afișa câmpul Nume în interfața publică și pentru a-l face obligatoriu dacă este necesar
+TicketFirstnameVisible                   = Afișați câmpul Prenume pentru crearea unui tichet
+TicketFirstnameVisibleHelp               = Activați această opțiune pentru a afișa câmpul Prenume în interfața publică și pentru a-l face obligatoriu dacă este necesar
+TicketPhoneVisible                       = Afișați câmpul Telefon pentru crearea unui tichet
+TicketPhoneVisibleHelp                   = Activați această opțiune pentru a afișa câmpul Telefon în interfața publică și pentru a-l face obligatoriu dacă este necesar
+TicketLocationVisible                    = Afișați câmpul Loc pentru crearea unui tichet
+TicketLocationVisibleHelp                = Activați această opțiune pentru a afișa câmpul Loc în interfața publică și pentru a-l face obligatoriu dacă este necesar
+TicketDateVisible                        = Afișați câmpul Dată pentru crearea unui tichet
+TicketDateVisibleHelp                    = Activați această opțiune pentru a afișa câmpul Dată în interfața publică și pentru a-l face obligatoriu dacă este necesar
+QRCodeGenerated                          = Cod QR generat
+FkTicket                                 = Tichet asociat
+PublicTicket                             = Interfața publică a tichetelor
+TicketPublicInterfaceForbidden           = Acces interzis la interfața publică a tichetelor
+DefaultUserGroup                         = Grup implicit
+DefaultUserGroupDescription              = Grup implicit în selectoarele de grupuri
+ConfigureDefaultUserGroup                = Configurați grupul implicit
+RegisterSigned                           = Registru semnat
+
+#Interfața publică
+TicketPublicInterfaceShowCategoryDescription     = Afișați descrierea categoriilor de tichete în interfața publică
+TicketPublicInterfaceShowCategoryDescriptionHelp = Activați această opțiune pentru a afișa descrierea categoriilor de tichete în interfața publică
+
+
+# Statistici
+TicketStatistics    = Statistici privind tichetele
+ExportCSV           = Export CSV
+GenerateCSV         = Generați fișierul CSV
+SuccessGenerateCSV  = Fișierul CSV %s a fost generat cu succes
+ErrorMissingData    = Eroare: fișierul CSV nu a putut fi generat, datele trimise către fișier sunt incorecte. <br> Verificați dacă aveți GP/UT atribuite unor tichete.
+CSVFileExport       = Exportul registrelor în format CSV asociate cu GP/UT
+ThirdPartyHelp      = Dacă filtrul "Terț" este gol, niciun terț nu este utilizat pentru căutare
+GP/UTHelp           = Implicit, filtrul preia toate GP/UT
+CategoryTicketHelp  = Implicit, filtrul preia toate categoriile
+CreatedByHelp       = Dacă filtrul "Creat de" este gol, niciun utilizator nu este utilizat pentru căutare
+AssignedToHelp      = Dacă filtrul "Atribuit lui" este gol, niciun utilizator nu este utilizat pentru căutare
+StatusHelp          = Implicit, filtrul preia toate stările<br>
+ConcernedTimePeriod = Perioada luată în considerare
+LessThan            = Mai puțin de
+MoreThan            = Mai mult de
+Comparator          = Comparator
+RangeNumber         = Cantitate
+TimeRange           = Unitate de timp
+RangeLabel          = Numele restricției
+Inferior            = Inferior lui
+Superior            = Superior lui
+TimeRangeAdded      = Restricție adăugată
+TimeRangeDeleted    = Restricție ștearsă
+
+NumberOfTicketsByMainCategorieAndDigiriskElement    = Numărul de registre pe categorie și pe GP
+NumberOfTicketsByMainSubCategorieAndDigiriskElement = Numărul de registre pe subcategorie și pe GP
+NumberOfTicketsByYear                           = Numărul de tichete pe an
+
+# Ticket Management Dashboard - Tablou de bord al gestiunii tichetelor
+TicketManagementDashboard                 = Tablou de bord al gestiunii tichetelor
+RunningTicket                             = Tichete în curs
+NbOfOpenedTicket                          = Numărul de tichete deschise
+OldestTicket                              = Cel mai vechi tichet
+OldestTicketDescription                   = Cel mai vechi tichet cu timpul scurs de la crearea sa
+OldestMessageTicket                       = Cel mai vechi tichet cu un mesaj
+OldestMessageTicketDescription            = Cel mai vechi tichet cu un mesaj și timpul scurs de la crearea mesajului
+MeanAnswerTime                            = Timp mediu de răspuns
+MeanAnswerTimeDescription                 = Termen mediu între deschidere și închidere, calculat doar pe tichetele închise
+MeanFirstResponseTime                     = Termen mediu al primului răspuns
+MeanFirstResponseTimeDescription          = Termen mediu între deschiderea tichetului și primul mesaj vizibil pentru declarant. Notele interne nu sunt luate în calcul, iar tichetele fără mesaj public sunt excluse din calcul
+NbTicketPerUser                           = Numărul mediu de tichete atribuite per persoană
+NbExchangePerTicket                       = Numărul de schimburi per tichet
+TicketRepartitionPerUserAndMeanAnswerTime = Repartizarea tichetelor pe utilizator și timpul mediu de răspuns
+TopSocietyWithMostTickets                 = Top %s companii cu cele mai multe tichete
+TicketsCreatedVersusClosedByMonth         = Tichete create și închise în ultimele %s luni
+TicketsCreated                            = Create
+TicketsClosed                             = Închise
+OpenTicketsByStatus                       = Repartizarea tichetelor deschise pe stări
+OpenTicketBacklogAge                      = Vechimea tichetelor deschise (de la creare)
+BacklogAgeUnderDays                       = Mai puțin de %s zile
+BacklogAgeBetweenDays                     = De la %s la %s zile
+BacklogAgeOverDays                        = Mai mult de %s zile
+ShowSelectedDateTypes                     = Selectați tipul de dată de afișat
+
+# Email
+The                            = La
+TicketMessage                  = Mesajul registrului
+SeeTicketUrl                   = Vedeți tichetul
+AutoNotificationTicket         = Notificare prin email trimisă automat de
+TicketPublicInterfaceOtherName = Interfața de gestiune a registrelor de securitate și sănătate în muncă și de pericol grav și iminent
+
+
+
+# Document de tichet
+
+# Date
+TicketDocument                 = Fișa tichetului
+Ticketdocument                 = Fișa tichetului
+ticketdocument.odt             = Fișa tichetului
+ticketdocument_custom.odt      = Fișă personalizată a tichetului
+ticketdocument_events.odt      = Fișa tichetului cu evenimente
+ticketdocument_sign.odt        = Fișa tichetului cu semnătură
+ticketdocument_event_sign.odt  = Fișa tichetului cu eveniment și semnătură
+TicketSuccessMessage           = Mesaj de succes al tichetului
+TicketSuccessMessageSet        = Mesajul a fost modificat
+TicketDocumentPDF              = FT-A4-PEISAJ
+TicketDocumentPDFDescription   = Afișați fișa tichetului
+GeneratedTicketDocumentDate    = Data exportului acestui tichet
+
+
+# Document de proiect
+
+# Șablon ODT
+DigiriskTemplateDocumentProject = Modele de documente pentru fișele de proiect Digirisk
+DocumentModelPapripactA3Paysage = Modele de document de raport previzional privind sarcinile proiectelor
+PapripactFullName               = Programul Anual de Prevenire a Riscurilor Profesionale și de Îmbunătățire a Condițiilor de Muncă
+
+# Document de registru
+
+RegisterDocument     = Registrul accidentelor de muncă ușoare
+Registerdocument     = Registrul accidentelor de muncă ușoare
+RegisterDocumentsMin = registre ale accidentelor de muncă ușoare
+registerdocument.odt = Registrul accidentelor de muncă ușoare
+
+#
+# Tools - Instrumente
+#
+
+# Date
+Tools                                        = Instrumente
+DigiriskDataMigration                        = Gestiunea datelor de migrare
+DataMigrationImport                          = Importul datelor structurii Digirisk
+DataMigrationImportDescription               = Importul datelor structurii Digirisk WordPress în format ZIP
+DataMigrationImportRisks                     = Importul datelor riscurilor Digirisk
+DataMigrationImportRisksDescription          = Importul datelor riscurilor Digirisk WordPress în format ZIP
+ErrorFileNotWellFormatted                    = Fișierul nu are formatul corect sau este gol. Trebuie să atașați un fișier de import provenind de la Digirisk WordPress, denumit DATE_OBJET_export.json
+ErrorFileNotWellFormattedZIP                 = Fișierul nu are formatul corect sau este gol. Trebuie să atașați un fișier de import provenind de la Digirisk WordPress, denumit DATE_OBJET_export.zip
+ErrorJsonBadFormatted                        = Fișierul JSON nu este formatat corect
+SuccessImport                                = Importul datelor a reușit
+DataMigrationImportRiskSigns                 = Importul datelor semnalizărilor Digirisk
+DataMigrationImportRiskSignsDescription      = Importul datelor semnalizărilor Digirisk WordPress în format ZIP
+DataMigrationImportGlobal                    = Importul datelor globale Digirisk <br> (Structură, riscuri și semnalizări)
+DataMigrationImportGlobalDescription         = Importul datelor globale Digirisk WordPress în format ZIP <br> (Structură, riscuri și semnalizări)
+DataMigrationExportGlobal                    = Exportul datelor globale Digirisk <br> (Structură, riscuri și semnalizări)
+DataMigrationExportGlobalDescription         = Exportul datelor globale Digirisk Dolibarr în format ZIP <br> (Structură, riscuri și semnalizări)
+DataMigrationExportTree                      = Exportul structurii Digirisk <br> (Doar structura)
+DataMigrationExportTreeDescription           = Exportul structurii Digirisk Dolibarr în format ZIP <br> (GP/UT vizibile pentru entitatea curentă, fără riscuri și fără semnalizări)
+DataMigrationImportGlobalDolibarrDescription = Importul datelor globale Digirisk Dolibarr în format ZIP <br> (Structură, riscuri și semnalizări)
+DataMigrationTreeAlreadyImported             = Importul datelor structurii a fost deja efectuat
+DataMigrationRisksAlreadyImported            = Importul datelor riscurilor a fost deja efectuat
+DataMigrationRiskSignsAlreadyImported        = Importul datelor semnalizărilor a fost deja efectuat
+DataMigrationGlobalAlreadyImported           = Importul datelor globale (Structură, riscuri și semnalizări) a fost deja efectuat
+AdvancedImport                               = Import avansat
+AdvancedImportDescription                    = Permite importul fiecărui element în mod independent (Structură, riscuri și semnalizări)
+DataMigrationWordPressToDolibarr             = Migrarea datelor din WordPress în Dolibarr
+DataMigrationDolibarrToDolibarr              = Migrarea datelor din Dolibarr în Dolibarr
+RepairRisks                                  = Reparați riscurile
+NumberOfRisksCorrupted                       = Aveți %s risc(uri) a căror categorie este coruptă, accesați pagina "Instrumente" pentru a le repara
+NoRiskToRepair                               = Niciun risc de reparat
+DigiriskElementSuccessfullyRepaired          = Elementele Digirisk (GP/UT) au fost reparate cu succes
+RiskSuccessfullyRepaired                     = Riscurile au fost reparate cu succes
+RiskAssessmentSuccessfullyRepaired           = Evaluările au fost reparate cu succes
+CorruptedCategoryOnRiskList                  = Lista riscurilor a căror categorie este coruptă
+
+# Clean - Curățare
+Clean                                          = Curățare
+CleanObject                                    = Curățați datele
+CleanDigiriskElementExistParentDigiriskElement = %d elemente Digirisk (GP/UT) au un element părinte nevalid
+CleanDigiriskElement                           = Curățați elementele Digirisk (GP/UT)
+CleanRiskFkElement                             = %d riscuri au un GP/UT nevalid
+CleanRiskStatus                                = %d riscuri au o stare nevalidă
+CleanRiskExistFkElement                        = %d riscuri sunt orfane
+CleanRiskExistRiskAssessment                   = %d riscuri nu au nicio evaluare
+CleanRisk                                      = Curățați riscurile
+CleanRiskAssessmentStatus                      = %d evaluări au o stare nevalidă
+CleanRiskAssessmentCotation                    = %d evaluări au o cotație goală
+CleanRiskAssessmentExistFkRisk                 = %d evaluări sunt orfane
+CleanRiskAssessment                            = Curățați evaluările
+NoDigiriskElementToClean                       = Niciun element Digirisk (GP/UT) de curățat
+NoRiskToClean                                  = Niciun risc de curățat
+NoRiskAssessmentToClean                        = Nicio evaluare de curățat
+
+
+#
+# Altele
+#
+
+# Date
+AT = la
+
+LabourInspectorName                 = DREETS
+UrlLabourInspector                  = https://travail-emploi.gouv.fr/ministere/organisation/article/dreets-directions-regionales-de-l-economie-de-l-emploi-du-travail-et-des
+IDCCTooltip                         = Acest câmp provine din modulul Digirisk pentru Dolibarr <br> Nomenclatura contractelor colective provine de la travail-emploi.gouv.fr
+NoEmailContact                      = Fără email la acest contact
+AddMedia                            = Adăugați un fișier media
+NoMediaLinked                       = Niciun fișier media asociat
+UserGroup                           = Grup de utilizatori
+ReaderGroup                         = Grup de cititori
+UserCreated                         = Utilizatorul a fost creat
+GetAPI                              = Utilizarea rutelor API Digirisk cu metoda GET
+PostAPI                             = Utilizarea rutelor API Digirisk cu metoda POST
+MinimizeMenu                        = Reduceți meniul
+ActionsLine                         = Acțiuni
+PhotoWellSent                       = Fotografia a fost adăugată în biblioteca media
+PhotoNotSent                        = Fotografia nu a fost trimisă corect
+PhotoWellSaved                      = Fișierul (fișierele) media a (au) fost adăugat(e)
+PhotoNotSaved                       = Fișierul (fișierele) media nu a (nu au) fost adăugat(e)
+UseCaptcha                          = Cod grafic (CAPTCHA)
+UseCaptchaDescription               = Utilizarea codului grafic (CAPTCHA) pe paginile interfeței publice
+GP/UTParticipation                  = Participare GP/UT
+LabourDoctorName                    = AMETRA
+LabourDoctorFirstName               = Medic de
+LabourDoctorLastName                = medicina muncii
+DashBoard                           = Tablou de bord
+Close                               = Închideți
+DateRange                           = Interval de date
+UseDateRange                        = Utilizați intervalul de date
+SiretNumber                         = Nr. de identificare fiscală
+Society                             = Companie
+MulticompanyTransverseModeEnabled   = Gestiunea centralizată a utilizatorilor și a grupurilor pe entitatea principală este activată.<br>Prin urmare, nu puteți crea un utilizator sau un grup pe această entitate.<br>Accesați entitatea principală pentru a efectua această adăugare.
+ManuelInputNBEmployees              = Introduceți manual numărul de angajați
+ManuelInputNBEmployeesDescription   = Dacă opțiunea este activată, puteți introduce manual numărul de angajați în configurarea companiei.<br>În caz contrar, numărul de angajați este calculat.<br>Consultați documentația pentru mai multe informații.
+ManuelInputNBWorkedHours            = Introduceți manual numărul de ore lucrate
+ManuelInputNBWorkedHoursDescription = Dacă opțiunea este activată, puteți introduce manual numărul de ore lucrate în configurarea companiei.<br>În caz contrar, numărul de ore lucrate este calculat.<br>Consultați documentația pentru mai multe informații.
+ShowPatchNoteAgain                  = Afișați nota de actualizare
+ShowPatchNoteAgainDescription       = Dacă opțiunea este activată, nota de actualizare a versiunii curente reapare pe pagina de pornire Digirisk.<br>(Necesită ca opțiunea «Afișați notele de actualizare de pe GitHub» să fie activată pentru a fi vizibilă.)
+HowToConfigureSetupConf             = Pentru a configura datele companiei asociate cu Digirisk,<br>accesați Digirisk - Configurare - Setări
+LabourDoctorNameFull                = Asociația Medicilor
+PermissionInheritedFromConfig       = Drepturile sunt moștenite din configurarea generală sau din configurarea părinte
+CategorieManagement                 = Gestiunea categoriilor
+ShowSelectedRiskTypes               = Selectați tipurile de riscuri de afișat
+CharRemaining                       = Caractere rămase
+NumberOfLinkedFiles                 = Numărul de fișiere atașate
+ChooseAnImage                       = Alegeți o imagine
+
+# Action Plan - Gantt / Kanban
+ActionPlanGantt                     = Diagramă Gantt
+ActionPlanKanban                    = Kanban
+ActionPlanView                      = Plan de acțiune
+ColumnDraft                         = Ciornă
+ColumnInProgress                    = În curs
+ColumnInControl                     = De verificat
+ColumnDone                          = Finalizat
+NoTasks                             = Nicio acțiune corectivă
+ActionPlanGlobalProgress            = Progresul global al PAPRIPACT
+ActionPlanGlobalProgressInfo        = Media progresului a %s acțiune(i) corectivă(e)
+KanbanLoadMore                      = Vedeți mai mult (%s)
+KanbanDisplay                       = Afișarea Kanban
+KanbanPageSize                      = Numărul de carduri pe coloană
+KanbanPageSizeDesc                  = Numărul de acțiuni corective afișate din start în fiecare coloană; următoarele sunt încărcate prin butonul «Vedeți mai mult» (îmbunătățește performanța la volume mari)
+KanbanDraftMax                      = Prag coloana «Ciornă»
+KanbanDraftMaxDesc                  = Progres maxim (%) pentru ca o acțiune să rămână în coloana «Ciornă»
+KanbanProgressMax                   = Prag coloana «În curs»
+KanbanProgressMaxDesc               = Progres maxim (%) pentru coloana «În curs»
+KanbanControlMax                    = Prag coloana «De verificat»
+KanbanControlMaxDesc                = Progres maxim (%) pentru coloana «De verificat»; peste acest prag acțiunea trece în «Finalizat»
+PlannedWorkload                     = Sarcină prevăzută
+TimeSpent                           = Timp consumat
+LinkedRisk                          = Risc asociat
+TaskMovedTo                         = Sarcină mutată în %s
+
+AddCategory                        = Adăugați o categorie
+SelectCategory                     = Alegeți o categorie
+DateEndBeforeStart                 = Data de sfârșit anterioară celei de început
+InternalUsers                      = Utilizatori interni
+ExternalContacts                   = Contacte externe
+AddContributor                     = Adăugați un contribuitor
+RemoveContact                      = Retrageți contactul
+ColumnWidth                        = Lățime
+ColumnGap                          = Spațiere
+ActionPlanExportCsv                = Descărcați PAPRIPACT în format CSV
+ActionPlanExportA3                 = Descărcați PAPRIPACT în PDF A3 peisaj
+ActionPlanExportGantt              = Descărcați diagrama Gantt ca imagine PNG
+ActionPlanDisplayedProject         = Proiect afișat
+ActionPlanChangeProject            = Schimbați proiectul
+ActionPlanDefaultProject           = Document de evaluare a riscurilor (implicit)
+ActionPlanNoProjectConfigured      = Niciun proiect configurat
+
+# ActionPlan — Jurnalizarea evenimentelor
+ActionPlanLogging                  = Plan de acțiune — Istoricul modificărilor
+ActionPlanLoggingDescription       = Activați crearea de evenimente la modificările din Kanban
+ActionPlanLogLabel                 = Modificarea denumirii
+ActionPlanLogLabelDesc             = Creați un eveniment atunci când denumirea unei sarcini este modificată
+ActionPlanLogWorkload              = Modificarea sarcinii de lucru
+ActionPlanLogWorkloadDesc          = Creați un eveniment atunci când sarcina de lucru prevăzută este modificată
+ActionPlanLogBudget                = Modificarea bugetului
+ActionPlanLogBudgetDesc            = Creați un eveniment atunci când bugetul este modificat
+ActionPlanLogContributorAdd        = Adăugarea unui contribuitor
+ActionPlanLogContributorAddDesc    = Creați un eveniment atunci când un contribuitor este adăugat
+ActionPlanLogContributorRemove     = Retragerea unui contribuitor
+ActionPlanLogContributorRemoveDesc = Creați un eveniment atunci când un contribuitor este retras
+ActionPlanLogProgress              = Modificarea progresului
+ActionPlanLogProgressDesc          = Creați un eveniment atunci când progresul este modificat
+ActionPlanLogTag                   = Modificarea etichetelor
+ActionPlanLogTagDesc               = Creați un eveniment atunci când o etichetă este adăugată sau retrasă
+ActionPlanLogDateStart             = Modificarea datei de început
+ActionPlanLogDateStartDesc         = Creați un eveniment atunci când data de început este modificată
+ActionPlanLogDateEnd               = Modificarea datei de sfârșit
+ActionPlanLogDateEndDesc           = Creați un eveniment atunci când data de sfârșit este modificată
+ActionPlanTaskLabelChanged         = Denumire modificată: "%s" → "%s"
+ActionPlanTaskWorkloadChanged      = Sarcină de lucru modificată: %s → %s
+ActionPlanTaskBudgetChanged        = Buget modificat: %s → %s
+ActionPlanTaskContributorAdded     = Contribuitor adăugat: %s
+ActionPlanTaskContributorRemoved   = Contribuitor retras: ID %s
+ActionPlanTaskProgressChanged      = Progres modificat: %s%% → %s%%
+ActionPlanTaskTagAdded             = Etichetă adăugată: %s
+ActionPlanTaskTagRemoved           = Etichetă retrasă: ID %s
+ActionPlanTaskDateStartChanged     = Data de început modificată: %s → %s
+ActionPlanTaskDateEndChanged       = Data de sfârșit modificată: %s → %s
+
+# ===========================================================================
+# Filtrele planului de acțiune — issue #4907 (GP/UT, nivel de risc, etichete)
+# ===========================================================================
+ActionPlanElement                    = GP/UT
+ActionPlanFilterElementChildren      = Cu subelementele
+ActionPlanFilterElementChildrenHelp  = Includeți acțiunile corective ale GP/UT subordonate GP/UT selectat
+ActionPlanFilterScale                = Nivel de risc
+ActionPlanFilterAllScales            = Toate nivelurile
+ActionPlanFilterTags                 = Etichete
+ActionPlanFilterCount                = %s acțiune(i) corectivă(e) afișată(e) din %s
+ActionPlanDictionaries               = Listele Kanban
+ActionPlanDictionariesDesc           = Gestionați valorile propuse în listele planului de acțiune și ale Kanban
+ActionPlanTagDictionary              = Etichetele acțiunilor corective
+ActionPlanTagDictionaryDesc          = Etichete (categorii de sarcini) propuse pe carduri și în filtrul Kanban al planului de acțiune
+ActionPlanTicketDictionaries         = Dicționarele Kanban tichete
+ActionPlanTicketDictionariesDesc     = Tipuri, grupuri și severități care compun coloanele Kanban tichete
+ActionPlanManageDictionary           = Gestionați
+
+# ===========================================================================
+# Card de acțiune tichet — issue #4443 (interfață cu 1 clic)
+# ===========================================================================
+TicketActionCard                     = Acțiune tichet
+TicketActionCardPickerIntro          = Selectați un tichet pentru a efectua o acțiune rapidă cu 1 clic.
+TicketActionCardStatusSection        = Stare
+TicketActionCardAssignSection        = Atribuire
+TicketActionCardContentSection       = Conținut
+TicketActionCardDangerSection        = Zonă sensibilă
+TicketActionMarkRead                 = Marcați ca citit
+TicketActionInProgress               = Puneți în curs
+TicketActionWaiting                  = Puneți în așteptare
+TicketActionClose                    = Închideți
+TicketActionCancel                   = Anulați tichetul
+TicketActionAssignSelf               = Atribuiți-mi
+TicketActionAssignOther              = Atribuiți lui...
+TicketActionAddMessage               = Adăugați un mesaj
+TicketActionLinkAccident             = Asociați un accident
+TicketActionOpenFull                 = Detalii complete
+TicketActionMarkedRead               = Tichet marcat ca citit
+TicketActionInProgressDone           = Tichet pus în curs
+TicketActionWaitingDone              = Tichet pus în așteptare
+TicketActionClosedDone               = Tichet închis
+TicketActionCancelledDone            = Tichet anulat
+TicketActionAssignedSelfDone         = Tichet atribuit dumneavoastră
+TicketActionAssignedOtherDone        = Tichet atribuit
+TicketActionCloseConfirm             = Confirmați închiderea
+TicketActionCancelConfirm            = Confirmați anularea
+TicketActionCardRegistresSection      = Informații registre
+TicketMessageTitle                    = Titlul mesajului
+TicketResponsibleAndProgress          = Responsabil și progres
+TicketActionCardClassificationSection = Clasificare
+TicketActionCardDatesSection          = Date-cheie
+TicketActionCardIdentificationSection = Identificare
+TicketActionCardOtherFieldsSection    = Alte informații
+TicketActionCardEventsSection         = Evenimente recente
+TicketActionCardRelatedSection        = Obiecte asociate
+UnknownFieldToUpdate                  = Câmp necunoscut: %s
+Saved                                 = Salvat
+SeeAll                                = Vedeți tot
+LayoutCustomize                       = Personalizați
+LayoutDone                            = Finalizat
+LayoutControls                        = Controale de aranjare
+LayoutWidthHalf                       = Jumătate de coloană
+LayoutWidthFull                       = Coloană întreagă
+LayoutWidthSpan                       = Lățime completă
+LayoutSaved                           = Aranjare salvată
+LayoutReset                           = Resetați
+LayoutResetTitle                      = Resetați aranjarea (revenire la valorile implicite)
+LayoutDensity                         = Densitatea afișării
+LayoutDensityCompact                  = Compact
+LayoutDensityCozy                     = Confortabil
+LayoutDensitySpacious                 = Spațios
+AddTag                                = Adăugați o etichetă
+TagAdded                              = Etichetă adăugată
+TagRemoved                            = Etichetă retrasă
+Preview                               = Previzualizare
+OpenInNewTab                          = Deschideți într-o filă nouă
+FileDeleted                           = Fișier șters
+OtherTicket                           = alt tichet
+OtherTickets                          = alte tichete
+SeeOtherTicketsForThisCompany         = Vedeți istoricul tichetelor acestui client
+StatusTimeline                        = Cronologia stării
+WatchTicket                           = Urmăriți acest tichet
+UnwatchTicket                         = Nu mai urmăriți acest tichet
+TicketWatched                         = Tichet urmărit
+TicketUnwatched                       = Tichet retras din urmărire
+WatchedTicket                         = Tichet urmărit
+WatchedOnly                           = Doar cele urmărite
+AllTickets                            = Toate
+NoWatchedTicket                       = Niciun tichet urmărit
+FileUploaded                          = Fișier trimis
+UploadFile                            = Alegeți un fișier
+OrDropAnywhere                        = sau trageți și plasați pe card
+Messages                              = Mesaje
+TypeYourReply                         = Scrieți răspunsul dumneavoastră…
+PrivateMessage                        = Mesaj privat
+Send                                  = Trimiteți
+NoMessageYet                          = Niciun mesaj deocamdată
+BeFirstToReply                        = Fiți primul care răspunde
+MessagePosted                         = Mesaj trimis
+MessageEdited                         = Mesaj modificat
+MessageDeleted                        = Mesaj șters
+ConfirmDeleteMessage                  = Ștergeți acest mesaj?
+ReplyByEmail                          = Trimiteți prin email
+SentByMail                            = Trimis prin email
+MailSentToNRecipients                 = email trimis către %d destinatar(i)
+MailNotSent                           = trimiterea emailului a eșuat
+NoRecipientFound                      = niciun destinatar găsit
+OriginalMessage                       = Mesaj original
+JustNow                               = chiar acum
+NMinAgo                               = acum %d min
+NHAgo                                 = acum %d h
+NDAgo                                 = acum %d z
+NAttachedFiles                        = %d fișier(e) atașat(e)
+Quote                                 = Citați
+NotAllowed                            = Acțiune neautorizată
+Private                               = Privat
+Unknown                               = Necunoscut
+LayoutTagsMode                        = Afișarea etichetelor
+LayoutTagsModeChips                   = Listă completă (chips)
+LayoutTagsModeSelector                = Selector derulant
+LayoutActionsMode                     = Afișarea acțiunilor
+LayoutActionsModeBar                  = Bară de acțiuni
+LayoutActionsModeMenu                 = Meniu (⋮)
+Move                                  = Mutați
+Hide                                  = Ascundeți
+Show                                  = Afișați
+
+# ===========================================================================
+# Kanban tichete — configurarea jurnalizării — issue #4753
+# ===========================================================================
+TicketKanban                           = Kanban tichete
+TicketKanbanLogging                    = Kanban tichete — Istoricul modificărilor
+TicketKanbanLoggingDescription         = Activați crearea de evenimente la modificările din kanban
+TicketKanbanLogStatus                  = Modificarea stării
+TicketKanbanLogStatusDesc              = Creați un eveniment atunci când starea unui tichet este modificată prin kanban
+TicketKanbanLogAssignee                = Modificarea persoanei atribuite
+TicketKanbanLogAssigneeDesc            = Creați un eveniment atunci când persoana atribuită unui tichet este modificată prin kanban
+TicketKanbanLogCategoryAdd             = Adăugarea unei etichete
+TicketKanbanLogCategoryAddDesc         = Creați un eveniment atunci când o etichetă este adăugată unui tichet prin kanban
+TicketKanbanLogCategoryRemove          = Retragerea unei etichete
+TicketKanbanLogCategoryRemoveDesc      = Creați un eveniment atunci când o etichetă este retrasă de la un tichet prin kanban
+TicketKanbanLogType                    = Modificarea tipului
+TicketKanbanLogTypeDesc                = Creați un eveniment atunci când tipul unui tichet este modificat prin kanban
+TicketKanbanLogGroup                   = Modificarea grupului
+TicketKanbanLogGroupDesc               = Creați un eveniment atunci când grupul unui tichet este modificat prin kanban
+TicketKanbanLogSeverity                = Modificarea severității
+TicketKanbanLogSeverityDesc            = Creați un eveniment atunci când severitatea unui tichet este modificată prin kanban
+TicketKanbanLogSubject                 = Modificarea subiectului
+TicketKanbanLogSubjectDesc             = Creați un eveniment atunci când subiectul unui tichet este modificat prin kanban
+TicketKanbanLogDeadline                = Modificarea termenului limită
+TicketKanbanLogDeadlineDesc            = Creați un eveniment atunci când termenul limită al unui tichet este modificat prin kanban
+TicketKanbanClosedLimit                = Limita tichetelor închise
+TicketKanbanClosedLimitDesc            = Numărul maxim de tichete închise/anulate afișate în kanban (0 = nelimitat)
+
+# ===========================================================================
+# Ticket — trasabilitatea modificărilor — issue #4885
+# ===========================================================================
+TicketLogModifications                 = Trasabilitatea modificărilor
+TicketLogModificationsDesc             = Creați un eveniment pentru fiecare editare efectuată din fișa tichetului (subiect, mesaj, registre, persoană atribuită, terț, proiect, progres, stare, sarcini, documente)
+TicketMessageEdited                    = Mesaj modificat
+TicketMessageDeleted                   = Mesaj șters
+TicketTaskCreated                      = Sarcină creată: %s
+TicketDocumentGenerated                = Document generat
+TicketFileDeleted                      = Fișier șters
+
+# Panou de creare rapidă a unui tichet
+SelectNothing                          = — Selectați —
+QuickCreateTicket                      = Creați rapid un tichet
+TicketSubjectPlaceholder               = Titlul tichetului...
+TicketInitialMessage                   = Mesaj inițial
+OptionalDescription                    = Descriere (opțional)...
+Unassigned                             = Neatribuit
+QuickCreateAttachments                 = Atașamente
+QuickCreateDropzone                    = Trageți și plasați sau faceți clic pentru a selecta
+QuickCreateDropzoneActive              = Plasați aici…
+QuickCreateAttachmentHint              = Formate acceptate: imagini, PDF, documente. Max. 10 MB per fișier.
+QuickCreateTicketSuccess               = Tichetul %s a fost creat cu succes.
+
+# MeteoVigilance - Avertizare meteo Météo-France
+MeteoVigilance = Avertizare meteo Météo-France
+MeteoVigilancePanelTitle = Avertizare %s
+MeteoVigilanceAdvice2 = Fiți atent
+MeteoVigilanceAdvice3 = Fiți foarte vigilent
+MeteoVigilanceAdvice4 = Vigilență absolută
+MeteoVigilanceUpdatedAt = Actualizat %s
+MeteoVigilanceEnabled = Activați avertizarea meteo
+MeteoVigilanceEnabledDescription = Afișează widgetul de avertizare meteo Météo-France pe tabloul de bord (și banda de alertă în caz de avertizare portocalie/roșie).
+MeteoVigilanceLevel = Nivel de avertizare
+MeteoVigilanceActivePhenomena = Fenomene active
+MeteoVigilanceNoAlert = Nicio avertizare specială
+MeteoVigilanceSource = Sursă
+MeteoVigilanceSeeOnMeteoFrance = Vedeți pe vigilance.meteofrance.fr
+MeteoVigilanceNotConfigured = Cheia API Météo-France nu este configurată — faceți clic pentru a o configura
+MeteoVigilanceUnknownDepartment = Departamentul companiei nu a fost determinat
+MeteoVigilanceUnavailable = Datele de avertizare sunt momentan indisponibile
+MeteoVigilanceBannerTitle = Avertizare %s în curs în departamentul %s
+MeteoVigilanceLevel1 = Verde
+MeteoVigilanceLevel2 = Galben
+MeteoVigilanceLevel3 = Portocaliu
+MeteoVigilanceLevel4 = Roșu
+MeteoVigilancePhenomenon1 = Vânt puternic
+MeteoVigilancePhenomenon2 = Ploaie și inundații
+MeteoVigilancePhenomenon3 = Furtuni
+MeteoVigilancePhenomenon4 = Viituri
+MeteoVigilancePhenomenon5 = Zăpadă și polei
+MeteoVigilancePhenomenon6 = Val de căldură
+MeteoVigilancePhenomenon7 = Frig extrem
+MeteoVigilancePhenomenon8 = Avalanșe
+MeteoVigilancePhenomenon9 = Valuri și inundații costiere
+MeteoVigilanceSetup = Configurarea avertizării meteo
+MeteoVigilanceApiKey = Cheia API Météo-France
+MeteoVigilanceApiKeyDescription = Cheia API a portalului Météo-France (creați un cont și o aplicație «Bulletin Vigilance» pe <a href="https://portail-api.meteofrance.fr" target="_blank">portail-api.meteofrance.fr</a> pentru a genera cheia).
+MeteoVigilanceDepartment = Cod de departament (suprascriere)
+MeteoVigilanceDepartmentDescription = Lăsați gol pentru a deduce automat departamentul din adresa companiei. În caz contrar, introduceți un cod (ex. 35, 2A).
+MeteoVigilanceCacheTTL = Durata memoriei cache (secunde)
+MeteoVigilanceCacheTTLDescription = Durata în care datele API sunt păstrate în memoria cache înainte de un nou apel (implicit 3600).
+MeteoVigilanceSettings = Configurarea avertizării meteo
+MeteoVigilanceRefreshNow = Actualizați acum
+MeteoVigilanceRefreshed = Date actualizate: avertizare %s în departamentul %s
+
+# Sistemul de conversație al tichetelor
+Conversation = Conversație
+PublicMessage = Mesaj public
+ConvTo = Către
+ConvCc = Cc
+
+SaveNote = Salvați nota
+
+AddRecipient = Adăugați un destinatar
+NoRecipientFound = Niciun destinatar
+
+AddFile = Adăugați un fișier
+
+MentionAgents = Menționați agenți
+YouWereMentionedOnTicket = Ați fost menționat pe tichetul %s
+YouWereMentionedOnTicketBody = %s v-a menționat pe tichetul %s:
+
+Mentioned = Menționat
+
+# Crearea rapidă mobilă a planului de prevenire
+MobileQuickCreation = Creare rapidă mobilă
+MobilePPInteriorCompany = Întreprindere utilizatoare (internă)
+MobilePPResponsibleAutoSign = Responsabil (semnează automat)
+MobilePPSignatureSaved = Semnătură înregistrată
+MobilePPEditSignature = Modificați semnătura
+MobilePPDrawSignatureHint = Desenați semnătura dumneavoastră mai jos și salvați-o. Va fi reutilizată pentru planurile următoare.
+MobilePPClearSignature = Ștergeți
+MobilePPSaveSignature = Salvați semnătura mea
+MobilePPExteriorCompany = Întreprindere externă
+MobileSirenOrSiret = SIREN / SIRET
+MobileSirenOrSiretPlaceholder = 9 sau 14 cifre
+MobilePPResponsibleToSign = Responsabil care trebuie să semneze
+MobilePPChooseExistingContact = Alegeți un contact existent
+MobilePPNewContact = Contact nou
+MobilePPEmailForSignatureHelp = Acest email va primi cererea de semnătură.
+MobilePPPeriod = Perioada de intervenție
+MobilePPMaxOneYearHint = Maximum 1 an între data de început și data de sfârșit.
+MobilePPSubmit = Creați planul de prevenire
+MobilePPErrorNoSignature = Trebuie să vă salvați semnătura înainte de a crea planul.
+MobilePPErrorEmptySignature = Semnătura este goală.
+MobilePPErrorInvalidSiren = SIREN sau SIRET nevalid (se așteaptă 9 sau 14 cifre).
+MobilePPErrorEndBeforeStart = Data de sfârșit trebuie să fie ulterioară datei de început.
+MobilePPErrorMaxOneYear = Durata nu poate depăși 1 an.
+MobilePPErrorDatesRequired = Completați data de început și data de sfârșit.
+MobilePPErrorStartRequired = Data de început lipsește.
+MobilePPErrorEndRequired = Data de sfârșit lipsește.
+MobilePPErrorNoProject = Nu este configurat niciun proiect implicit de plan de prevenire.
+MobilePPCompanyFound = Întreprindere găsită:
+MobilePPCompanyNotFound = Nicio întreprindere găsită în baza de date: va fi creată una nouă.
+MobilePPWarningEmailNotSent = Planul a fost creat, dar emailul de semnătură nu a putut fi trimis.
+MobilePPWarningEmailNotConfigured = Planul a fost creat, dar emailul nu este configurat: cererea de semnătură nu a fost trimisă.
+MobilePPCreated = Planul de prevenire %s a fost creat.
+MobilePPUpdated = Planul de prevenire %s a fost actualizat.
+MobilePPSignatureEmailSubject = Cerere de semnare a planului de prevenire %s
+MobilePPSignatureEmailContent = Bună ziua,<br><br>Sunteți invitat să semnați planul de prevenire referitor la %s.<br><br><a href="%s">Faceți clic aici pentru a semna</a><br><br>Cu stimă.
+MobilePPSuccessTitle = Plan de prevenire creat
+MobilePPSuccessText = Responsabilul intern a semnat automat. O cerere de semnătură a fost trimisă întreprinderii externe.
+MobilePPViewPlan = Vedeți planul
+MobilePPCreateAnother = Creați un alt plan
+MobileSuccessInteriorSigned = Responsabil intern: semnat
+MobileSuccessExteriorNotified = Întreprindere externă: cerere de semnătură trimisă
+MobileSuccessExteriorNotSigned = Întreprindere externă: semnătură de obținut
+MobileSuccessExteriorNotNotified = Întreprindere externă: cerere de semnătură netrimisă
+MobileSuccessExteriorSigned = Întreprindere externă: semnat
+MobileSuccessDocumentGenerated = Documentul planului a fost generat
+MobilePPWarningEmailNotSentDetail = Emailul de semnătură nu a putut fi trimis: %s
+MobilePPWarningNoRecipientEmail = nicio adresă de email validă pentru responsabilul extern
+MobilePPSignatureEmailSentTo = Cerere de semnătură trimisă către %s
+MobilePPExtSignatureTitle = Semnătura întreprinderii externe
+MobilePPExtEmailSentOn = Cerere trimisă către %s la %s
+MobilePPExtEmailNotSent = Cerere de semnătură netrimisă: transmiteți linkul sau solicitați semnătura acum
+MobilePPSpreadDefaultsTitle = Afișarea publică a difuzării
+MobilePPSpreadShowCount = Afișați numărul de semnatari
+MobilePPSpreadShowName = Afișați numele și prenumele
+MobilePPSpreadShowContact = Afișați telefonul și emailul
+MobilePPSpreadHidePublicNote = Nu afișați nota publică
+MobilePPExtAlreadySigned = Semnat la %s
+MobilePPExtSignNow = Solicitați semnătura acum
+MobilePPExtResendEmail = Retrimiteți emailul
+MobilePPNoTagAvailable = Nicio etichetă de plan de prevenire nu este disponibilă.
+MobilePPCreateTag = Creați o etichetă
+MobileSpreadShareTitle = Partajați difuzarea
+MobileSpreadShareText = Cereți persoanelor vizate să scaneze acest cod. Fără cont și fără conectare, își completează datele de contact, își depun documentele și semnează.
+MobileSpreadOpen = Deschideți difuzarea
+MobilePPRisks = Riscuri
+MobilePPAddRisk = Adăugați un risc
+MobilePPRiskModalTitle = Alegeți un risc
+MobilePPRiskComment = Comentariu
+MobilePPRiskDescriptionPlaceholder = Descrieți riscul la fața locului
+MobilePPNoRiskYet = Niciun risc adăugat deocamdată.
+MobilePPDeleteRiskTitle = Ștergeți riscul
+MobilePPDeleteRiskConfirm = «%s» va fi retras din plan, împreună cu descrierea, fotografiile și protecțiile sale.
+MobilePPUserCompany = Întreprindere utilizatoare
+MobilePPUserCompanyShort = EU
+MobilePPConcernedCompanies = Privește
+MobilePPExteriorCompanyShort = EE
+MobilePPPriorFormalities = Formalități prealabile
+MobilePPPriorVisitDone = Inspecție comună prealabilă efectuată
+MobilePPPriorVisitTextPlaceholder = Ce a fost constatat în timpul inspecției
+MobileRiskCompanies = Întreprinderi vizate de riscuri (mobil)
+CertificationDictionary = Certificări și autorizări
+MobilePPChooseExistingCompany = Alegeți un terț existent
+MobilePPOrFillManually = sau introduceți informațiile
+MobilePPProtections = Protecții
+MobilePPAddProtection = Adăugați o protecție
+MobilePPProtectionModalTitle = Alegeți o protecție
+MobilePPMandatory = Obligatoriu
+MobileProtections = Protecții (mobil)
+MobilePPCertifications = Certificări obligatorii
+MobilePPAddCertification = Adăugați o certificare
+MobileCertifications = Certificări (mobil)
+MobilePPUploadCertPhoto = Trimiteți o fotografie
+MobilePPErrorCreatingThirdparty = Eroare la crearea terțului.
+MobilePPErrorCreatingContact = Eroare la crearea contactului.
+MobilePPErrorUpdatingPlan = Eroare la actualizarea planului de prevenire.
+MobilePPErrorCreatingPlan = Eroare la crearea planului de prevenire.
+MobileSuccessViewDocument = Vedeți documentul
+MobileSuccessPlanSentByEmailOn = Plan de prevenire trimis prin email la %s
+MobileSuccessExteriorSignedOn = Responsabilul Întreprinderii Externe (EE): Semnat la %s
+MobileSuccessExteriorPendingSignature = Responsabilul Întreprinderii Externe (EE): În așteptarea semnăturii
+MobilePPDefaultsTitle = Valori implicite (creare mobilă)
+MobilePPDefaultDateStartToday = Data de început = data de azi
+MobilePPDefaultDuration = Durata implicită a perioadei (zile)
+MobilePPEmailAutoSend = Trimiteți automat emailul de semnătură la creare
+
+# Crearea rapidă mobilă a permisului de lucru cu foc
+MobileFPPreventionPlanHelp = Întreprinderea externă și perioada planului selectat sunt preluate automat.
+MobileFPPeriod = Locul și perioada lucrărilor
+MobileFPMaxOneMonthHint = Maximum o lună între începutul și sfârșitul lucrărilor.
+MobileFPErrorMaxOneMonth = Durata nu poate depăși o lună.
+MobileFPErrorNoProject = Nu este configurat niciun proiect implicit de permis de lucru cu foc.
+MobileFPWorkTypes = Tipuri de lucrări
+MobileFPAddWorkType = Adăugați un tip de lucrări
+MobileFPWorkTypeModalTitle = Alegeți un tip de lucrări
+MobileFPSubmit = Creați permisul de lucru cu foc
+MobileFPCreated = Permisul de lucru cu foc %s a fost creat.
+MobileFPUpdated = Permisul de lucru cu foc %s a fost actualizat.
+MobileFPSignatureEmailSubject = Cerere de semnare a permisului de lucru cu foc %s
+MobileFPSignatureEmailContent = Bună ziua,<br><br>Sunteți invitat să semnați permisul de lucru cu foc pentru %s.<br><br><a href="%s">Faceți clic aici pentru a semna</a><br><br>Cu stimă.
+MobileFPSuccessTitle = Permis de lucru cu foc creat
+MobileFPViewPermit = Vedeți permisul
+MobileFPCreateAnother = Creați un alt permis
+
+# Digirisk PWA
+PwaApplication = Aplicație mobilă
+PwaNavHome = Acasă
+PwaNavPreventionPlans = Planuri
+PwaNavFirePermits = Permise
+PwaNavMenu = Meniu
+PwaNavFavoritesHint = Favorite afișate jos (max. %s)
+PwaNavAddFavorite = Adăugați la favorite
+PwaNavRemoveFavorite = Retrageți din favorite
+PwaHello = Bună ziua %s
+PwaResultCount = %s rezultat(e)
+AllStatus = Toate stările
+PwaTilePreventionPlanInProgress = Planuri în curs
+PwaTilePreventionPlanToSign = Planuri de semnat
+PwaTileFirePermitInProgress = Permise în curs
+PwaTileFirePermitToSign = Permise de semnat
+
+# Acțiuni în masă asupra sarcinilor
+MassValidateTasks = Validați sarcinile
+MassChangeTasksProject = Schimbați proiectul
+ConfirmMassValidateTasksQuestion = Sigur doriți să validați cele %s sarcină(i) selectată(e)? Vor fi validate doar sarcinile cu starea ciornă.
+ConfirmMassChangeTasksProjectQuestion = Sigur doriți să atașați cele %s sarcină(i) selectată(e) la proiectul ales?
+MassValidateTasksSuccess = %s sarcină(i) validată(e) din %s selectată(e)
+MassChangeTasksProjectSuccess = %s sarcină(i) atașată(e) la proiectul %s
+
+# PDF-ul planului de prevenire
+PreventionPlanLegalNotice = Planul de prevenire este un document obligatoriu care vizează prevenirea riscurilor legate de interferența dintre activitățile mai multor întreprinderi pe același amplasament, în conformitate cu articolul R4512-7 din Codul muncii francez.
+PreventionPlanUserCompany = Întreprindere Utilizatoare - EU
+PreventionPlanExteriorCompany = Întreprindere Externă - EE
+PreventionPlanUserCompanyResponsible = Responsabilul Întreprinderii Utilizatoare (EU)
+PreventionPlanExteriorCompanyResponsible = Responsabilul Întreprinderii Externe (EE)
+EmergencyNumbers = Numere de urgență
+Firefighters = Pompieri
+AnyEmergency = Orice urgență
+PriorVisitIntro = Întreprinderea utilizatoare a efectuat, înainte de executarea operațiunii, o inspecție comună prealabilă la data de %s. În timpul acestei vizite, următoarele puncte au fost prezentate de întreprinderea utilizatoare (art. R. 4512-2 și R. 4512-3 din Codul muncii francez):
+PriorVisitCheckList = Locurile de muncă|Instalațiile aflate acolo|Materialele eventual puse la dispoziția întreprinderilor externe|Delimitarea sectorului de intervenție al întreprinderilor externe|Marcarea zonelor din acest sector care pot prezenta pericole pentru lucrători|Indicarea căilor de circulație pe care le vor putea folosi lucrătorii, precum și vehiculele și utilajele de orice natură aparținând întreprinderilor externe|Definirea căilor de acces ale lucrătorilor la spațiile și instalațiile destinate EE (în special instalațiile sanitare, vestiarele colective și spațiile de servire a mesei)
+PriorVisitComments = Au fost consemnate următoarele observații:
+InterventionPeriodSentence = Acest plan începe la %s și se încheie la %s. Intervențiile se vor desfășura în următoarele intervale orare:
+RiskAnalysisIntro = Ați prevăzut %s intervenție(i) pentru acest plan de prevenire: mai jos, detaliul acțiunilor prevăzute, riscurile generate și mijloacele de prevenire puse în aplicare.
+PreventionPlanAttendants = Participanți: Întreprinderea Externă (EE) și subcontractanții
+Morning = Dimineața
+Afternoon = După-amiaza
+Signatures = Semnături
+SignaturePending = În așteptare
+PreventionPlanRiskPhotos = Fotografiile riscului
+InterventionPeriodOnly = Acest plan începe la %s și se încheie la %s.
+
+DigiRisk=DigiRisk
+DigiriskIdentification=DESCRIERE ȘI CARACTERISTICI
+DigiriskSecurity=SECURITATE
+DigiriskUserManual=MOD DE UTILIZARE SIMPLIFICAT
+DigiriskQualification=CALIFICARE ȘI AUTORIZARE
+DigiriskHygiene=IGIENĂ ȘI CURĂȚENIE
+DigiriskMaintenance=MENTENANȚĂ ȘI CONTROALE
+DangerCategory=Familie de risc
+SelectDangerCategory=Alegeți o familie de risc
+DescribeRiskOnProduct=Descrieți riscul pentru acest produs...
+ConfirmDeleteProductRisk=Ștergeți acest risc?
+AddProductRisk=Adăugați un risc de produs
+ClickToAddContent=Faceți clic pentru a adăuga conținut...
+AddProtection=Adăugați o protecție
+
+SelectProtection=Alegeți o protecție EIP
+TechnicalSheet=Fișă tehnică
+DigiriskRisks=RISCURI ȘI PROTECȚII
+MobileSuccessInteriorSignedOn=Responsabilul Întreprinderii Utilizatoare (EU): Semnat la %s
+
+MobileSuccessPlanSentByEmailOn = Plan de prevenire trimis prin email la %s
+MobileSuccessExteriorSignedOn = Responsabilul Întreprinderii Externe (EE): Semnat la %s
+MobileSuccessExteriorPendingSignature = Responsabilul Întreprinderii Externe (EE): În așteptarea semnăturii
+
+MobilePPErrorInvalidEmail = Respectați formatul adresei de email.
+MobilePPErrorInvalidPhone = Respectați formatul numărului de telefon.
+MobilePPExtSendEmail = Trimiteți emailul
+MobilePPErrorMailServerNotConfigured = Serverul dumneavoastră de email nu este configurat, contactați administratorul.
+MobilePPDoliletterNotInstalled = Modulul Doliletter nu este instalat. Difuzarea planurilor de prevenire și a permiselor de lucru cu foc nu va fi disponibilă (contactați administratorul)
+
+# Stări și tipuri pentru indicii
+preventionplan = Plan de prevenire
+Locked = Blocat
+InProgress = În curs
+ValidatePendingSignature = În așteptarea semnăturii
+Archived = Arhivat
+
+ProductFIChaptersManagement=Personalizarea capitolelor fișei de instruire
+ProductFIChaptersManagementSub=Personalizarea filei "Fișă de instruire" și a filei "Riscuri" din fișa produsului
+DefaultContent=Conținut implicit
+CustomSvgUploaded=SVG personalizat
+DeleteCustomSvg=Ștergeți
+DefaultSvgUsed=SVG implicit
+
+PwaTilePreventionPlanLocked = Planuri validate
+PwaTileFirePermitLocked = Permise validate
+
+# ===========================================================================
+# Dicționarul coloanelor Kanban ale planului de acțiune — issue #5017
+# ===========================================================================
+ActionPlanColumnDictionary           = Coloanele Kanban ale planului de acțiune
+ActionPlanColumnDictionaryDesc       = Coloane afișate în Kanbanul PAPRIPACT atunci când modul dicționar este activat: denumire, interval de progres, culoare și pictogramă
+KanbanColumnSource                   = Sursa coloanelor
+KanbanColumnSourceDesc               = Împărțiți Kanbanul cu pragurile procentuale de mai jos (funcționare istorică) sau cu dicționarul coloanelor
+KanbanColumnSourceThresholds         = Praguri procentuale (implicit)
+KanbanColumnSourceDictionary         = Dicționarul coloanelor
+ActionPlanColumnProgressHelp         = Limitele de progres acoperite de coloană, de la 0 la 100
+ActionPlanColumnColorHelp            = Culoarea hexazecimală a coloanei, de exemplu #3085d6
+ActionPlanColumnPictoHelp            = Numele pictogramei Font Awesome, de exemplu fa-check
+Progress_min                         = Progres min.
+Progress_max                         = Progres max.
+Picto                                = Pictogramă
+
+# Urmărirea timpului consumat
+GenerateTimeSpentReport = Generați urmărirea timpului (PDF)
+TimeSpentReport = Urmărirea timpului consumat
+TimeSpentReportUsersHelp = Lăsați gol pentru a include toate persoanele care au înregistrat timp pe acest proiect.
+TimeSpentReportSummary = Rezumat pe utilizator
+TimeSpentReportGrandTotal = Total general
+TimeSpentReportGeneratedAt = Generat la
+TimeSpentReportWholePeriod = De la începutul proiectului
+TimeSpentReportNoData = Niciun timp consumat nu corespunde utilizatorilor și perioadei selectate.
+TimeSpentDocumentPDFDescription = Timp consumat pe un proiect, grupat pe utilizator
+
+# Alinierea permisului de lucru cu foc mobil la planul de prevenire - issue #5042
+MobileProgress = Progres
+MobileStepDone = EFECTUAT
+MobileStepInProgress = ÎN CURS
+MobileStepTodo = DE EFECTUAT
+MobileStepSignedOn = SEMNAT LA
+MobilePPStepCreated = PP creat
+MobileFPStepCreated = PF creat
+MobileStepUserCompanyResponsible = Resp. EU
+MobileStepExteriorCompanyResponsible = Resp. EE
+MobileStepLock = Blocați
+MobileStepArchive = Arhivați
+MobileLock = Blocați
+MobileResponsibleShort = Resp.
+MobileMailSentTo = Email trimis către
+MobilePPMotif = Motivul intervenției
+MobilePPSchedules = Program de intervenție
+MobilePPConfigHours = Configurați aici programul dumneavoastră
+MobilePPCopyCompanyHours = Copiați programul companiei
+FirePermitUserCompany = Întreprindere Utilizatoare - EU
+FirePermitExteriorCompany = Întreprindere Externă - EE
+MobileFPMotif = Motivul lucrărilor
+MobileFPMotifPlaceholder = Ex.: sudură pe șarpantă
+MobileFPNoMotif = Niciun motiv completat
+MobileFPSchedules = Programul lucrărilor
+MobileFPWorkTypeDescriptionPlaceholder = Descrieți lucrările la fața locului
+MobileFPNoWorkTypeYet = Niciun tip de lucrări adăugat deocamdată.
+MobileFPDeleteWorkTypeTitle = Ștergeți tipul de lucrări
+MobileFPDeleteWorkTypeConfirm = «%s» va fi retras din permis, împreună cu descrierea, materialul, fotografiile și protecțiile sale.
+MobileFPNoTagAvailable = Nicio etichetă de permis de lucru cu foc nu este disponibilă.
+MobileFPErrorUpdatingPermit = Eroare la actualizarea permisului de lucru cu foc.
+MobileFPErrorCreatingPermit = Eroare la crearea permisului de lucru cu foc.
+MobileFPLockNeedsSignature = Permisul trebuie semnat înainte de a putea fi blocat.
+MobileFPSpreadAvailableOnceSignedAndLocked = Difuzarea va fi disponibilă de îndată ce permisul va fi semnat de responsabili și blocat.
+MobileFPDefaultDateStartToday = Data de început = data de azi
+MobileFPDefaultDuration = Durata implicită a perioadei (zile)
+firepermit = Permis de lucru cu foc
+ErrorRecordIsLocked = Această înregistrare este blocată, nu mai poate fi modificată.
+MobilePPEmailTemplateExt = Șablon de email pentru responsabilul întreprinderii externe
+MobilePPEmailTemplateInt = Șablon de email pentru lucrătorii întreprinderii externe
+
+#
+# ListingRisksDocument PDF - Listă de riscuri în format PDF
+#
+
+ListingRisksDocumentPDF            = Listă de riscuri PDF
+ListingRisksDocumentPDFDescription = Listă de riscuri în PDF nativ, deschisă pe mini documentul de evaluare a riscurilor al elementului
+ListingRisksDocumentPDFTitle       = EVALUAREA RISCURILOR
+ListingRisksEstablishment          = Unitate
+ListingRisksCoverContent           = Cuprins
+ListingRisksCoverHierarchy         = Ierarhie
+ListingRisksCoverDuerpFollowUp     = Monitorizarea documentului de evaluare a riscurilor
+ListingRisksCoverEmergencyNumbers  = Numere de urgență
+ListingRisksCoverReportIncident    = Semnalați un accident sau o problemă
+ListingRisksCoverRegisters         = Registre de securitate și sănătate în muncă și de pericol grav și iminent
+ListingRisksCoverIllustration      = Imagine ilustrativă
+NoPreventionOfficerAssigned        = Niciun responsabil cu prevenirea desemnat
+NoEmergencyNumberConfigured        = Niciun număr de urgență configurat
+NoResponsibleAssigned              = Niciun responsabil desemnat
+ListingRisksLegalTitle             = Cadru de reglementare
+RiskDefinitionTitle                = Definiția unui risc
+RiskDefinitionText                 = Risc: subst. masc. Pericol sau inconvenient la care cineva se expune. A face ceva pe riscul propriu, asumându-și întreaga responsabilitate pentru consecințe. Un risc calculat. A-și asuma riscuri: a se expune unui pericol.
+DangerDefinitionTitle              = Definiția unui pericol
+DangerDefinitionText               = Pericol: subst. neutru (din latina populară dominiarium «putere», de la dominus «stăpân»; inițial faptul de a fi la discreția cuiva). Ceea ce amenință siguranța sau viața cuiva; ceea ce riscă să compromită o situație, o întreprindere etc.
+SingleDocumentTitle                = Documentul de evaluare a riscurilor
+SingleDocumentText                 = Documentul de evaluare a riscurilor este reglementat de articolele R4121-1 până la 4 din Codul muncii francez. Principiile generale de prevenire impun ordinea de tratare a riscului.
+PreventionPrinciplesTitle          = Principiile generale de prevenire - Articolul L4121-2
+PreventionPrinciplesIntro          = Angajatorul pune în aplicare măsurile prevăzute la articolul L. 4121-1 pe baza următoarelor principii generale de prevenire:
+PreventionPrinciple1               = Evitarea riscurilor.
+PreventionPrinciple2               = Evaluarea riscurilor care nu pot fi evitate.
+PreventionPrinciple3               = Combaterea riscurilor la sursă.
+PreventionPrinciple4               = Adaptarea muncii la om, în special în ceea ce privește proiectarea posturilor de lucru, precum și alegerea echipamentelor de muncă și a metodelor de muncă și de producție, în vederea limitării muncii monotone și a muncii în ritm impus și a reducerii efectelor acestora asupra sănătății.
+PreventionPrinciple5               = Luarea în considerare a stadiului de evoluție a tehnicii.
+PreventionPrinciple6               = Înlocuirea a ceea ce este periculos cu ceea ce nu este periculos sau cu ceea ce este mai puțin periculos.
+PreventionPrinciple7               = Planificarea prevenirii prin integrarea, într-un ansamblu coerent, a tehnicii, a organizării muncii, a condițiilor de muncă, a relațiilor sociale și a influenței factorilor de mediu, în special a riscurilor legate de hărțuirea morală și de hărțuirea sexuală, precum și a celor legate de comportamentele sexiste.
+PreventionPrinciple8               = Adoptarea de măsuri de protecție colectivă, acordându-le prioritate față de măsurile de protecție individuală.
+PreventionPrinciple9               = Furnizarea de instrucțiuni adecvate lucrătorilor.
+ListingRisksCotationMethodTitle    = Metoda de calcul a cotațiilor
+ListingRisksCotationMethodText     = Cotația unui risc este un punctaj de la 0 la 100 atribuit la evaluarea acestuia. Nivelul de risc indicat în listă decurge direct din acesta, conform grilei de mai jos.
+ListingRisksCotationLevel          = Nivel
+ListingRisksCotationRange          = Cotație
+ListingRisksCotationMeaning        = Semnificație
+ListingRisksCotationAction         = Conduita de urmat
+ListingRisksCotationAction1        = Menținerea mijloacelor de prevenire existente.
+ListingRisksCotationAction2        = Înscrierea unei acțiuni în programul anual de prevenire.
+ListingRisksCotationAction3        = Inițierea unei acțiuni de prevenire pe termen scurt.
+ListingRisksCotationAction4        = Acțiune imediată, expunerea trebuie să înceteze.
+ListingRisksListTitle              = Lista riscurilor
+ListingRisksActionPlan             = Acțiunile programului anual de prevenire
+ListingRisksCotationColumn         = Cot.
+ListingRisksRiskColumn             = Risc
+ListingRisksAssessmentColumn       = Informații despre evaluare
+NoRiskAssessed                     = Niciun risc evaluat în acest perimetru

--- a/langs/ro_RO/index.php
+++ b/langs/ro_RO/index.php
@@ -1,0 +1,2 @@
+<?php
+//Silence is golden


### PR DESCRIPTION
## Changements

Digirisk n'était traduit qu'en français : `en_US` couvrait 468 clés sur 1960. Cette PR complète l'anglais et ajoute sept langues.

- **`en_US` complété** : 468 → 1960 clés. Le fichier devient un miroir ligne à ligne du `fr_FR` (même ordre, mêmes sections, commentaires traduits), ce qui rend les deux fichiers diffables côte à côte pour les évolutions futures.
- **Sept nouvelles langues**, 1960 clés chacune, construites sur le même modèle : `es_ES`, `de_DE`, `pt_PT`, `ro_RO`, `nl_NL`, `pl_PL`, `it_IT`.
- **Deux correctifs dans `fr_FR`**, nécessaires pour que les fichiers cibles ne contiennent aucune clé absente de la source :
  - `DigiriskElementInheritedRiskSignsList` n'avait pas de `=` : la clé n'existait donc pas du tout.
  - `AddProductRisk` et `ClickToAddContent`, utilisées dans `view/product/`, n'existaient qu'en anglais.
- Chaque nouveau dossier de langue reçoit son `index.php` (`//Silence is golden`), comme les dossiers existants.

## Terminologie

Les termes réglementaires locaux ont été utilisés plutôt que des traductions littérales, quand l'équivalent légal existe :

| FR | EN | ES | DE | PT | RO | NL | PL | IT |
|---|---|---|---|---|---|---|---|---|
| Document Unique | Risk assessment document | Documento de evaluación de riesgos | **Gefährdungsbeurteilung** | Documento de avaliação de riscos | Document de evaluare a riscurilor | **Risico-inventarisatie** | Ocena ryzyka zawodowego | **Documento di valutazione dei rischi** |
| Plan de prévention | Prevention plan | Plan de prevención | Präventionsplan | Plano de prevenção | Plan de prevenire | Preventieplan | Plan prewencji | Piano di prevenzione |
| Permis de feu | Fire permit | Permiso de fuego | Feuererlaubnisschein | Licença de fogo | Permis de lucru cu foc | Vuurvergunning | Zezwolenie na prace pożarowe | Permesso di lavoro a caldo |
| Signalisation | Risk sign | Señalización | Kennzeichnung | Sinalização | Semnalizare | Signalering | Oznakowanie | Segnaletica |

`GP/UT` reste non traduit dans toutes les langues : ce sont les préfixes des références en base (`GP01`, `UT03`), pas seulement des libellés.

## Vérifications

Pour chacune des huit langues, contrôlé automatiquement contre `fr_FR` :

- **1960 / 1960 clés** — aucune clé manquante
- **0 clé présente dans la cible mais absente de `fr_FR`** — c'est le cas qui fige la langue pour toute la requête
- **0 écart de placeholder** `%s` / `%d`, comparé occurrence par occurrence (les clés dupliquées comme `RiskDeleted` gardent la valeur propre à chaque occurrence)
- **0 valeur vide**

Chargement testé en exécution réelle via `Translate::load()`, pas seulement au niveau du format.

## Effet de bord utile

La cascade de Dolibarr (`xx_YY` → `xx_XX` → `en_US`) fait que ces sept fichiers en servent d'autres sans travail supplémentaire — vérifié en exécution : `es_MX`, `es_AR`, `pt_BR`, `de_AT`, `de_CH`, `nl_BE`. Et les huit locales francophones (`fr_BE`, `fr_CH`, `fr_CA`, `fr_TN`, `fr_CI`, `fr_CM`, `fr_GA`, `fr_NC`) continuent d'être servies par `fr_FR`.

## À noter pour la suite

Saturne ne livre que `en_US` et `fr_FR` (376 clés). Tant qu'il n'est pas traduit, signature, médias et objets resteront en anglais au milieu de ces interfaces traduites.

Le volet Transifex de l'issue (`.tx/config` absent du dépôt, organisation à trancher entre `o:evarisk:p:digirisk` et `o:eoxia-1`) n'est pas traité ici : il demande un accès au compte.

## Fichiers modifiés

- `langs/fr_FR/digiriskdolibarr.lang` (2 correctifs)
- `langs/en_US/digiriskdolibarr.lang` (complété)
- `langs/es_ES/`, `langs/de_DE/`, `langs/pt_PT/`, `langs/ro_RO/`, `langs/nl_NL/`, `langs/pl_PL/`, `langs/it_IT/` (nouveaux)

## Issue

Close #5073
