### PR TITLE
#5096 [Mod] fix: retirer les dependances de modules inutiles

### DIFF
--- a/core/modules/modDigiriskDolibarr.class.php
+++ b/core/modules/modDigiriskDolibarr.class.php
@@ -491,7 +491,8 @@ class modDigiriskdolibarr extends DolibarrModules
 		// Dependencies
 
 		$this->hidden                  = false;
-		$this->depends                 = ['modSaturne', 'modECM', 'modProjet', 'modSociete', 'modTicket', 'modCategorie', 'modFckeditor', 'modApi', 'modExport', 'modImport'];
+		// ECM, Agenda, Fckeditor et Categorie sont declares par Saturne et herites de lui
+		$this->depends                 = ['modSaturne', 'modProjet', 'modSociete', 'modTicket'];
 		$this->requiredby              = ['modDigiBoard'];
 		$this->conflictwith            = [];
 		$this->langfiles               = ["digiriskdolibarr@digiriskdolibarr"];


### PR DESCRIPTION
Closes #5096

Depend de Evarisk/Saturne#1571, a merger en premier.

## Probleme

`$this->depends` declarait 10 modules et `activateModule()` les allume en cascade (`htdocs/core/lib/admin.lib.php:1264-1284`) : avec `modTicket -> modAgenda`, cocher Digirisk allumait **11 modules**.

## Correction

```php
$this->depends = ['modSaturne', 'modProjet', 'modSociete', 'modTicket'];
```

### Dependances conservees

| Module | Pourquoi |
|---|---|
| `modSaturne` | socle |
| `modProjet` | les taches d'evaluation vivent dans `llx_projet_task`, 6 extrafields sur `projet_task`, PAPRIPACT |
| `modSociete` | `new Societe` non garde dans `firepermit.class.php`, `preventionplandocument.class.php`, `legaldisplay.class.php`, `accident.class.php` |
| `modTicket` | 8 extrafields sur `ticket`, registre, tableaux de bord, interface publique |

### Dependances desormais heritees de Saturne

`modECM`, `modFckeditor` et `modCategorie` sont declares par Saturne (Evarisk/Saturne#1571), qui y ajoute `modAgenda` : leur besoin naît dans le socle (galerie medias, champs `type => html`, tags des listes generiques, trigger et onglet Evenements), pas dans Digirisk.

### Dependances supprimees

- **`modApi`** : aucun `isModEnabled('api')` dans le module. Ne sert qu'a exposer `class/api_digiriskdolibarr.class.php`, dont l'usage est optionnel. Activer l'API REST de toute l'instance pour des utilisateurs qui ne s'en servent pas est une exposition gratuite.
- **`modExport` / `modImport`** : seuls les tableaux `export_*` / `import_*` du descripteur les concernent, et ils sont inertes quand les modules sont eteints.

## Portee

11 modules actives -> 8 (Saturne, ECM, Agenda, Fckeditor, Categorie, Projet, Societe, Ticket), et surtout plus d'API REST ni de modules Exports/Imports allumes sans l'avoir demande.

Aucun effet sur les installations existantes : Dolibarr ne desactive un module que via `requiredby`, les modules deja allumes le restent. Les tableaux `export_*` / `import_*` sont conserves, ils redeviennent utilisables des que l'utilisateur active Exports ou Imports.

## Test

- `php -l` OK.
- Activation de Digirisk sur une instance vierge : les 8 modules attendus s'allument, aucun autre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)