### PR TITLE
#5088 [Card] Erreur fatale sur une fiche appelée avec un identifiant inexistant

### DIFF
--- a/view/accident/accident_card.php
+++ b/view/accident/accident_card.php
@@ -47,7 +47,7 @@ require_once __DIR__ . '/../../lib/digiriskdolibarr_accident.lib.php';
 global $conf, $db, $hookmanager, $langs, $moduleNameLowerCase, $mysoc, $user;
 
 // Load translation files required by the page
-saturne_load_langs();
+saturne_load_langs(['errors']);
 
 // Get parameters
 $id                  = GETPOSTINT('id');
@@ -119,6 +119,14 @@ $permissiontoadd    = $user->rights->digiriskdolibarr->accident->write;
 $permissiontodelete = $user->rights->digiriskdolibarr->accident->delete;
 
 saturne_check_access($permissiontoread, $object);
+
+// Un identifiant inconnu laisse l'objet vide : la page continuerait jusqu'a passer une propriete
+// nulle a une methode typee, et s'arreterait sur une erreur fatale
+if (($id > 0 || dol_strlen($ref)) && $object->id <= 0) {
+	setEventMessages($langs->trans('ErrorRecordNotFound'), null, 'errors');
+	header('Location: ' . dol_buildpath('/digiriskdolibarr/view/accident/accident_list.php', 1));
+	exit;
+}
 
 /*
  * Actions

--- a/view/digiriskelement/digiriskelement_card.php
+++ b/view/digiriskelement/digiriskelement_card.php
@@ -49,7 +49,7 @@ require_once __DIR__ . '/../../lib/digiriskdolibarr_function.lib.php';
 global $conf, $db, $hookmanager, $langs, $user;
 
 // Load translation files required by the page
-saturne_load_langs(['other']);
+saturne_load_langs(['errors', 'other']);
 
 // Get parameters
 $id                  = GETPOSTINT('id');
@@ -91,6 +91,14 @@ $permissiontoadd    = $user->rights->digiriskdolibarr->digiriskelement->write;
 $permissiontodelete = $user->rights->digiriskdolibarr->digiriskelement->delete;
 
 saturne_check_access($permissiontoread, $object);
+
+// Un identifiant inconnu laisse l'objet vide : la page continuerait jusqu'a passer une propriete
+// nulle a une methode typee, et s'arreterait sur une erreur fatale
+if (($id > 0 || dol_strlen($ref)) && $object->id <= 0) {
+	setEventMessages($langs->trans('ErrorRecordNotFound'), null, 'errors');
+	header('Location: ' . dol_buildpath('/digiriskdolibarr/view/digiriskstandard/digiriskstandard_card.php?id=1', 1));
+	exit;
+}
 
 /*
  * Actions

--- a/view/firepermit/firepermit_card.php
+++ b/view/firepermit/firepermit_card.php
@@ -53,7 +53,7 @@ require_once __DIR__ . '/../../lib/digiriskdolibarr_firepermit.lib.php';
 global $conf, $db, $hookmanager, $langs, $user;
 
 // Load translation files required by the page
-saturne_load_langs(['other', 'mails']);
+saturne_load_langs(['errors', 'other', 'mails']);
 
 // Get parameters
 $id                  = GETPOSTINT('id');
@@ -120,6 +120,14 @@ $permissiontoadd    = $user->rights->digiriskdolibarr->firepermit->write;
 $permissiontodelete = $user->rights->digiriskdolibarr->firepermit->delete;
 
 saturne_check_access($permissiontoadd, $object);
+
+// Un identifiant inconnu laisse l'objet vide : la page continuerait jusqu'a passer une propriete
+// nulle a une methode typee, et s'arreterait sur une erreur fatale
+if (($id > 0 || dol_strlen($ref)) && $object->id <= 0) {
+	setEventMessages($langs->trans('ErrorRecordNotFound'), null, 'errors');
+	header('Location: ' . dol_buildpath('/digiriskdolibarr/view/firepermit/firepermit_list.php', 1));
+	exit;
+}
 
 /*
  * Actions

--- a/view/preventionplan/preventionplan_card.php
+++ b/view/preventionplan/preventionplan_card.php
@@ -54,7 +54,7 @@ require_once __DIR__ . '/../../lib/digiriskdolibarr_preventionplan.lib.php';
 global $conf, $db, $hookmanager, $langs, $moduleNameLowerCase, $user;
 
 // Load translation files required by the page
-saturne_load_langs(['other', 'mails']);
+saturne_load_langs(['errors', 'other', 'mails']);
 
 // Get parameters
 $id                  = GETPOSTINT('id');
@@ -127,6 +127,14 @@ $permissiontoadd    = $user->rights->digiriskdolibarr->preventionplan->write;
 $permissiontodelete = $user->rights->digiriskdolibarr->preventionplan->delete;
 
 saturne_check_access($permissiontoadd, $object);
+
+// Un identifiant inconnu laisse l'objet vide : la page continuerait jusqu'a passer une propriete
+// nulle a une methode typee, et s'arreterait sur une erreur fatale
+if (($id > 0 || dol_strlen($ref)) && $object->id <= 0) {
+	setEventMessages($langs->trans('ErrorRecordNotFound'), null, 'errors');
+	header('Location: ' . dol_buildpath('/digiriskdolibarr/view/preventionplan/preventionplan_list.php', 1));
+	exit;
+}
 
 /*
  * Actions


### PR DESCRIPTION
Closes #5088

## Le problème

Les fiches chargeaient leur objet sans vérifier que le `fetch()` avait abouti :

```php
// Load object
$object->fetch($id);
```

Sur un identifiant inconnu — lien périmé, favori vers un enregistrement supprimé, identifiant saisi à la main — la page continuait avec un objet vide jusqu'à passer une propriété nulle à une méthode typée, et s'arrêtait sur une page blanche.

`saturne_check_access()` ne couvre pas ce cas : elle vérifie les droits et l'entité, pas l'existence de l'enregistrement.

## Le correctif

Après le contrôle d'accès — pour ne pas court-circuiter la vérification des permissions — la page redirige vers la liste du module avec le message « Enregistrement non trouvé », comme le fait le cœur de Dolibarr. Le fichier de langue `errors` est chargé sur ces pages, il ne l'était pas.

## Tests

| Fiche, `?id=999999` | Avant | Après |
|---|---|---|
| Permis de feu | `FirePermit::LibStatut(): … null given` | liste + message |
| Plan de prévention | `PreventionPlan::LibStatut(): … null given` | liste + message |
| Accident | `AccidentWorkStop::fetchFromParent(): … null given` | liste + message |
| Élément | `DigiriskElement::LibStatut(): … null given` | arborescence + message |

Non-régression : les fiches réelles s'ouvrent normalement (permis de feu, plan de prévention, accident, élément), l'écran de création d'un groupement — qui n'a pas d'identifiant — n'est pas intercepté, et l'accès par référence fonctionne toujours (`?ref=PP1` ouvre la fiche, `?ref=INEXISTANT` redirige vers la liste).

🤖 Generated with [Claude Code](https://claude.com/claude-code)