### PR TITLE
#5105 [Lib] fix: lire MAIN_INFO_SOCIETE_NOM via getDolGlobalString (warnings PHP 8)

### DIFF
--- a/class/accident.class.php
+++ b/class/accident.class.php
@@ -1137,7 +1137,7 @@ class Accident extends SaturneObject
                     require_once __DIR__ . '/digiriskstandard.class.php';
                     $digiriskStandard = new DigiriskStandard($this->db);
                     $digiriskStandard->fetch($this->fk_standard);
-                    $accidentLocation = $digiriskStandard->ref . " - " . $conf->global->MAIN_INFO_SOCIETE_NOM;
+                    $accidentLocation = $digiriskStandard->ref . " - " . getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
                 } else if (!empty($this->fk_element)) {
                     require_once __DIR__ . '/digiriskelement.class.php';
                     $digiriskElement  = new DigiriskElement($this->db);

--- a/class/digiriskdolibarrdocuments/riskassessmentdocument.class.php
+++ b/class/digiriskdolibarrdocuments/riskassessmentdocument.class.php
@@ -78,7 +78,7 @@ class RiskAssessmentDocument extends DigiriskDocuments
 		}
 
 		// *** JSON FILLING ***
-		$json['RiskAssessmentDocument']['nomEntreprise']  = $conf->global->MAIN_INFO_SOCIETE_NOM;
+		$json['RiskAssessmentDocument']['nomEntreprise']  = getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
 		$json['RiskAssessmentDocument']['dateAudit']      = dol_print_date($conf->global->DIGIRISKDOLIBARR_RISKASSESSMENTDOCUMENT_AUDIT_START_DATE, 'day', 'tzuser') . ' - ' . dol_print_date($conf->global->DIGIRISKDOLIBARR_RISKASSESSMENTDOCUMENT_AUDIT_END_DATE, 'day', 'tzuser');
 		$json['RiskAssessmentDocument']['emetteurDUER']   = $user->lastname . ' ' . $user->firstname;
 		$json['RiskAssessmentDocument']['dateGeneration'] = dol_print_date($now, 'dayhour', 'tzuser');

--- a/class/digiriskelement.class.php
+++ b/class/digiriskelement.class.php
@@ -369,7 +369,7 @@ class DigiriskElement extends SaturneObject
         $objectList = $this->fetchDigiriskElementFlat(0);
         $digiriskElementsData = [];
         if ($noroot == 0) {
-            $digiriskElementsData[0] = $langs->trans('Root') . ' : ' . $conf->global->MAIN_INFO_SOCIETE_NOM ;
+            $digiriskElementsData[0] = $langs->trans('Root') . ' : ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM') ;
         }
 
         if (is_array($objectList) && !empty($objectList)) {
@@ -754,7 +754,7 @@ class DigiriskElement extends SaturneObject
             $ret .= $langs->trans('ParentElement') . ' : ' .  $digiriskElement->ref . ' - ' . $digiriskElement->label . '<br/>';
         }
 
-        $ret .= $langs->trans('Standard') . ' : ' . $digiriskStandard->ref . ' - ' . $conf->global->MAIN_INFO_SOCIETE_NOM . '<br/>';
+        $ret .= $langs->trans('Standard') . ' : ' . $digiriskStandard->ref . ' - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM') . '<br/>';
         $ret .= $langs->trans('Photo') . ' : ' . (!empty($this->photo) ? $this->photo : 'N/A') . '<br>';
         $ret .= $langs->trans('ElementType') . ' : ' . $langs->trans($this->element_type) . '<br>';
         ($this->ranks != 0 ? $ret .= $langs->trans('Order') . ' : ' . $this->ranks . '<br>' : '');

--- a/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/accidentinvestigationdocument/doc_accidentinvestigationdocument_odt.modules.php
+++ b/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/accidentinvestigationdocument/doc_accidentinvestigationdocument_odt.modules.php
@@ -241,7 +241,7 @@ class doc_accidentinvestigationdocument_odt extends ModeleODTDigiriskDolibarrDoc
 			} else {
 				$element = new DigiriskStandard($this->db);
 				$element->fetch($accident->fk_standard);
-				$tmpArray['gp_ut'] = $element->ref . ' - ' . $conf->global->MAIN_INFO_SOCIETE_NOM;
+				$tmpArray['gp_ut'] = $element->ref . ' - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
 			}
 		} else if ($accident->external_accident == 2) {
 			$societe = new Societe($this->db);

--- a/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/projectdocument/pdf_papripact_a3_paysage_projectdocument.modules.php
+++ b/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/projectdocument/pdf_papripact_a3_paysage_projectdocument.modules.php
@@ -296,7 +296,7 @@ class pdf_papripact_a3_paysage_projectdocument
             }
 
             if (file_exists($dir)) {
-                $societyName = preg_replace('/\./', '_', $conf->global->MAIN_INFO_SOCIETE_NOM);
+                $societyName = preg_replace('/\./', '_', getDolGlobalString('MAIN_INFO_SOCIETE_NOM'));
 
                 $date       = dol_print_date(dol_now(), 'dayxcard');
                 $newFileTmp = $date . (dol_strlen($object->ref) > 0 ? '_' . $object->ref : '') . '_' . $objectDocumentRef . '_' .  $societyName;
@@ -876,7 +876,7 @@ class pdf_papripact_a3_paysage_projectdocument
 		$pdf->SetXY($this->marge_gauche, $posy);
 
         // PAPRIPACT title
-        $pdf->Cell(0, 10, 'PAPRIPACT - ' . $conf->global->MAIN_INFO_SOCIETE_NOM . ' ' . dol_print_date($object->date_start, 'day', false, $outputLangs, true) . ' - ' . dol_print_date($object->date_end, 'day', false, $outputLangs, true), 0, 1, 'C');
+        $pdf->Cell(0, 10, 'PAPRIPACT - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM') . ' ' . dol_print_date($object->date_start, 'day', false, $outputLangs, true) . ' - ' . dol_print_date($object->date_end, 'day', false, $outputLangs, true), 0, 1, 'C');
         $pdf->Cell(0, 10, $langs->transnoentities('PapripactFullName'), 0, 1, 'C');
 		// Logo
 		$logo = $conf->mycompany->dir_output.'/logos/'.$mysoc->logo;

--- a/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/registerdocument/doc_registerdocument_odt.modules.php
+++ b/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/registerdocument/doc_registerdocument_odt.modules.php
@@ -295,7 +295,7 @@ class doc_registerdocument_odt extends SaturneDocumentModel
                                 $tmpArray['register_controller_id'] = $ticketController->id;
                                 $tmpArray['register_controller_lastname'] = $ticketController->lastname;
                                 $tmpArray['register_controller_firstname'] = $ticketController->firstname;
-                                $tmpArray['register_controller_society'] = $conf->global->MAIN_INFO_SOCIETE_NOM;
+                                $tmpArray['register_controller_society'] = getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
                                 $tmpArray['register_controller_date'] = dol_print_date($ticketControl->control_date);
                                 $encodedImage = explode(',', $ticketController->signature)[1];
                                 $decodedImage = base64_decode($encodedImage);

--- a/core/modules/modDigiriskDolibarr.class.php
+++ b/core/modules/modDigiriskDolibarr.class.php
@@ -2347,25 +2347,25 @@ class modDigiriskdolibarr extends DolibarrModules
         $resources = new DigiriskResources($this->db);
 
         if (getDolGlobalInt('DIGIRISKDOLIBARR_THIRDPARTY_SET') == 0) {
-            $societe->name   = $langs->trans('SAMU') . ' - ' . $conf->global->MAIN_INFO_SOCIETE_NOM;
+            $societe->name   = $langs->trans('SAMU') . ' - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
             $societe->client = 0;
             $societe->phone  = '15';
             $societe->url    = '';
             $samuID          = $societe->create($user);
 
-            $societe->name   = $langs->trans('Pompiers') . ' - ' . $conf->global->MAIN_INFO_SOCIETE_NOM;
+            $societe->name   = $langs->trans('Pompiers') . ' - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
             $societe->client = 0;
             $societe->phone  = '18';
             $societe->url    = '';
             $pompiersID      = $societe->create($user);
 
-            $societe->name   = $langs->trans('Police') . ' - ' . $conf->global->MAIN_INFO_SOCIETE_NOM;
+            $societe->name   = $langs->trans('Police') . ' - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
             $societe->client = 0;
             $societe->phone  = '17';
             $societe->url    = '';
             $policeID        = $societe->create($user);
 
-            $societe->name   = $langs->trans('AllEmergencies') . ' - ' . $conf->global->MAIN_INFO_SOCIETE_NOM;
+            $societe->name   = $langs->trans('AllEmergencies') . ' - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
             $societe->client = 0;
             $societe->phone  = '112';
             $societe->url    = '';
@@ -2380,19 +2380,19 @@ class modDigiriskdolibarr extends DolibarrModules
         }
         if (getDolGlobalInt('DIGIRISKDOLIBARR_THIRDPARTY_SET') == 1) {
             //Install after 8.1.2
-            $societe->name     = $langs->trans('LabourInspectorName') . ' - ' . $conf->global->MAIN_INFO_SOCIETE_NOM;
+            $societe->name     = $langs->trans('LabourInspectorName') . ' - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
             $societe->client   = 0;
             $societe->phone    = '';
             $societe->url      = $langs->trans('UrlLabourInspector');
             $labourInspectorID = $societe->create($user);
 
-            $societe->name    = $langs->trans('RightsDefender') . ' - ' . $conf->global->MAIN_INFO_SOCIETE_NOM;
+            $societe->name    = $langs->trans('RightsDefender') . ' - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
             $societe->client  = 0;
             $societe->phone   = '';
             $societe->url     = '';
             $rightsDefenderID = $societe->create($user);
 
-            $societe->name         = $langs->trans('PoisonControlCenter') . ' - ' . $conf->global->MAIN_INFO_SOCIETE_NOM;
+            $societe->name         = $langs->trans('PoisonControlCenter') . ' - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
             $societe->client       = 0;
             $societe->phone        = '';
             $societe->url          = '';
@@ -2405,7 +2405,7 @@ class modDigiriskdolibarr extends DolibarrModules
             dolibarr_set_const($this->db, 'DIGIRISKDOLIBARR_THIRDPARTY_SET', 2, 'integer', 0, '', $conf->entity);
         }
         if (getDolGlobalInt('DIGIRISKDOLIBARR_THIRDPARTY_SET') == 2) {
-            $societe->name   = $langs->trans('LabourDoctorName') . ' - ' . $conf->global->MAIN_INFO_SOCIETE_NOM;
+            $societe->name   = $langs->trans('LabourDoctorName') . ' - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
             $societe->client = 0;
             $societe->phone  = '';
             $societe->url    = '';
@@ -2428,7 +2428,7 @@ class modDigiriskdolibarr extends DolibarrModules
             ];
 
             foreach ($poisonCenters as $city => $poisonCenter) {
-                $societe->name         = $langs->trans('PoisonControlCenter') . ' ' . $city . ' - ' . $conf->global->MAIN_INFO_SOCIETE_NOM;
+                $societe->name         = $langs->trans('PoisonControlCenter') . ' ' . $city . ' - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
                 $societe->client       = 0;
                 $societe->phone        = $poisonCenter['phone'];
                 $societe->url          = '';
@@ -2470,37 +2470,37 @@ class modDigiriskdolibarr extends DolibarrModules
         if (getDolGlobalInt('DIGIRISKDOLIBARR_THIRDPARTY_UPDATED') == 0) {
             $labourInspectorID = $resources->fetchDigiriskResource('LabourInspectorSociety');
             $societe->fetch($labourInspectorID);
-            $societe->name = $langs->trans('LabourInspectorName') . ' - ' . $conf->global->MAIN_INFO_SOCIETE_NOM;
+            $societe->name = $langs->trans('LabourInspectorName') . ' - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
             $societe->update(0, $user);
 
             $policeID = $resources->fetchDigiriskResource('Police');
             $societe->fetch($policeID);
-            $societe->name = $langs->trans('Police') . ' - ' . $conf->global->MAIN_INFO_SOCIETE_NOM;
+            $societe->name = $langs->trans('Police') . ' - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
             $societe->update(0, $user);
 
             $samuID = $resources->fetchDigiriskResource('SAMU');
             $societe->fetch($samuID);
-            $societe->name = $langs->trans('SAMU') . ' - ' . $conf->global->MAIN_INFO_SOCIETE_NOM;
+            $societe->name = $langs->trans('SAMU') . ' - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
             $societe->update(0, $user);
 
             $pompiersID = $resources->fetchDigiriskResource('Pompiers');
             $societe->fetch($pompiersID);
-            $societe->name = $langs->trans('Pompiers') . ' - ' . $conf->global->MAIN_INFO_SOCIETE_NOM;
+            $societe->name = $langs->trans('Pompiers') . ' - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
             $societe->update(0, $user);
 
             $emergencyID = $resources->fetchDigiriskResource('AllEmergencies');
             $societe->fetch($emergencyID);
-            $societe->name = $langs->trans('AllEmergencies') . ' - ' . $conf->global->MAIN_INFO_SOCIETE_NOM;
+            $societe->name = $langs->trans('AllEmergencies') . ' - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
             $societe->update(0, $user);
 
             $rightsDefenderID = $resources->fetchDigiriskResource('RightsDefender');
             $societe->fetch($rightsDefenderID);
-            $societe->name = $langs->transnoentities('RightsDefender') . ' - ' . $conf->global->MAIN_INFO_SOCIETE_NOM;
+            $societe->name = $langs->transnoentities('RightsDefender') . ' - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
             $societe->update(0, $user);
 
             $poisonControlCenterID = $resources->fetchDigiriskResource('PoisonControlCenter');
             $societe->fetch($poisonControlCenterID);
-            $societe->name = $langs->trans('PoisonControlCenter') . ' - ' . $conf->global->MAIN_INFO_SOCIETE_NOM;
+            $societe->name = $langs->trans('PoisonControlCenter') . ' - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
             $societe->update(0, $user);
 
             dolibarr_set_const($this->db, 'DIGIRISKDOLIBARR_THIRDPARTY_UPDATED', 1, 'integer', 0, '', $conf->entity);

--- a/core/tpl/digiriskdolibarr_projectcreation_action.tpl.php
+++ b/core/tpl/digiriskdolibarr_projectcreation_action.tpl.php
@@ -126,7 +126,7 @@ if ($conf->global->DIGIRISKDOLIBARR_DU_PROJECT > 0 && empty($conf->global->DIGIR
 	$project->fetch($conf->global->DIGIRISKDOLIBARR_DU_PROJECT);
 	//Backward compatibility
 	if ($project->title == $langs->trans('RiskAssessmentDocument')) {
-		$project->title       = $langs->trans('RiskAssessmentDocument') . ' - ' . $conf->global->MAIN_INFO_SOCIETE_NOM;
+		$project->title       = $langs->trans('RiskAssessmentDocument') . ' - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
 		$project->description = $langs->trans('RiskAssessmentDocumentDescription');
 		$project->update($user);
 	}
@@ -140,7 +140,7 @@ if ($conf->global->DIGIRISKDOLIBARR_DU_PROJECT > 0 && empty($conf->global->DIGIR
 
 if ( $conf->global->DIGIRISKDOLIBARR_DU_PROJECT == 0 || $project->statut == 2 ) {
 	$project->ref         = $projectRef->getNextValue($third_party, $project);
-	$project->title       = $langs->trans('RiskAssessmentDocument') . ' - ' . $conf->global->MAIN_INFO_SOCIETE_NOM;
+	$project->title       = $langs->trans('RiskAssessmentDocument') . ' - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
 	$project->description = $langs->trans('RiskAssessmentDocumentDescription');
 	$project->date_c      = dol_now();
 	$currentYear          = dol_print_date(dol_now(), '%Y');
@@ -182,7 +182,7 @@ if ($conf->global->DIGIRISKDOLIBARR_PREVENTIONPLAN_PROJECT > 0 && empty($conf->g
 	$project->fetch($conf->global->DIGIRISKDOLIBARR_PREVENTIONPLAN_PROJECT);
 	//Backward compatibility
 	if ($project->title == $langs->trans('PreventionPlan')) {
-		$project->title = $langs->trans('PreventionPlan') . ' - ' . $conf->global->MAIN_INFO_SOCIETE_NOM;
+		$project->title = $langs->trans('PreventionPlan') . ' - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
 		$project->update($user);
 	}
 
@@ -196,7 +196,7 @@ if ($conf->global->DIGIRISKDOLIBARR_PREVENTIONPLAN_PROJECT > 0 && empty($conf->g
 
 if ( $conf->global->DIGIRISKDOLIBARR_PREVENTIONPLAN_PROJECT == 0 || $project->statut == 2 ) {
 	$project->ref         = $projectRef->getNextValue($third_party, $project);
-	$project->title       = $langs->trans('PreventionPlan') . ' - ' . $conf->global->MAIN_INFO_SOCIETE_NOM;
+	$project->title       = $langs->trans('PreventionPlan') . ' - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
 	$project->description = $langs->transnoentities('PreventionPlanDescription');
 	$project->date_c      = dol_now();
 	$currentYear          = dol_print_date(dol_now(), '%Y');
@@ -222,7 +222,7 @@ if ( $conf->global->DIGIRISKDOLIBARR_PREVENTIONPLAN_PROJECT == 0 || $project->st
 
 if ( $conf->global->DIGIRISKDOLIBARR_FIREPERMIT_PROJECT == 0 || $project->statut == 2 ) {
 	$project->ref         = $projectRef->getNextValue($third_party, $project);
-	$project->title       = $langs->trans('FirePermit') . ' - ' . $conf->global->MAIN_INFO_SOCIETE_NOM;
+	$project->title       = $langs->trans('FirePermit') . ' - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
 	$project->description = $langs->trans('FirePermitDescription');
 	$project->date_c      = dol_now();
 	$currentYear          = dol_print_date(dol_now(), '%Y');
@@ -248,7 +248,7 @@ if ( $conf->global->DIGIRISKDOLIBARR_FIREPERMIT_PROJECT == 0 || $project->statut
 
 if ( $conf->global->DIGIRISKDOLIBARR_ACCIDENT_PROJECT == 0 || $project->statut == 2 ) {
 	$project->ref         = $projectRef->getNextValue($third_party, $project);
-	$project->title       = $langs->trans('Accident') . ' - ' . $conf->global->MAIN_INFO_SOCIETE_NOM;
+	$project->title       = $langs->trans('Accident') . ' - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
 	$project->description = $langs->trans('AccidentDescription');
 	$project->date_c      = dol_now();
 	$currentYear          = dol_print_date(dol_now(), '%Y');
@@ -274,7 +274,7 @@ if ( $conf->global->DIGIRISKDOLIBARR_ACCIDENT_PROJECT == 0 || $project->statut =
 
 if ( $conf->global->DIGIRISKDOLIBARR_TICKET_PROJECT == 0 || $project->statut == 2 ) {
 	$project->ref         = $projectRef->getNextValue($third_party, $project);
-	$project->title       = $langs->trans('Ticket') . ' - ' . $conf->global->MAIN_INFO_SOCIETE_NOM;
+	$project->title       = $langs->trans('Ticket') . ' - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
 	$project->description = $langs->trans('TicketDescription');
 	$project->date_c      = dol_now();
 	$currentYear          = dol_print_date(dol_now(), '%Y');
@@ -300,7 +300,7 @@ if ( $conf->global->DIGIRISKDOLIBARR_TICKET_PROJECT == 0 || $project->statut == 
 
 if ( $conf->global->DIGIRISKDOLIBARR_ENVIRONMENT_PROJECT == 0 || $project->statut == 2 ) {
     $project->ref         = $projectRef->getNextValue($third_party, $project);
-    $project->title       = $langs->trans('Environment') . ' - ' . $conf->global->MAIN_INFO_SOCIETE_NOM;
+    $project->title       = $langs->trans('Environment') . ' - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
     $project->description = $langs->trans('EnvironmentDescription');
     $project->date_c      = dol_now();
     $currentYear          = dol_print_date(dol_now(), '%Y');
@@ -362,7 +362,7 @@ if (!dolibarr_get_const($db, 'DIGIRISKDOLIBARR_USERAPI_SET', 0)) {
 
 if (getDolGlobalInt('DIGIRISKDOLIBARR_READERGROUP_SET') == 0) {
     $userGroup->entity = $conf->entity;
-    $userGroup->name   = $conf->global->MAIN_INFO_SOCIETE_NOM . ' - ' . $langs->trans('DigiriskReaderGroup');
+    $userGroup->name   = getDolGlobalString('MAIN_INFO_SOCIETE_NOM') . ' - ' . $langs->trans('DigiriskReaderGroup');
     $userGroup->note   = $langs->trans('DigiriskReaderGroupDescription');
 
     $userGroupID = $userGroup->create($user);
@@ -415,7 +415,7 @@ if (getDolGlobalInt('DIGIRISKDOLIBARR_READERGROUP_UPDATED') >= 0 && getDolGlobal
                 $readerGroupConf = 4;
                 break;
             case 1 :
-                $userGroup->name = $conf->global->MAIN_INFO_SOCIETE_NOM . ' - ' . $langs->trans('DigiriskReaderGroup');
+                $userGroup->name = getDolGlobalString('MAIN_INFO_SOCIETE_NOM') . ' - ' . $langs->trans('DigiriskReaderGroup');
                 $userGroup->note = $langs->trans('DigiriskReaderGroupDescription');
                 $userGroup->update($user);
 
@@ -428,7 +428,7 @@ if (getDolGlobalInt('DIGIRISKDOLIBARR_READERGROUP_UPDATED') >= 0 && getDolGlobal
 
 if (getDolGlobalInt('DIGIRISKDOLIBARR_USERGROUP_SET') == 0) {
     $userGroup->entity = $conf->entity;
-    $userGroup->name   = $conf->global->MAIN_INFO_SOCIETE_NOM . ' - ' . $langs->trans('DigiriskUserGroup');
+    $userGroup->name   = getDolGlobalString('MAIN_INFO_SOCIETE_NOM') . ' - ' . $langs->trans('DigiriskUserGroup');
     $userGroup->note   = $langs->trans('DigiriskUserGroupDescription');
 
     $userGroupID = $userGroup->create($user);
@@ -507,7 +507,7 @@ if (getDolGlobalInt('DIGIRISKDOLIBARR_USERGROUP_UPDATED') >= 0 && getDolGlobalIn
                 $userGroupConf = 5;
                 break;
             case 1 :
-                $userGroup->name = $conf->global->MAIN_INFO_SOCIETE_NOM . ' - ' . $langs->trans('DigiriskUserGroup');
+                $userGroup->name = getDolGlobalString('MAIN_INFO_SOCIETE_NOM') . ' - ' . $langs->trans('DigiriskUserGroup');
                 $userGroup->note = $langs->trans('DigiriskUserGroupDescription');
                 $userGroup->update($user);
 
@@ -520,7 +520,7 @@ if (getDolGlobalInt('DIGIRISKDOLIBARR_USERGROUP_UPDATED') >= 0 && getDolGlobalIn
 
 if (getDolGlobalInt('DIGIRISKDOLIBARR_ADMINUSERGROUP_SET') == 0) {
     $userGroup->entity = $conf->entity;
-    $userGroup->name   = $conf->global->MAIN_INFO_SOCIETE_NOM . ' - ' . $langs->trans('DigiriskAdminUserGroup');
+    $userGroup->name   = getDolGlobalString('MAIN_INFO_SOCIETE_NOM') . ' - ' . $langs->trans('DigiriskAdminUserGroup');
     $userGroup->note   = $langs->trans('DigiriskAdminUserGroupDescription');
 
     $userGroupID = $userGroup->create($user);
@@ -543,7 +543,7 @@ if (getDolGlobalInt('DIGIRISKDOLIBARR_ADMINUSERGROUP_UPDATED') >= 0 && getDolGlo
                 $adminUserGroupConf = 6;
                 break;
             case 1:
-                $userGroup->name = $conf->global->MAIN_INFO_SOCIETE_NOM . ' - ' . $langs->trans('DigiriskAdminUserGroup');
+                $userGroup->name = getDolGlobalString('MAIN_INFO_SOCIETE_NOM') . ' - ' . $langs->trans('DigiriskAdminUserGroup');
                 $userGroup->note = $langs->trans('DigiriskAdminUserGroupDescription');
                 $userGroup->update($user);
 
@@ -911,7 +911,7 @@ if ($conf->global->DIGIRISKDOLIBARR_ENCODE_BACKWARD_COMPATIBILITY == 0) {
 	$resources = new DigiriskResources($db);
 	$rights_defenderID = $resources->fetchDigiriskResource('RightsDefender');
 	$societe->fetch($rights_defenderID);
-	$societe->name = $langs->transnoentities('RightsDefender') . ' - ' . $conf->global->MAIN_INFO_SOCIETE_NOM;
+	$societe->name = $langs->transnoentities('RightsDefender') . ' - ' . getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
 	$societe->update(0, $user);
 
 	require_once DOL_DOCUMENT_ROOT . '/user/class/usergroup.class.php';

--- a/core/triggers/interface_99_modDigiriskdolibarr_DigiriskdolibarrTriggers.class.php
+++ b/core/triggers/interface_99_modDigiriskdolibarr_DigiriskdolibarrTriggers.class.php
@@ -467,7 +467,7 @@ class InterfaceDigiriskdolibarrTriggers extends DolibarrTriggers
 					$substitutionarray = getCommonSubstitutionArray($langs, 0, null,$object);
 
 					$message = $langs->trans('Hello') . ',' . '<br><br>';
-					$message .= '<span style="color:#c55a11">' . $langs->trans('ANewTicketHasBeenSubmitted', $conf->global->MAIN_INFO_SOCIETE_NOM) . '.' . '</span><br><br>';
+					$message .= '<span style="color:#c55a11">' . $langs->trans('ANewTicketHasBeenSubmitted', getDolGlobalString('MAIN_INFO_SOCIETE_NOM')) . '.' . '</span><br><br>';
 					$message .= '<strong>' . $langs->trans('Service') . ' : ' . '</strong>';
 					$digiriskelement->fetch((int)$object->array_options['options_digiriskdolibarr_ticket_service']);
 					$message .= $digiriskelement->ref . ' - ' . $digiriskelement->label . '<br><br>';

--- a/lib/digiriskdolibarr_function.lib.php
+++ b/lib/digiriskdolibarr_function.lib.php
@@ -175,7 +175,7 @@ function digirisk_header($title = '', $helpUrl = '', $arrayofjs = [], $arrayofcs
 						<div class="society-header">
 							<a class="linkElement" href="<?php echo dol_buildpath('/custom/digiriskdolibarr/view/digiriskstandard/digiriskstandard_card.php?id=' . $conf->global->DIGIRISKDOLIBARR_ACTIVE_STANDARD, 1);?>">
 								<span class="icon fas fa-building fa-fw"></span>
-								<div class="title"><?php echo $conf->global->MAIN_INFO_SOCIETE_NOM ?></div>
+								<div class="title"><?php echo getDolGlobalString('MAIN_INFO_SOCIETE_NOM') ?></div>
 							</a>
                             <?php if ($user->rights->digiriskdolibarr->digiriskelement->write) : ?>
                                 <div class="add-container">

--- a/lib/digiriskdolibarr_preventionplan.lib.php
+++ b/lib/digiriskdolibarr_preventionplan.lib.php
@@ -283,7 +283,7 @@ function digiriskSendPreventionPlanSignatureEmail(DoliDB $db, PreventionPlan $pl
             $userFullName = $user->getFullName($langs);
             $userEmail = $user->email;
             $userPhonePro = $user->office_phone;
-            $myCompanyName = $conf->global->MAIN_INFO_SOCIETE_NOM;
+            $myCompanyName = getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
             $myCompanyFullAddress = trim($conf->global->MAIN_INFO_SOCIETE_ADDRESS . ' ' . $conf->global->MAIN_INFO_SOCIETE_ZIP . ' ' . $conf->global->MAIN_INFO_SOCIETE_TOWN);
 
             $subject = str_replace(

--- a/view/digiriskelement/digiriskelement_card.php
+++ b/view/digiriskelement/digiriskelement_card.php
@@ -359,7 +359,7 @@ if (($id || $ref) && $action == 'edit') {
 }
 
 if ( ! $object->id) {
-	$object->ref    = $conf->global->MAIN_INFO_SOCIETE_NOM;
+	$object->ref    = getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
 	$object->label  = $langs->trans('Society');
 	$object->entity = $conf->entity;
 	unset($object->fields['element_type']);

--- a/view/digiriskelement/digiriskelement_organization.php
+++ b/view/digiriskelement/digiriskelement_organization.php
@@ -127,7 +127,7 @@ if (!empty($results)) :
 ?>
     <div class="organization-page organization-tree">
         <div class="organization-header">
-            <h3 class='title' id='title0'><?php echo $conf->global->MAIN_INFO_SOCIETE_NOM ?></h3>
+            <h3 class='title' id='title0'><?php echo getDolGlobalString('MAIN_INFO_SOCIETE_NOM') ?></h3>
             <span class="unsaved-indicator"><i class="fas fa-exclamation-circle"></i> <?php echo $langs->trans('UnsavedChanges') ?></span>
         </div>
 

--- a/view/digiriskusers.php
+++ b/view/digiriskusers.php
@@ -806,7 +806,7 @@ if ($permissiontoadd) {
 						<div class="wpeo-table table-flex table-risk">
 							<div class="table-row user-row edit">
 								<input type="hidden" name="action" value="add" />
-								<input type="hidden" class="input-domain-mail" name="societyname" value="<?php echo preg_replace('/ /', '', $conf->global->MAIN_INFO_SOCIETE_NOM) . '.fr' ?>" />
+								<input type="hidden" class="input-domain-mail" name="societyname" value="<?php echo preg_replace('/ /', '', getDolGlobalString('MAIN_INFO_SOCIETE_NOM')) . '.fr' ?>" />
 								<div class="table-cell table-150">
 									<input type="text" id="lastname" placeholder="<?php echo $langs->trans('LastName'); ?>" name="lastname" value="<?php echo dol_escape_htmltag(GETPOST('lastname')); ?>" />
 								</div>


### PR DESCRIPTION
Closes #5105

## Probleme

L'activation de Digirisk sur une entite neuve ecrit des warnings PHP 8 dans le log :

```
PHP Warning:  Undefined property: stdClass::$MAIN_INFO_SOCIETE_NOM
  in core/modules/modDigiriskDolibarr.class.php on line 2431 (puis 2473, 2478)
```

La creation des ressources par defaut (SAMU, pompiers, police, inspection et medecine du travail, centres antipoison…) compose le nom du tiers avec `$conf->global->MAIN_INFO_SOCIETE_NOM`. Sur une entite fraiche la constante n'existe pas encore : warning PHP 8, et le nom du tiers se termine par un ` - ` orphelin.

## Correction

Les 45 lectures directes deviennent `getDolGlobalString('MAIN_INFO_SOCIETE_NOM')`, accesseur qui renvoie une chaine vide au lieu de declencher un warning, et que le module utilisait deja a 5 endroits.

| Fichier | Occurrences |
|---|---|
| `core/modules/modDigiriskDolibarr.class.php` | 16 |
| `core/tpl/digiriskdolibarr_projectcreation_action.tpl.php` | 15 |
| `class/digiriskelement.class.php`, `pdf_papripact_a3_paysage_projectdocument.modules.php` | 2 chacun |
| 10 autres fichiers (documents ODT, trigger, libs, vues) | 1 chacun |

Les deux fichiers les plus touches sont le descripteur et le TPL de creation initiale, c'est-a-dire le chemin d'installation, la ou la constante a le plus de chances d'etre encore vide.

## Portee du remplacement

Aucune des 45 occurrences n'etait dans un `isset()`, un `empty()` ni une interpolation de chaine : toutes sont des concatenations, le remplacement est mecanique et ne change pas le comportement quand la constante est renseignee.

## Test

- `php -l` sur les 14 fichiers modifies : aucun probleme.
- Repere lors du test d'activation sur une entite multi-societe neuve (#5096) ; le meme scenario ne doit plus rien ecrire dans `php_error.log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)