### PR TITLE
#5086 [FirePermit] fix: supprime l'appel à saturne_asset_urls() absente de Saturne

### DIFF
--- a/view/firepermit/firepermit_mobile_create.php
+++ b/view/firepermit/firepermit_mobile_create.php
@@ -842,15 +842,15 @@ if ($action == 'resend_ext_signature_email' && $permissiontoadd) {
 
 $title    = mb_strtoupper($langs->transnoentities('firepermit'), 'UTF-8');
 $help_url = 'FR:Module_Digirisk';
-$moreJS   = saturne_asset_urls([
+$moreJS   = [
     '/custom/saturne/js/saturne.min.js',
     '/custom/digiriskdolibarr/js/signature-pad.min.js',
     '/custom/digiriskdolibarr/js/digiriskdolibarr.min.js',
-]);
-$moreCSS  = saturne_asset_urls([
+];
+$moreCSS  = [
     '/custom/saturne/css/saturne.min.css',
     '/custom/digiriskdolibarr/css/digiriskdolibarr.min.css',
-]);
+];
 
 $conf->dol_hide_topmenu         = 1;
 $conf->dol_hide_leftmenu        = 1;


### PR DESCRIPTION
## Contexte

L'interface mobile de création d'un permis de feu renvoie une page blanche en production :

```
PHP Fatal error:  Uncaught Error: Call to undefined function saturne_asset_urls()
in custom/digiriskdolibarr/view/firepermit/firepermit_mobile_create.php:845
```

`saturne_asset_urls()` est définie dans `saturne/lib/asset.lib.php`, un fichier qui n'est pas livré sur `develop` côté Saturne. Le Saturne installé en production ne connaît donc pas cette fonction, et le fatal se déclenche avant `llxHeader()` : la page entière est inaccessible.

`preventionplan_mobile_create.php` n'est pas impacté, il utilise encore des tableaux bruts.

## Changements

- Remplacement des deux appels à `saturne_asset_urls()` par des tableaux d'URLs bruts, à l'identique de `preventionplan_mobile_create.php`

Le cache busting des assets sera réintroduit sur les deux écrans mobiles une fois `asset.lib.php` livré côté Saturne.

## Fichiers modifiés

- `view/firepermit/firepermit_mobile_create.php`

Close #5086
