### PR TITLE
#4869 [Risk] fix: div non fermée dans la modale d'ajout de risque

### DIFF
--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
@@ -807,6 +807,7 @@ $massactionbutton = $form->selectMassAction('', $arrayofmassactions);
                                 <?php print '<textarea class="evaluation-comment-textarea" name="evaluationComment' . $risk->id . '" cols="50" rows="' . ROWS_2 . '">' . ('') . '</textarea>' . "\n"; ?>
                             </div>
                         </div>
+                    </div>
                     <?php if ($conf->global->DIGIRISKDOLIBARR_TASK_MANAGEMENT) : ?>
                         <div class="riskassessment-task">
                             <div style="display: flex; align-items: center; margin-bottom: 5px;">


### PR DESCRIPTION
## Problème

La refonte IHM de la modale d'ajout de risque (`e7c3c3f0`, issue #4869) a ouvert `<div class="risk-evaluation-container standard">` sans jamais la fermer.

Avant la refonte le bloc modale était équilibré (56 balises ouvrantes / 56 fermantes), depuis il est à 58/57 — et le fichier entier à 218/217.

Le navigateur rattrape l'oubli en décalant toutes les fermetures d'un cran, ce qui donne, mesuré sur une fiche unité de travail (Dolibarr 23.0.3) :

| sélecteur | develop | attendu |
|---|---|---|
| `.risk-add-modal .risk-evaluation-header-right` | **11 éléments** | 1 |
| liste des risques incluse dans `.risk-add-modal` | **oui** | non |
| parent de `.riskassessment-task` | `.risk-evaluation-container` | `.modal-content` |

Rien ne casse visuellement aujourd'hui, mais toute la liste des risques (et ses modales d'édition par ligne) se retrouve à l'intérieur de la modale d'ajout : chaque sélecteur jQuery cadré sur `.risk-add-modal` balaie désormais la page entière, notamment `createRisk()` dans `js/modules/risk.js` qui travaille par `riskAddModal.closest('.fichecenter').find(...)`.

## Correction

Une ligne : la `</div>` manquante, à l'emplacement que l'indentation existante désignait déjà (juste avant le `<?php if (DIGIRISKDOLIBARR_TASK_MANAGEMENT) : ?>`), ce qui restitue la structure d'avant la refonte — `.riskassessment-task` redevient un frère de `.risk-evaluation-container`.

## Vérifications

- `php -l` OK, fichier de nouveau équilibré (218/218, bloc modale 63/63) ;
- structure DOM contrôlée dans Chrome avant/après : `.risk-evaluation-header-right` repasse de 11 à 1, la liste ressort de la modale, `.riskassessment-task` retrouve `.modal-content` comme parent ;
- rendu inchangé : le séparateur au-dessus de la section Tâche vient de `.wpeo-modal[class*="modal-risk"] .modal-container .riskassessment-task` (sélecteur descendant), il s'applique toujours ;
- parcours complet rejoué : catégorie de danger + cotation + description + libellé de tâche + budget → « Ajouter le risque » crée bien le risque, son évaluation et sa tâche, sans erreur JS.

Closes #4869

🤖 Generated with [Claude Code](https://claude.com/claude-code)
