### PR TITLE
#5072 [Admin] feat: masquer les entrées de menu objet par objet depuis la configuration

### DIFF
--- a/admin/setup.php
+++ b/admin/setup.php
@@ -165,6 +165,44 @@ print '</table>';
 // Click on a tuto image to display it full size
 digiriskdolibarr_tuto_overlay();
 
+print load_fiche_titre($langs->trans("MenuVisibility"), '', '');
+
+print '<table class="noborder centpercent">';
+print '<tr class="liste_titre">';
+print '<td>' . $langs->trans("Name") . '</td>';
+print '<td>' . $langs->trans("Description") . '</td>';
+print '<td class="center">' . $langs->trans("Status") . '</td>';
+print '</tr>';
+
+// Each entry: constant => [label key, description key]
+// The constant stores the hidden state: an absent constant means the menu entries are shown, so an
+// installation upgraded without reactivating the module keeps every entry visible.
+// The environment constant is named after riskenvironmental on purpose: dol_eval() rejects the whole
+// menu condition as soon as it contains the _ENV substring, which DIGIRISKDOLIBARR_ENVIRONMENT_ has.
+$digiriskMenuSettings = [
+    'DIGIRISKDOLIBARR_RISKASSESSMENTDOCUMENT_MENU_HIDDEN' => ['RiskAssessmentDocument', 'RiskAssessmentDocumentMenuVisibilityDescription'],
+    'DIGIRISKDOLIBARR_RISKENVIRONMENTAL_MENU_HIDDEN'      => ['Environment', 'EnvironmentMenuVisibilityDescription'],
+    'DIGIRISKDOLIBARR_PREVENTIONPLAN_MENU_HIDDEN'         => ['PreventionPlan', 'PreventionPlanMenuVisibilityDescription'],
+    'DIGIRISKDOLIBARR_FIREPERMIT_MENU_HIDDEN'             => ['FirePermit', 'FirePermitMenuVisibilityDescription'],
+    'DIGIRISKDOLIBARR_ACCIDENT_MENU_HIDDEN'               => ['Accident', 'AccidentMenuVisibilityDescription'],
+    'DIGIRISKDOLIBARR_ACCIDENTINVESTIGATION_MENU_HIDDEN'  => ['AccidentInvestigation', 'AccidentInvestigationMenuVisibilityDescription'],
+    'DIGIRISKDOLIBARR_TOOLS_MENU_HIDDEN'                  => ['Tools', 'ToolsMenuVisibilityDescription'],
+];
+
+foreach ($digiriskMenuSettings as $constName => $transKeys) {
+    print '<tr class="oddeven"><td>';
+    print $langs->trans($transKeys[0]);
+    print '</td><td>';
+    print $langs->trans($transKeys[1]);
+    print '</td>';
+    print '<td class="center">';
+    // Revert the switch: the constant holds the hidden state, the switch shows the visible one
+    print ajax_constantonoff($constName, [], null, 1);
+    print '</td>';
+    print '</tr>';
+}
+print '</table>';
+
 print load_fiche_titre($langs->trans("MediaData"), '', '');
 
 print '<form method="POST" action="' . $_SERVER['PHP_SELF'] . '" name="media_data">';

--- a/core/modules/modDigiriskDolibarr.class.php
+++ b/core/modules/modDigiriskDolibarr.class.php
@@ -1497,7 +1497,7 @@ class modDigiriskdolibarr extends DolibarrModules
 			'url'      => '/digiriskdolibarr/view/digiriskstandard/digiriskstandard_card.php?risk_type=risk',
 			'langs'    => 'digiriskdolibarr@digiriskdolibarr',	        // Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
 			'position' => 100 + $r,
-			'enabled'  => 'isModEnabled(\'digiriskdolibarr\')',  // Define condition to show or hide menu entry. Use '!empty($conf->digiriskdolibarr->enabled)' if entry must be visible if module is enabled. Use '$leftmenu==\'system\'' to show if leftmenu system is selected.
+			'enabled'  => 'isModEnabled(\'digiriskdolibarr\') && !getDolGlobalInt(\'DIGIRISKDOLIBARR_RISKASSESSMENTDOCUMENT_MENU_HIDDEN\')',  // Define condition to show or hide menu entry. Use '!empty($conf->digiriskdolibarr->enabled)' if entry must be visible if module is enabled. Use '$leftmenu==\'system\'' to show if leftmenu system is selected.
 			'perms'    => '$user->rights->digiriskdolibarr->riskassessmentdocument->read', // Use 'perms'=>'$user->rights->digiriskdolibarr->level1->level2' if you want your menu with a permission rules
 			'target'   => '',
 			'user'     => 0,				                // 0=Menu for internal users, 1=external users, 2=both
@@ -1512,7 +1512,7 @@ class modDigiriskdolibarr extends DolibarrModules
 			'url'      => '/digiriskdolibarr/view/digiriskelement/risk_list.php?risk_type=risk',
 			'langs'    => 'digiriskdolibarr@digiriskdolibarr',	        // Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
 			'position' => 100 + $r,
-			'enabled'  => 'isModEnabled(\'digiriskdolibarr\')',  // Define condition to show or hide menu entry. Use '!empty($conf->digiriskdolibarr->enabled)' if entry must be visible if module is enabled. Use '$leftmenu==\'system\'' to show if leftmenu system is selected.
+			'enabled'  => 'isModEnabled(\'digiriskdolibarr\') && !getDolGlobalInt(\'DIGIRISKDOLIBARR_RISKASSESSMENTDOCUMENT_MENU_HIDDEN\')',  // Define condition to show or hide menu entry. Use '!empty($conf->digiriskdolibarr->enabled)' if entry must be visible if module is enabled. Use '$leftmenu==\'system\'' to show if leftmenu system is selected.
 			'perms'    => '$user->rights->digiriskdolibarr->risk->read', // Use 'perms'=>'$user->rights->digiriskdolibarr->level1->level2' if you want your menu with a permission rules
 			'target'   => '',
 			'user'     => 0,				                // 0=Menu for internal users, 1=external users, 2=both
@@ -1527,7 +1527,7 @@ class modDigiriskdolibarr extends DolibarrModules
             'url'      => '/digiriskdolibarr/view/digiriskstandard/actionplan_list.php?view=kanban',
             'langs'    => 'digiriskdolibarr@digiriskdolibarr',
             'position' => 100 + $r,
-            'enabled'  => 'isModEnabled(\'digiriskdolibarr\') && isModEnabled(\'projet\')',
+            'enabled'  => 'isModEnabled(\'digiriskdolibarr\') && isModEnabled(\'projet\') && !getDolGlobalInt(\'DIGIRISKDOLIBARR_RISKASSESSMENTDOCUMENT_MENU_HIDDEN\')',
             'perms'    => '$user->rights->projet->lire',
             'target'   => '',
             'user'     => 0,
@@ -1542,7 +1542,7 @@ class modDigiriskdolibarr extends DolibarrModules
             'url'      => '/categories/categorie_list.php?type=digiriskrisk',
             'langs'    => 'digiriskdolibarr@digiriskdolibarr',
             'position' => 100 + $r,
-            'enabled'  => 'isModEnabled(\'digiriskdolibarr\') && isModEnabled(\'categorie\') && $user->rights->digiriskdolibarr->risk->read && getDolGlobalString(\'DIGIRISKDOLIBARR_CATEGORY_ON_RISK\')',
+            'enabled'  => 'isModEnabled(\'digiriskdolibarr\') && isModEnabled(\'categorie\') && $user->rights->digiriskdolibarr->risk->read && getDolGlobalString(\'DIGIRISKDOLIBARR_CATEGORY_ON_RISK\') && !getDolGlobalInt(\'DIGIRISKDOLIBARR_RISKASSESSMENTDOCUMENT_MENU_HIDDEN\')',
             'perms'    => '$user->rights->digiriskdolibarr->risk->read',
             'target'   => '',
             'user'     => 0,
@@ -1558,7 +1558,7 @@ class modDigiriskdolibarr extends DolibarrModules
             'url'      => '/digiriskdolibarr/view/digiriskstandard/digiriskstandard_card.php?risk_type=riskenvironmental',
             'langs'    => 'digiriskdolibarr@digiriskdolibarr',
             'position' => 100 + $r,
-            'enabled'  => 'isModEnabled(\'digiriskdolibarr\')',
+            'enabled'  => 'isModEnabled(\'digiriskdolibarr\') && !getDolGlobalInt(\'DIGIRISKDOLIBARR_RISKENVIRONMENTAL_MENU_HIDDEN\')',
             'perms'    => '$user->rights->digiriskdolibarr->riskassessmentdocument->read && $user->rights->digiriskdolibarr->riskenvironmental->read',
             'target'   => '',
             'user'     => 0
@@ -1573,7 +1573,7 @@ class modDigiriskdolibarr extends DolibarrModules
             'url'      => '/digiriskdolibarr/view/digiriskelement/risk_list.php?risk_type=riskenvironmental',
             'langs'    => 'digiriskdolibarr@digiriskdolibarr',
             'position' => 100 + $r,
-            'enabled'  => 'isModEnabled(\'digiriskdolibarr\')',
+            'enabled'  => 'isModEnabled(\'digiriskdolibarr\') && !getDolGlobalInt(\'DIGIRISKDOLIBARR_RISKENVIRONMENTAL_MENU_HIDDEN\')',
             'perms'    => '$user->rights->digiriskdolibarr->riskenvironmental->read',
             'target'   => '',
             'user'     => 0
@@ -1588,7 +1588,7 @@ class modDigiriskdolibarr extends DolibarrModules
             'url'      => '/projet/tasks.php?id=' . ($conf->global->DIGIRISKDOLIBARR_ENVIRONMENT_PROJECT ?? ''),
             'langs'    => 'digiriskdolibarr@digiriskdolibarr',
             'position' => 100 + $r,
-            'enabled'  => 'isModEnabled(\'digiriskdolibarr\') && isModEnabled(\'projet\')',
+            'enabled'  => 'isModEnabled(\'digiriskdolibarr\') && isModEnabled(\'projet\') && !getDolGlobalInt(\'DIGIRISKDOLIBARR_RISKENVIRONMENTAL_MENU_HIDDEN\')',
             'perms'    => '$user->rights->projet->lire',
             'target'   => '_blank',
             'user'     => 0,
@@ -1604,7 +1604,7 @@ class modDigiriskdolibarr extends DolibarrModules
 			'url'      => '/digiriskdolibarr/view/preventionplan/preventionplan_list.php',
 			'langs'    => 'digiriskdolibarr@digiriskdolibarr',	        // Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
 			'position' => 100 + $r,
-			'enabled'  => 'isModEnabled(\'digiriskdolibarr\')',  // Define condition to show or hide menu entry. Use '!empty($conf->digiriskdolibarr->enabled)' if entry must be visible if module is enabled. Use '$leftmenu==\'system\'' to show if leftmenu system is selected.
+			'enabled'  => 'isModEnabled(\'digiriskdolibarr\') && !getDolGlobalInt(\'DIGIRISKDOLIBARR_PREVENTIONPLAN_MENU_HIDDEN\')',  // Define condition to show or hide menu entry. Use '!empty($conf->digiriskdolibarr->enabled)' if entry must be visible if module is enabled. Use '$leftmenu==\'system\'' to show if leftmenu system is selected.
 			'perms'    => '$user->rights->digiriskdolibarr->preventionplan->read', // Use 'perms'=>'$user->rights->digiriskdolibarr->level1->level2' if you want your menu with a permission rules
 			'target'   => '',
 			'user'     => 0,				                // 0=Menu for internal users, 1=external users, 2=both
@@ -1620,7 +1620,7 @@ class modDigiriskdolibarr extends DolibarrModules
             'url'      => '/categories/categorie_list.php?type=digiriskpreventionplan',
             'langs'    => 'digiriskdolibarr@digiriskdolibarr',
             'position' => 100 + $r,
-            'enabled'  => 'isModEnabled(\'digiriskdolibarr\') && isModEnabled(\'categorie\') && $user->rights->digiriskdolibarr->preventionplan->read',
+            'enabled'  => 'isModEnabled(\'digiriskdolibarr\') && isModEnabled(\'categorie\') && $user->rights->digiriskdolibarr->preventionplan->read && !getDolGlobalInt(\'DIGIRISKDOLIBARR_PREVENTIONPLAN_MENU_HIDDEN\')',
             'perms'    => '$user->rights->digiriskdolibarr->preventionplan->read',
             'target'   => '',
             'user'     => 0,
@@ -1652,7 +1652,7 @@ class modDigiriskdolibarr extends DolibarrModules
 			'url'      => '/digiriskdolibarr/view/firepermit/firepermit_list.php',
 			'langs'    => 'digiriskdolibarr@digiriskdolibarr',	        // Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
 			'position' => 100 + $r,
-			'enabled'  => 'isModEnabled(\'digiriskdolibarr\')',  // Define condition to show or hide menu entry. Use '!empty($conf->digiriskdolibarr->enabled)' if entry must be visible if module is enabled. Use '$leftmenu==\'system\'' to show if leftmenu system is selected.
+			'enabled'  => 'isModEnabled(\'digiriskdolibarr\') && !getDolGlobalInt(\'DIGIRISKDOLIBARR_FIREPERMIT_MENU_HIDDEN\')',  // Define condition to show or hide menu entry. Use '!empty($conf->digiriskdolibarr->enabled)' if entry must be visible if module is enabled. Use '$leftmenu==\'system\'' to show if leftmenu system is selected.
 			'perms'    => '$user->rights->digiriskdolibarr->firepermit->read', // Use 'perms'=>'$user->rights->digiriskdolibarr->level1->level2' if you want your menu with a permission rules
 			'target'   => '',
 			'user'     => 0,				                // 0=Menu for internal users, 1=external users, 2=both
@@ -1668,7 +1668,7 @@ class modDigiriskdolibarr extends DolibarrModules
             'url'      => '/categories/categorie_list.php?type=digiriskfirepermit',
             'langs'    => 'digiriskdolibarr@digiriskdolibarr',
             'position' => 100 + $r,
-            'enabled'  => 'isModEnabled(\'digiriskdolibarr\') && isModEnabled(\'categorie\') && $user->rights->digiriskdolibarr->firepermit->read',
+            'enabled'  => 'isModEnabled(\'digiriskdolibarr\') && isModEnabled(\'categorie\') && $user->rights->digiriskdolibarr->firepermit->read && !getDolGlobalInt(\'DIGIRISKDOLIBARR_FIREPERMIT_MENU_HIDDEN\')',
             'perms'    => '$user->rights->digiriskdolibarr->firepermit->read',
             'target'   => '',
             'user'     => 0,
@@ -1686,7 +1686,7 @@ class modDigiriskdolibarr extends DolibarrModules
 			'url'      => '/digiriskdolibarr/view/accident/accident.php',
 			'langs'    => 'digiriskdolibarr@digiriskdolibarr',	        // Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
 			'position' => 100 + $r,
-			'enabled'  => 'isModEnabled(\'digiriskdolibarr\')',  // Define condition to show or hide menu entry. Use '!empty($conf->digiriskdolibarr->enabled)' if entry must be visible if module is enabled. Use '$leftmenu==\'system\'' to show if leftmenu system is selected.
+			'enabled'  => 'isModEnabled(\'digiriskdolibarr\') && !getDolGlobalInt(\'DIGIRISKDOLIBARR_ACCIDENT_MENU_HIDDEN\')',  // Define condition to show or hide menu entry. Use '!empty($conf->digiriskdolibarr->enabled)' if entry must be visible if module is enabled. Use '$leftmenu==\'system\'' to show if leftmenu system is selected.
 			'perms'    => '$user->rights->digiriskdolibarr->accident->read', // Use 'perms'=>'$user->rights->digiriskdolibarr->level1->level2' if you want your menu with a permission rules
 			'target'   => '',
 			'user'     => 0,				                // 0=Menu for internal users, 1=external users, 2=both
@@ -1701,7 +1701,7 @@ class modDigiriskdolibarr extends DolibarrModules
 			'url'      => '/digiriskdolibarr/view/accident/accident_list.php',
 			'langs'    => 'digiriskdolibarr@digiriskdolibarr',	        // Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
 			'position' => 100 + $r,
-			'enabled'  => 'isModEnabled(\'digiriskdolibarr\')',  // Define condition to show or hide menu entry. Use '!empty($conf->digiriskdolibarr->enabled)' if entry must be visible if module is enabled. Use '$leftmenu==\'system\'' to show if leftmenu system is selected.
+			'enabled'  => 'isModEnabled(\'digiriskdolibarr\') && !getDolGlobalInt(\'DIGIRISKDOLIBARR_ACCIDENT_MENU_HIDDEN\')',  // Define condition to show or hide menu entry. Use '!empty($conf->digiriskdolibarr->enabled)' if entry must be visible if module is enabled. Use '$leftmenu==\'system\'' to show if leftmenu system is selected.
 			'perms'    => '$user->rights->digiriskdolibarr->accident->read', // Use 'perms'=>'$user->rights->digiriskdolibarr->level1->level2' if you want your menu with a permission rules
 			'target'   => '',
 			'user'     => 0,				                // 0=Menu for internal users, 1=external users, 2=both
@@ -1716,7 +1716,7 @@ class modDigiriskdolibarr extends DolibarrModules
             'url'      => '/categories/categorie_list.php?type=digiriskaccident',
             'langs'    => 'digiriskdolibarr@digiriskdolibarr',
             'position' => 100 + $r,
-            'enabled'  => 'isModEnabled(\'digiriskdolibarr\') && isModEnabled(\'categorie\') && $user->rights->digiriskdolibarr->accident->read',
+            'enabled'  => 'isModEnabled(\'digiriskdolibarr\') && isModEnabled(\'categorie\') && $user->rights->digiriskdolibarr->accident->read && !getDolGlobalInt(\'DIGIRISKDOLIBARR_ACCIDENT_MENU_HIDDEN\')',
             'perms'    => '$user->rights->digiriskdolibarr->accident->read',
             'target'   => '',
             'user'     => 0,
@@ -1731,7 +1731,7 @@ class modDigiriskdolibarr extends DolibarrModules
             'url'      => '/digiriskdolibarr/view/accidentinvestigation/accidentinvestigation_list.php',
             'langs'    => 'digiriskdolibarr@digiriskdolibarr',	        // Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
             'position' => 100 + $r,
-            'enabled'  => 'isModEnabled(\'digiriskdolibarr\') && isModEnabled(\'saturne\')',  // Define condition to show or hide menu entry. Use '!empty($conf->digiriskdolibarr->enabled)' if entry must be visible if module is enabled. Use '$leftmenu==\'system\'' to show if leftmenu system is selected.
+            'enabled'  => 'isModEnabled(\'digiriskdolibarr\') && isModEnabled(\'saturne\') && !getDolGlobalInt(\'DIGIRISKDOLIBARR_ACCIDENTINVESTIGATION_MENU_HIDDEN\')',  // Define condition to show or hide menu entry. Use '!empty($conf->digiriskdolibarr->enabled)' if entry must be visible if module is enabled. Use '$leftmenu==\'system\'' to show if leftmenu system is selected.
             'perms'    => '$user->rights->digiriskdolibarr->lire && $user->rights->digiriskdolibarr->accidentinvestigation->read', // Use 'perms'=>'$user->rights->digiriskdolibarr->level1->level2' if you want your menu with a permission rules
             'target'   => '',
             'user'     => 0,				                // 0=Menu for internal users, 1=external users, 2=both
@@ -1810,7 +1810,7 @@ class modDigiriskdolibarr extends DolibarrModules
 			'url'      => '/digiriskdolibarr/view/digirisktools.php',
 			'langs'    => 'digiriskdolibarr@digiriskdolibarr',	        // Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
 			'position' => 100 + $r,
-			'enabled'  => 'isModEnabled(\'digiriskdolibarr\')',  // Define condition to show or hide menu entry. Use '!empty($conf->digiriskdolibarr->enabled)' if entry must be visible if module is enabled. Use '$leftmenu==\'system\'' to show if leftmenu system is selected.
+			'enabled'  => 'isModEnabled(\'digiriskdolibarr\') && !getDolGlobalInt(\'DIGIRISKDOLIBARR_TOOLS_MENU_HIDDEN\')',  // Define condition to show or hide menu entry. Use '!empty($conf->digiriskdolibarr->enabled)' if entry must be visible if module is enabled. Use '$leftmenu==\'system\'' to show if leftmenu system is selected.
 			'perms'    => '$user->rights->digiriskdolibarr->adminpage->read',			                // Use 'perms'=>'$user->rights->digiriskdolibarr->level1->level2' if you want your menu with a permission rules
 			'target'   => '',
 			'user'     => 0,				                // 0=Menu for internal users, 1=external users, 2=both

--- a/langs/en_US/digiriskdolibarr.lang
+++ b/langs/en_US/digiriskdolibarr.lang
@@ -537,3 +537,17 @@ RiskTrendNew             = ⊕ New
 RiskTrendUp              = ↗ Up (%s → %s)
 RiskTrendDown            = ↘ Down (%s → %s)
 RiskTrendStable          = Stable (%s)
+
+# Menu visibility
+RiskAssessmentDocument                          = Risk assessment document
+Environment                                     = Environment
+Accident                                        = Accident
+AccidentInvestigation                           = Accident investigation
+MenuVisibility                                  = Menu entries visibility
+RiskAssessmentDocumentMenuVisibilityDescription = When the option is disabled, the risk assessment document menu entries (occupational risks, PAPRIPACT and risk categories) are hidden.<br>The "Risk assessment document" configuration tab is hidden only if the environment is hidden too.
+EnvironmentMenuVisibilityDescription            = When the option is disabled, the environment menu entries (environmental risks and action plan) are hidden.<br>The "Risk assessment document" configuration tab is hidden only if the risk assessment document is hidden too.
+PreventionPlanMenuVisibilityDescription         = When the option is disabled, the prevention plan menu entries (and its categories) and its configuration tab are hidden.
+FirePermitMenuVisibilityDescription             = When the option is disabled, the fire permit menu entries (and its categories) and its configuration tab are hidden.
+AccidentMenuVisibilityDescription               = When the option is disabled, the accident menu entries (list and categories) are hidden.<br>The "Accident" configuration tab is hidden only if the accident investigations are hidden too.
+AccidentInvestigationMenuVisibilityDescription  = When the option is disabled, the accident investigation menu entry is hidden.<br>The "Accident" configuration tab is hidden only if the accidents are hidden too.
+ToolsMenuVisibilityDescription                  = When the option is disabled, the tools menu entry is hidden.

--- a/langs/fr_FR/digiriskdolibarr.lang
+++ b/langs/fr_FR/digiriskdolibarr.lang
@@ -2394,3 +2394,13 @@ RiskTrendNew             = ⊕ Nouveau
 RiskTrendUp              = ↗ Hausse (%s → %s)
 RiskTrendDown            = ↘ Baisse (%s → %s)
 RiskTrendStable          = Stable (%s)
+
+# Menu visibility
+MenuVisibility                                  = Visibilité des entrées de menu
+RiskAssessmentDocumentMenuVisibilityDescription = Si l'option est désactivée, les entrées de menu du document unique (risques professionnels, PAPRIPACT et catégories de risques) sont masquées.<br>L'onglet de configuration « Document unique » n'est masqué que si l'environnement l'est également.
+EnvironmentMenuVisibilityDescription            = Si l'option est désactivée, les entrées de menu de l'environnement (risques environnementaux et plan d'action) sont masquées.<br>L'onglet de configuration « Document unique » n'est masqué que si le document unique l'est également.
+PreventionPlanMenuVisibilityDescription         = Si l'option est désactivée, les entrées de menu du plan de prévention (et ses catégories) ainsi que son onglet de configuration sont masqués.
+FirePermitMenuVisibilityDescription             = Si l'option est désactivée, les entrées de menu du permis de feu (et ses catégories) ainsi que son onglet de configuration sont masqués.
+AccidentMenuVisibilityDescription               = Si l'option est désactivée, les entrées de menu des accidents (liste et catégories) sont masquées.<br>L'onglet de configuration « Accident » n'est masqué que si les enquêtes accident le sont également.
+AccidentInvestigationMenuVisibilityDescription  = Si l'option est désactivée, l'entrée de menu des enquêtes accident est masquée.<br>L'onglet de configuration « Accident » n'est masqué que si les accidents le sont également.
+ToolsMenuVisibilityDescription                  = Si l'option est désactivée, l'entrée de menu des outils est masquée.

--- a/lib/digiriskdolibarr.lib.php
+++ b/lib/digiriskdolibarr.lib.php
@@ -107,10 +107,12 @@ function digiriskdolibarr_admin_prepare_head(): array
     $h    = 0;
     $head = [];
 
-    $head[$h][0] = dol_buildpath('/digiriskdolibarr/admin/config/riskassessmentdocument.php', 1);
-    $head[$h][1] = $conf->browser->layout != 'phone' ? '<i class="fas fa-exclamation-triangle pictofixedwidth"></i>' . $langs->trans('RiskAssessmentDocument') : '<i class="fas fa-exclamation-triangle"></i>';
-    $head[$h][2] = 'riskassessmentdocument';
-    $h++;
+    if (!getDolGlobalInt('DIGIRISKDOLIBARR_RISKASSESSMENTDOCUMENT_MENU_HIDDEN') || !getDolGlobalInt('DIGIRISKDOLIBARR_RISKENVIRONMENTAL_MENU_HIDDEN')) {
+        $head[$h][0] = dol_buildpath('/digiriskdolibarr/admin/config/riskassessmentdocument.php', 1);
+        $head[$h][1] = $conf->browser->layout != 'phone' ? '<i class="fas fa-exclamation-triangle pictofixedwidth"></i>' . $langs->trans('RiskAssessmentDocument') : '<i class="fas fa-exclamation-triangle"></i>';
+        $head[$h][2] = 'riskassessmentdocument';
+        $h++;
+    }
 
     $head[$h][0] = dol_buildpath('/digiriskdolibarr/admin/config/digiriskelement.php', 1);
     $head[$h][1] = $conf->browser->layout != 'phone' ? '<i class="fas fa-network-wired pictofixedwidth"></i>' . $langs->trans('Organization') : '<i class="fas fa-network-wired"></i>';
@@ -127,20 +129,26 @@ function digiriskdolibarr_admin_prepare_head(): array
     $head[$h][2] = 'ticket_kanban';
     $h++;
 
-    $head[$h][0] = dol_buildpath('/digiriskdolibarr/admin/config/preventionplan.php', 1);
-    $head[$h][1] = $conf->browser->layout != 'phone' ? '<i class="fas fa-info pictofixedwidth"></i>' . $langs->trans('PreventionPlan') : '<i class="fas fa-info"></i>';
-    $head[$h][2] = 'preventionplan';
-    $h++;
+    if (!getDolGlobalInt('DIGIRISKDOLIBARR_PREVENTIONPLAN_MENU_HIDDEN')) {
+        $head[$h][0] = dol_buildpath('/digiriskdolibarr/admin/config/preventionplan.php', 1);
+        $head[$h][1] = $conf->browser->layout != 'phone' ? '<i class="fas fa-info pictofixedwidth"></i>' . $langs->trans('PreventionPlan') : '<i class="fas fa-info"></i>';
+        $head[$h][2] = 'preventionplan';
+        $h++;
+    }
 
-    $head[$h][0] = dol_buildpath('/digiriskdolibarr/admin/config/firepermit.php', 1);
-    $head[$h][1] = $conf->browser->layout != 'phone' ? '<i class="fas fa-fire-alt pictofixedwidth"></i>' . $langs->trans('FirePermit') : '<i class="fas fa-fire-alt"></i>';
-    $head[$h][2] = 'firepermit';
-    $h++;
+    if (!getDolGlobalInt('DIGIRISKDOLIBARR_FIREPERMIT_MENU_HIDDEN')) {
+        $head[$h][0] = dol_buildpath('/digiriskdolibarr/admin/config/firepermit.php', 1);
+        $head[$h][1] = $conf->browser->layout != 'phone' ? '<i class="fas fa-fire-alt pictofixedwidth"></i>' . $langs->trans('FirePermit') : '<i class="fas fa-fire-alt"></i>';
+        $head[$h][2] = 'firepermit';
+        $h++;
+    }
 
-    $head[$h][0] = dol_buildpath('/digiriskdolibarr/admin/config/accident.php', 1);
-    $head[$h][1] = $conf->browser->layout != 'phone' ? '<i class="fas fa-user-injured pictofixedwidth"></i>' . $langs->trans('Accident') : '<i class="fas fa-user-injured"></i>';
-    $head[$h][2] = 'accident';
-    $h++;
+    if (!getDolGlobalInt('DIGIRISKDOLIBARR_ACCIDENT_MENU_HIDDEN') || !getDolGlobalInt('DIGIRISKDOLIBARR_ACCIDENTINVESTIGATION_MENU_HIDDEN')) {
+        $head[$h][0] = dol_buildpath('/digiriskdolibarr/admin/config/accident.php', 1);
+        $head[$h][1] = $conf->browser->layout != 'phone' ? '<i class="fas fa-user-injured pictofixedwidth"></i>' . $langs->trans('Accident') : '<i class="fas fa-user-injured"></i>';
+        $head[$h][2] = 'accident';
+        $h++;
+    }
 
     $head[$h][0] = dol_buildpath('/digiriskdolibarr/admin/config/meteovigilance.php', 1);
     $head[$h][1] = $conf->browser->layout != 'phone' ? '<i class="fas fa-cloud-sun-rain pictofixedwidth"></i>' . $langs->trans('MeteoVigilance') : '<i class="fas fa-cloud-sun-rain"></i>';


### PR DESCRIPTION
Closes #5072

## Ce que ça fait

Un tableau **« Visibilité des entrées de menu »** dans `Configuration → Réglages`, avec un interrupteur par objet : document unique, environnement, plan de prévention, permis de feu, accident, enquête accident, outils.

Couper un interrupteur masque les entrées de menu de l'objet (16 entrées au total, enfants compris : listes, PAPRIPACT, plans d'action, catégories) **et** son onglet d'administration.

## Choix d'implémentation

**La constante stocke l'état masqué** — `DIGIRISKDOLIBARR_<OBJET>_MENU_HIDDEN` — et l'interrupteur est inversé (`ajax_constantonoff($const, [], null, 1)`). Une constante absente vaut donc « visible » : une installation mise à jour sans réactivation garde tous ses menus, et l'interrupteur affiché est cohérent avec l'état réel dès la première visite. Aucun `update.sql` ni entrée dans `$this->const` n'est nécessaire.

**La constante de l'environnement s'appelle `DIGIRISKDOLIBARR_RISKENVIRONMENTAL_MENU_HIDDEN`.** `dol_eval()` remplace la sous-chaîne `_ENV` par `__forbiddenstring__` avant d'évaluer ; `DIGIRISKDOLIBARR_ENVIRONMENT_MENU_HIDDEN` faisait donc rejeter toute la condition et **supprimait le menu Environnement en permanence** — le bug de #4846. Le nom retenu reprend le vocabulaire du module (`risk_type=riskenvironmental`) et passe le validateur.

**Les onglets d'administration partagés ne disparaissent que si tous les objets qu'ils configurent sont masqués :** l'onglet « Document unique » porte aussi le sélecteur de projet environnement, et l'onglet « Accident » porte aussi la configuration des enquêtes accident.

## Vérifications

Harnais CLI sur l'installation locale (Dolibarr 23) :

- les 16 conditions `enabled` passées à `verifCond()` exactement comme le fait `menubase` : constante absente et constante à `0` donnent le même résultat que `develop`, constante à `1` masque l'entrée, aucune condition rejetée par le validateur de `dol_eval()` ;
- l'interrupteur rendu par `ajax_constantonoff()` : `on` quand la constante est absente, `off` quand elle vaut `1` ;
- `digiriskdolibarr_admin_prepare_head()` : chaque cas de masquage retire bien l'onglet attendu (et seulement lui), et le tableau reste indexé sans trou, ce dont dépend `complete_head_from_modules()` ;
- les clés de langue résolvent en `fr_FR` et en `en_US`.

## À savoir au déploiement

Les entrées de menu d'un module sont figées dans `llx_menu` au moment de l'activation : **la réactivation du module est nécessaire** pour que les nouvelles conditions `enabled` soient prises en compte. Tant qu'elle n'a pas eu lieu, les interrupteurs restent sans effet sur les menus (les onglets d'administration, eux, suivent immédiatement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)