### PR TITLE
#4425 [Risk] feat: active d'office le préremplissage de la description du risque

### DIFF
--- a/core/modules/modDigiriskDolibarr.class.php
+++ b/core/modules/modDigiriskDolibarr.class.php
@@ -704,7 +704,7 @@ class modDigiriskdolibarr extends DolibarrModules
 			$i++ => ['DIGIRISKDOLIBARR_RISK_CATEGORY_EDIT', 'integer', 0, '', 0, 'current'],
 			$i++ => ['DIGIRISKDOLIBARR_MOVE_RISKS', 'integer', 0, '', 0, 'current'],
 			$i++ => ['DIGIRISKDOLIBARR_SORT_LISTINGS_BY_COTATION', 'integer', 1, '', 0, 'current'],
-			$i++ => ['DIGIRISKDOLIBARR_RISK_DESCRIPTION_PREFILL', 'integer', 0, '', 0, 'current'],
+			$i++ => ['DIGIRISKDOLIBARR_RISK_DESCRIPTION_PREFILL', 'integer', 1, '', 0, 'current'],
 			$i++ => ['DIGIRISKDOLIBARR_SHOW_RISK_ORIGIN', 'integer', 1, '', 0, 'current'],
 			$i++ => ['DIGIRISKDOLIBARR_SHOW_RISKS', 'integer', 1, '', 0, 'current'],
             $i++ => ['DIGIRISKDOLIBARR_RISK_LIST_PARENT_VIEW', 'integer', 0, '', 0, 'current'],

--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
@@ -650,7 +650,7 @@ $massactionbutton = $form->selectMassAction('', $arrayofmassactions);
                             <span class="title"><?php echo $langs->trans('Risk'); ?><required>*</required></span>
                             <div class="wpeo-dropdown dropdown-large dropdown-grid category-danger padding">
                                 <input class="input-hidden-danger" type="hidden" name="risk_category_id" value="undefined" />
-                                <input class="input-risk-description-prefill" type="hidden" name="risk_description_prefill" value="<?php echo $conf->global->DIGIRISKDOLIBARR_RISK_DESCRIPTION_PREFILL; ?>" />
+                                <input class="input-risk-description-prefill" type="hidden" name="risk_description_prefill" value="<?php echo getDolGlobalInt('DIGIRISKDOLIBARR_RISK_DESCRIPTION_PREFILL'); ?>" />
                                 <div class="dropdown-toggle dropdown-add-button button-cotation">
                                     <span class="wpeo-button button-square-50 button-grey"><i class="fas fa-exclamation-triangle button-icon"></i><i class="fas fa-plus-circle button-add"></i></span>
                                     <img class="danger-category-pic wpeo-tooltip-event hidden" src="" aria-label=""/>

--- a/sql/update.sql
+++ b/sql/update.sql
@@ -285,3 +285,6 @@ DELETE FROM llx_const WHERE name = 'MAIN_MODULE_DIGIRISKDOLIBARR_TABS';
 
 -- 23.1.x - index used by the per-risk loading of risk assessments on the risk lists
 ALTER TABLE llx_digiriskdolibarr_riskassessment ADD INDEX idx_digiriskdolibarr_riskassessment_fk_risk (fk_risk);
+
+-- 23.1.x - enable the prefill of the risk description with the danger category name on every entity
+UPDATE llx_const SET value = 1 WHERE name = 'DIGIRISKDOLIBARR_RISK_DESCRIPTION_PREFILL';


### PR DESCRIPTION
Closes #4425

## Contexte

L'option **Préremplir la description du risque avec le nom de la catégorie** (`DIGIRISKDOLIBARR_RISK_DESCRIPTION_PREFILL`) était désactivée par défaut alors qu'elle est systématiquement activée à la main.

## Modifications

- `core/modules/modDigiriskDolibarr.class.php` : valeur par défaut de la constante passée de `0` à `1` (nouvelles activations du module).
- `sql/update.sql` : `UPDATE llx_const SET value = 1` pour activer l'option sur les installations existantes, toutes entités confondues.
- `core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php` : lecture de la constante via `getDolGlobalInt()` au lieu de `$conf->global->...` (évite un warning si la constante est absente).

⚠️ La migration réactive l'option même chez les rares utilisateurs qui l'avaient volontairement désactivée — c'est le comportement demandé dans l'issue ; l'option reste débrayable dans la configuration.

## Tests

Testé en local (Dolibarr 23.0.3, Digirisk 23.1.1) sur la liste des risques d'un GP :

| Constante à `0` (avant migration) | Constante à `1` (après migration) |
|---|---|
| description vide après choix du danger | description préremplie « Risques de chute de plain-pied » |

- Écran de configuration : l'interrupteur s'affiche bien sur « activé ».
- Aucune erreur JS en console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)