### PR TITLE
#5100 [DigiriskElement] Renvoyer à l'arborescence quand l'élément est introuvable

### DIFF
--- a/view/digiriskelement/digiriskelement_card.php
+++ b/view/digiriskelement/digiriskelement_card.php
@@ -90,7 +90,11 @@ $permissiontoread   = $user->rights->digiriskdolibarr->digiriskelement->read;
 $permissiontoadd    = $user->rights->digiriskdolibarr->digiriskelement->write;
 $permissiontodelete = $user->rights->digiriskdolibarr->digiriskelement->delete;
 
-saturne_check_access($permissiontoread, $object);
+// Les elements n'ont pas de liste, ils se parcourent dans l'arborescence : c'est la que renvoie
+// un element introuvable, plutot que sur l'accueil du module
+$elementTreeUrl = dol_buildpath('/digiriskdolibarr/view/digiriskstandard/digiriskstandard_card.php?id=1', 1);
+
+saturne_check_access($permissiontoread, $object, false, $elementTreeUrl);
 
 /*
  * Actions


### PR DESCRIPTION
Closes #5100

Depuis #5095, c'est `saturne_check_access()` qui traite l'enregistrement introuvable, en déduisant sa destination du nom de l'élément : `view/<element>/<element>_list.php`, puis l'accueil du module à défaut.

Les éléments — groupements et unités de travail — n'ont pas de liste dédiée : ils se parcourent dans l'arborescence. Une fiche appelée avec un identifiant inconnu retombait donc sur le tableau de bord. Saturne#1573 rend la destination surchargeable, la fiche passe désormais la sienne.

## Tests

| Page | Destination |
|---|---|
| `digiriskelement_card.php?id=999999` | `view/digiriskstandard/digiriskstandard_card.php?id=1` + « Enregistrement non trouvé » |
| `digiriskelement_card.php?id=1` | s'ouvre normalement |
| `digiriskelement_card.php?action=create&element_type=groupment&fk_parent=1` | écran de création, non intercepté |

**Cette PR suppose la version de Saturne qui porte #1573.** Mergée avant, le quatrième argument est simplement ignoré : l'élément introuvable retombe sur l'accueil, comme aujourd'hui — pas de régression, seulement l'amélioration qui n'a pas lieu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)