### PR TITLE
#1912 [SCSS] fix: risksign picker takes the full modal width

### DIFF
--- a/core/tpl/riskanalysis/risksign/digiriskdolibarr_inheritedrisksignlist_view.tpl.php
+++ b/core/tpl/riskanalysis/risksign/digiriskdolibarr_inheritedrisksignlist_view.tpl.php
@@ -181,7 +181,7 @@ foreach ($risksign->fields as $key => $val) {
 		elseif (strpos($val['type'] ?? '', 'integer:') === 0) {
 			print $risksign->showInputField($val, $key, $search[$key], '', '', 'search_', 'maxwidth150', 1);
 		} elseif ($key == 'fk_element') {
-			print $digiriskelement->selectDigiriskElementList($search['fk_element'], 'search_fk_element', [], 1, 0, array(), 0, 0, 'minwidth100 maxwidth300', 0, false, 1);
+			print $digiriskelement->selectDigiriskElementList($search['fk_element'] ?? '', 'search_fk_element', [], 1, 0, array(), 0, 0, 'minwidth100 maxwidth300', 0, false, 1);
 		} elseif ($key == 'category') { ?>
 			<div class="wpeo-dropdown dropdown-large dropdown-grid category-danger padding">
 				<input class="input-hidden-danger" type="hidden" name="<?php echo 'search_' . $key ?>" value="<?php echo dol_escape_htmltag($search[$key] ?? '') ?>" />

--- a/css/scss/modal/_risksign.scss
+++ b/css/scss/modal/_risksign.scss
@@ -24,12 +24,37 @@
 
 .wpeo-modal[class*="modal-risksign"] .modal-container .risksign-content {
   display: flex;
+  // Ancre de la liste de pictogrammes : le panneau se cale sur la largeur du bloc plutot
+  // que sur celle du bouton qui l'ouvre.
+  position: relative;
   padding-bottom: 1em;
   margin-bottom: 1em;
   border-bottom: 1px solid rgba(0,0,0,0.2);
 
   .risksign-category {
     margin-right: 1.5em;
+
+    .wpeo-dropdown {
+      position: static;
+    }
+    // La grille prend toute la largeur de la modale au lieu des 360px du dropdown, et se
+    // borne en hauteur pour ne pas deborder sous le pied de la modale.
+    .saturne-dropdown-content {
+      top: 100%;
+      left: 0;
+      right: 0;
+      width: auto;
+      max-height: 300px;
+      overflow-y: auto;
+      grid-template-columns: repeat(auto-fill, minmax(64px, 1fr));
+      grid-gap: 0.3em;
+
+      // Le padding du dropdown mangeait un quart de la cellule : l'espacement passe par la
+      // gouttiere de la grille, le pictogramme occupe toute sa case.
+      .dropdown-item {
+        padding: 0;
+      }
+    }
   }
   .risksign-description {
     flex-grow: 1;


### PR DESCRIPTION
## Changements

La grille de pictogrammes de la modale d'ajout / edition d'une signalisation ne prenait que les 360 px du dropdown, dans une modale de 860 px, et debordait sous le pied de la modale.

- `.risksign-content` devient l'ancre de positionnement (`position: relative`) et le `.wpeo-dropdown` passe en `position: static` : le panneau se cale sur la largeur du bloc (804 px) au lieu de celle du bouton qui l'ouvre.
- Grille en `repeat(auto-fill, minmax(64px, 1fr))` : 11 colonnes au lieu de 5, et `max-height` pour rester dans la modale.
- `padding: 0` sur les `.dropdown-item` : le padding du dropdown mangeait 8,4 px de chaque cote de la case, le pictogramme fait maintenant 69 px et remplit la sienne.

Correction sans rapport avec l'IHM, faite au passage sur la meme page : `$search['fk_element']` etait lu sans garde alors que `$search` n'est alimente que pour les filtres reellement postes, d'ou un `Warning: Undefined array key "fk_element"` affiche en haut de la liste des signalisations heritees tant qu'aucun filtre sur l'element parent n'avait ete pose.

Verifie sur l'ecran reel (modale d'ajout et modale d'edition) : selection d'un picto, remontee dans le bouton, activation du bouton de validation, et disparition du warning.

Le `.min.css` n'est pas commite : le workflow build-assets le regenere au merge.

## Fichiers modifies

- `css/scss/modal/_risksign.scss`
- `core/tpl/riskanalysis/risksign/digiriskdolibarr_inheritedrisksignlist_view.tpl.php`

## Issue

Close #1912
