### PR TITLE
#5088 [Card] Laisser Saturne traiter l'enregistrement introuvable

### DIFF
--- a/view/accident/accident_card.php
+++ b/view/accident/accident_card.php
@@ -47,7 +47,7 @@ require_once __DIR__ . '/../../lib/digiriskdolibarr_accident.lib.php';
 global $conf, $db, $hookmanager, $langs, $moduleNameLowerCase, $mysoc, $user;
 
 // Load translation files required by the page
-saturne_load_langs(['errors']);
+saturne_load_langs();
 
 // Get parameters
 $id                  = GETPOSTINT('id');
@@ -119,14 +119,6 @@ $permissiontoadd    = $user->rights->digiriskdolibarr->accident->write;
 $permissiontodelete = $user->rights->digiriskdolibarr->accident->delete;
 
 saturne_check_access($permissiontoread, $object);
-
-// Un identifiant inconnu laisse l'objet vide : la page continuerait jusqu'a passer une propriete
-// nulle a une methode typee, et s'arreterait sur une erreur fatale
-if (($id > 0 || dol_strlen($ref)) && $object->id <= 0) {
-	setEventMessages($langs->trans('ErrorRecordNotFound'), null, 'errors');
-	header('Location: ' . dol_buildpath('/digiriskdolibarr/view/accident/accident_list.php', 1));
-	exit;
-}
 
 /*
  * Actions

--- a/view/digiriskelement/digiriskelement_card.php
+++ b/view/digiriskelement/digiriskelement_card.php
@@ -49,7 +49,7 @@ require_once __DIR__ . '/../../lib/digiriskdolibarr_function.lib.php';
 global $conf, $db, $hookmanager, $langs, $user;
 
 // Load translation files required by the page
-saturne_load_langs(['errors', 'other']);
+saturne_load_langs(['other']);
 
 // Get parameters
 $id                  = GETPOSTINT('id');
@@ -91,14 +91,6 @@ $permissiontoadd    = $user->rights->digiriskdolibarr->digiriskelement->write;
 $permissiontodelete = $user->rights->digiriskdolibarr->digiriskelement->delete;
 
 saturne_check_access($permissiontoread, $object);
-
-// Un identifiant inconnu laisse l'objet vide : la page continuerait jusqu'a passer une propriete
-// nulle a une methode typee, et s'arreterait sur une erreur fatale
-if (($id > 0 || dol_strlen($ref)) && $object->id <= 0) {
-	setEventMessages($langs->trans('ErrorRecordNotFound'), null, 'errors');
-	header('Location: ' . dol_buildpath('/digiriskdolibarr/view/digiriskstandard/digiriskstandard_card.php?id=1', 1));
-	exit;
-}
 
 /*
  * Actions

--- a/view/firepermit/firepermit_card.php
+++ b/view/firepermit/firepermit_card.php
@@ -53,7 +53,7 @@ require_once __DIR__ . '/../../lib/digiriskdolibarr_firepermit.lib.php';
 global $conf, $db, $hookmanager, $langs, $user;
 
 // Load translation files required by the page
-saturne_load_langs(['errors', 'other', 'mails']);
+saturne_load_langs(['other', 'mails']);
 
 // Get parameters
 $id                  = GETPOSTINT('id');
@@ -120,14 +120,6 @@ $permissiontoadd    = $user->rights->digiriskdolibarr->firepermit->write;
 $permissiontodelete = $user->rights->digiriskdolibarr->firepermit->delete;
 
 saturne_check_access($permissiontoadd, $object);
-
-// Un identifiant inconnu laisse l'objet vide : la page continuerait jusqu'a passer une propriete
-// nulle a une methode typee, et s'arreterait sur une erreur fatale
-if (($id > 0 || dol_strlen($ref)) && $object->id <= 0) {
-	setEventMessages($langs->trans('ErrorRecordNotFound'), null, 'errors');
-	header('Location: ' . dol_buildpath('/digiriskdolibarr/view/firepermit/firepermit_list.php', 1));
-	exit;
-}
 
 /*
  * Actions

--- a/view/preventionplan/preventionplan_card.php
+++ b/view/preventionplan/preventionplan_card.php
@@ -54,7 +54,7 @@ require_once __DIR__ . '/../../lib/digiriskdolibarr_preventionplan.lib.php';
 global $conf, $db, $hookmanager, $langs, $moduleNameLowerCase, $user;
 
 // Load translation files required by the page
-saturne_load_langs(['errors', 'other', 'mails']);
+saturne_load_langs(['other', 'mails']);
 
 // Get parameters
 $id                  = GETPOSTINT('id');
@@ -127,14 +127,6 @@ $permissiontoadd    = $user->rights->digiriskdolibarr->preventionplan->write;
 $permissiontodelete = $user->rights->digiriskdolibarr->preventionplan->delete;
 
 saturne_check_access($permissiontoadd, $object);
-
-// Un identifiant inconnu laisse l'objet vide : la page continuerait jusqu'a passer une propriete
-// nulle a une methode typee, et s'arreterait sur une erreur fatale
-if (($id > 0 || dol_strlen($ref)) && $object->id <= 0) {
-	setEventMessages($langs->trans('ErrorRecordNotFound'), null, 'errors');
-	header('Location: ' . dol_buildpath('/digiriskdolibarr/view/preventionplan/preventionplan_list.php', 1));
-	exit;
-}
 
 /*
  * Actions


### PR DESCRIPTION
Suite de #5089, une fois Saturne#1565 et Saturne#1568 en place.

Le contrôle ajouté dans les quatre fiches en #5089 fait désormais double emploi : `saturne_check_access()` redirige elle-même quand l'objet qu'on lui passe a été fetché sans succès, et vise la liste du type demandé — la destination même que ce code écrivait à la main.

Les quatre fiches reviennent donc à leur état d'avant #5089, chargement du fichier de langue `errors` compris, que Saturne fait maintenant lui-même.

## Vérification

Avec le Saturne à jour, les fiches sans leur garde locale :

| Page, identifiant inconnu | Destination |
|---|---|
| `firepermit_card.php?id=999999` | `view/firepermit/firepermit_list.php` + message |
| `preventionplan_card.php?id=999999` | `view/preventionplan/preventionplan_list.php` + message |
| `accident_card.php?id=999999` | `view/accident/accident_list.php` + message |
| `digiriskelement_card.php?id=999999` | accueil DigiRisk + message |

Les fiches réelles s'ouvrent normalement (`preventionplan_card.php?id=5`, `accident_card.php?id=1`, `digiriskelement_card.php?id=1`).

## Deux points d'attention

- **Cette PR suppose la version de Saturne qui porte #1565.** Mergée avant, les quatre fiches repartiraient en erreur fatale sur un identifiant inconnu.
- Seul changement de comportement : la fiche d'un élément renvoyait à l'arborescence (`digiriskstandard_card.php?id=1`), elle renvoie maintenant à l'accueil du module, faute de `digiriskelement_list.php` à déduire. Si l'arborescence est préférable, le plus propre serait de rendre la destination surchargeable côté Saturne plutôt que de réintroduire la garde ici.

🤖 Generated with [Claude Code](https://claude.com/claude-code)