### PR TITLE
#1867 [Risk] feat: carte de lecture complète du risque

### DIFF
--- a/class/riskanalysis/risk.class.php
+++ b/class/riskanalysis/risk.class.php
@@ -1592,7 +1592,7 @@ class Risk extends SaturneObject
         $label .= '<br><b>' . $langs->trans('Ref') . ' : </b> ' . $this->ref;
         $label .= '<br><b>' . $langs->transnoentities('Description') . ' : </b> ' . $this->description;
 
-        $url = dol_buildpath('/' . $this->module . '/view/digiriskelement/digiriskelement_risk.php', 1) . '?id=' . $this->fk_element;
+        $url = dol_buildpath('/' . $this->module . '/view/risk/risk_card.php', 1) . '?id=' . $this->id;
 
         if ($option != 'nolink') {
             // Add param to save lastsearch_values or not

--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_inheritedrisklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_inheritedrisklist_view.tpl.php
@@ -479,7 +479,7 @@
 					</div>
 					<?php
 				} elseif ($key == 'ref') {
-					print $risk->getNomUrl(1, 'nolink');
+					print $risk->getNomUrl(1);
 				} elseif ($key == 'description') {
 					if ($conf->global->DIGIRISKDOLIBARR_RISK_DESCRIPTION == 0 ) {
 						print $langs->trans('RiskDescriptionNotActivated');

--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_riskcard_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_riskcard_view.tpl.php
@@ -1,0 +1,269 @@
+<?php
+/* Copyright (C) 2021-2026 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    core/tpl/riskanalysis/risk/digiriskdolibarr_riskcard_view.tpl.php
+ * \ingroup digiriskdolibarr
+ * \brief   Read view of the risk card
+ *
+ * Expects the risk card controller to have loaded $object, $digiriskElement, $riskAssessment,
+ * $riskAssessments, $lastRiskAssessment, $relatedTasks and $usersList.
+ */
+
+global $conf, $db, $form, $hookmanager, $langs, $user;
+
+// The standard method stores the lower bound of the range the risk falls in, the advanced one the computed cotation
+$defaultCotation = [0 => '0-47', 48 => '48-50', 51 => '51-80', 100 => '81-100'];
+$cotations       = $object->getCotations();
+$riskType        = $object->type;
+
+// Object card
+// ------------------------------------------------------------
+saturne_get_fiche_head($object, 'card', $title);
+
+$backToList = '<a href="' . dol_buildpath('/digiriskdolibarr/view/digiriskelement/risk_list.php', 1) . '?restore_lastsearch_values=1&risk_type=' . $riskType . '">' . $langs->trans('BackToList') . '</a>';
+
+// A risk is named by its ref only, the danger category is what tells what it is about
+$dangerCategoryThumbnail = $object->getDangerCategory($object, $riskType);
+
+$moreHtmlRef = '<span class="risk-card-danger-category">';
+if ($dangerCategoryThumbnail != -1) {
+    $moreHtmlRef .= '<img class="risk-card-danger-category-pic" src="' . DOL_URL_ROOT . '/custom/digiriskdolibarr/img/categorieDangers/' . $dangerCategoryThumbnail . '.png" alt="">';
+}
+$moreHtmlRef .= '<span class="risk-card-danger-category-name">' . $object->getDangerCategoryName($object, $riskType) . '</span>';
+$moreHtmlRef .= '</span>';
+
+saturne_banner_tab($object, 'id', $backToList, 1, 'rowid', 'ref', $moreHtmlRef);
+
+print '<div class="fichecenter risk-card">';
+
+// Left column: what the risk is
+print '<div class="fichehalfleft">';
+print '<table class="border centpercent tableforfield">';
+
+// Sub category, only the danger categories declaring one have it filled
+$subCategoryLabel = $object->getDangerSubCategoryName($object->category, $object->sub_category);
+if ($subCategoryLabel != -1) {
+    print '<tr><td class="titlefield">' . $langs->trans('SubCategory') . '</td><td>' . $langs->trans($subCategoryLabel) . '</td></tr>';
+}
+
+// Parent element, read as the whole branch it hangs from so the risk is placed in the organisation
+print '<tr><td class="titlefield">' . $langs->trans('ParentElement') . '</td><td>';
+if ($digiriskElement->id > 0) {
+    $branchIds = array_reverse($digiriskElement->getBranch($digiriskElement->id));
+    $parentElement = new DigiriskElement($db);
+    foreach ($branchIds as $branchKey => $branchId) {
+        if ($parentElement->fetch($branchId) > 0) {
+            print str_repeat('&#160;', $branchKey * 2) . ($branchKey > 0 ? '&#x21B3; ' : '') . $parentElement->getNomUrl(1, 'blank', 0, '', -1, 1) . '<br>';
+        }
+    }
+} else {
+    print '<span class="opacitymedium">' . $langs->trans('None') . '</span>';
+}
+print '</td></tr>';
+
+// When the risk entered the document unique, and who put it there
+print '<tr><td class="titlefield">' . $langs->trans('DateCreation') . '</td><td>';
+print dol_print_date($object->date_creation, 'dayhour');
+if (!empty($usersList[$object->fk_user_creat])) {
+    print ' &nbsp; ' . getNomUrlUser($usersList[$object->fk_user_creat]);
+}
+print '</td></tr>';
+
+if (!empty($object->tms)) {
+    print '<tr><td class="titlefield">' . $langs->trans('DateModification') . '</td><td>';
+    print dol_print_date($object->tms, 'dayhour');
+    if (!empty($usersList[$object->fk_user_modif])) {
+        print ' &nbsp; ' . getNomUrlUser($usersList[$object->fk_user_modif]);
+    }
+    print '</td></tr>';
+}
+
+// Tags-Categories
+if (isModEnabled('categorie') && getDolGlobalInt('DIGIRISKDOLIBARR_CATEGORY_ON_RISK') > 0 && $user->rights->categorie->lire) {
+    print '<tr><td>' . $langs->trans('Categories') . '</td><td>';
+    print $form->showCategories($object->id, 'risk', 1);
+    print '</td></tr>';
+}
+
+print '</table>';
+print '</div>';
+
+// Right column: where the risk stands today
+print '<div class="fichehalfright">';
+print '<div class="risk-card-cotation-panel">';
+print '<div class="risk-card-cotation-panel-title">' . $langs->trans('LastRiskAssessment') . '</div>';
+
+if (is_object($lastRiskAssessment)) {
+    $cotationLevel = $object->getCotationLevel($lastRiskAssessment->cotation);
+
+    print '<div class="risk-card-cotation-panel-content">';
+    print '<div class="risk-evaluation-cotation" data-scale="' . $lastRiskAssessment->getEvaluationScale() . '">' . ($lastRiskAssessment->method == 'standard' ? ($defaultCotation[$lastRiskAssessment->cotation] ?? 0) : $lastRiskAssessment->cotation) . '</div>';
+    print '<div class="risk-card-cotation-panel-data">';
+    print '<div class="risk-card-cotation-level">' . ($cotations[$cotationLevel]['label'] ?? '') . '</div>';
+    print '<div class="risk-card-cotation-meta">';
+    print '<i class="fas fa-calendar-alt"></i> ' . dol_print_date((getDolGlobalInt('DIGIRISKDOLIBARR_SHOW_RISKASSESSMENT_DATE') && !empty($lastRiskAssessment->date_riskassessment)) ? $lastRiskAssessment->date_riskassessment : $lastRiskAssessment->date_creation, 'day');
+    if (!empty($usersList[$lastRiskAssessment->fk_user_creat])) {
+        print ' &nbsp; ' . getNomUrlUser($usersList[$lastRiskAssessment->fk_user_creat]);
+    }
+    print '</div>';
+    print '</div>';
+    print '</div>';
+} else {
+    print '<div class="risk-card-cotation-panel-content opacitymedium">' . $langs->trans('NoRiskAssessmentYet') . '</div>';
+}
+
+print '</div>';
+
+// Counters of what hangs from the risk, each one linking to the block that details it
+print '<div class="risk-card-counters">';
+print '<a class="risk-card-counter" href="#riskCardAssessments"><span class="risk-card-counter-value">' . count($riskAssessments) . '</span><span class="risk-card-counter-label">' . $langs->trans('ListingHeaderEvaluation') . '</span></a>';
+if (getDolGlobalInt('DIGIRISKDOLIBARR_TASK_MANAGEMENT')) {
+    print '<a class="risk-card-counter" href="#riskCardTasks"><span class="risk-card-counter-value">' . count($relatedTasks) . '</span><span class="risk-card-counter-label">' . $langs->trans('ListingHeaderTask') . '</span></a>';
+}
+print '</div>';
+
+print '</div>';
+print '</div>';
+print '<div class="clearboth"></div>';
+
+// Description, the very reason of this card: the list only shows its first 120 characters
+print load_fiche_titre($langs->trans('Description'), '', '');
+print '<div class="risk-card-description wordbreak">';
+if (!getDolGlobalInt('DIGIRISKDOLIBARR_RISK_DESCRIPTION')) {
+    print '<span class="opacitymedium">' . $langs->trans('RiskDescriptionNotActivated') . '</span>';
+} elseif (dol_strlen($object->description) > 0) {
+    print dol_nl2br(dol_escape_htmltag($object->description));
+} else {
+    print '<span class="opacitymedium">' . $langs->trans('NoDescription') . '</span>';
+}
+print '</div>';
+
+// Every assessment the risk went through, the list only shows the last one
+print '<div id="riskCardAssessments"></div>';
+print load_fiche_titre($langs->trans('ListingHeaderEvaluation') . ' (' . count($riskAssessments) . ')', '', '');
+print '<div class="div-table-responsive-no-min">';
+print '<table class="noborder centpercent">';
+print '<tr class="liste_titre">';
+print '<th class="liste_titre">' . $langs->trans('Ref') . '</th>';
+print '<th class="liste_titre center">' . $langs->trans('Evaluation') . '</th>';
+print '<th class="liste_titre">' . $langs->trans('RiskAssessmentDate') . '</th>';
+print '<th class="liste_titre">' . $langs->trans('UserAuthor') . '</th>';
+print '<th class="liste_titre">' . $langs->trans('Comment') . '</th>';
+print '<th class="liste_titre center">' . $langs->trans('Photo') . '</th>';
+print '<th class="liste_titre center">' . $langs->trans('Status') . '</th>';
+print '</tr>';
+
+if (!empty($riskAssessments)) {
+    foreach ($riskAssessments as $riskAssessmentSingle) {
+        print '<tr class="oddeven">';
+        print '<td class="nowrap">' . $riskAssessmentSingle->ref . '</td>';
+
+        print '<td class="center">';
+        print '<div class="risk-evaluation-cotation" data-scale="' . $riskAssessmentSingle->getEvaluationScale() . '">' . ($riskAssessmentSingle->method == 'standard' ? ($defaultCotation[$riskAssessmentSingle->cotation] ?? 0) : $riskAssessmentSingle->cotation) . '</div>';
+        // The advanced method computes the cotation from criteria worth reading next to it
+        if ($riskAssessmentSingle->method == 'advanced') {
+            print '<div class="risk-card-criteria">';
+            foreach ($riskAssessmentSingle->advancedCotation as $criterion) {
+                if (dol_strlen($riskAssessmentSingle->$criterion) > 0) {
+                    print '<span class="risk-card-criterion">' . $langs->trans($riskAssessment->fields[$criterion]['label']) . ' : ' . $riskAssessmentSingle->$criterion . '</span>';
+                }
+            }
+            print '</div>';
+        }
+        print '</td>';
+
+        print '<td class="nowrap">' . dol_print_date((getDolGlobalInt('DIGIRISKDOLIBARR_SHOW_RISKASSESSMENT_DATE') && !empty($riskAssessmentSingle->date_riskassessment)) ? $riskAssessmentSingle->date_riskassessment : $riskAssessmentSingle->date_creation, 'day') . '</td>';
+
+        print '<td class="nowrap">' . (!empty($usersList[$riskAssessmentSingle->fk_user_creat]) ? getNomUrlUser($usersList[$riskAssessmentSingle->fk_user_creat]) : '') . '</td>';
+
+        // The comment is read in full here, the list truncates it to 120 characters
+        print '<td class="wordbreak">' . (dol_strlen($riskAssessmentSingle->comment) > 0 ? dol_nl2br(dol_escape_htmltag($riskAssessmentSingle->comment)) : '') . '</td>';
+
+        // saturne_show_medias_linked() draws a placeholder when the folder holds nothing, which
+        // would fill the whole column with empty frames: only the assessments carrying a photo show one
+        print '<td class="center">';
+        if (dol_strlen($riskAssessmentSingle->photo) > 0) {
+            print saturne_show_medias_linked('digiriskdolibarr', DOL_DATA_ROOT . '/' . ($riskAssessmentSingle->entity > 1 ? $riskAssessmentSingle->entity . '/' : '') . 'digiriskdolibarr/riskassessment/' . $riskAssessmentSingle->ref, 'small', 1, 0, 0, 0, 50, 50, 0, 0, 1, '/riskassessment/' . $riskAssessmentSingle->ref, $riskAssessmentSingle, 'photo', 0, 0, 0, 1);
+        }
+        print '</td>';
+
+        print '<td class="center">' . $riskAssessmentSingle->getLibStatut(5) . '</td>';
+        print '</tr>';
+    }
+} else {
+    print '<tr><td colspan="7" class="opacitymedium">' . $langs->trans('NoRiskAssessmentYet') . '</td></tr>';
+}
+print '</table>';
+print '</div>';
+
+// Action plan opened on the risk, read either as a table or as the Gantt of the module
+if (getDolGlobalInt('DIGIRISKDOLIBARR_TASK_MANAGEMENT')) {
+    print '<div id="riskCardTasks"></div>';
+
+    $taskViewUrl    = $_SERVER['PHP_SELF'] . '?id=' . $object->id . '&taskview=';
+    $taskViewSwitch = '<div class="risk-card-taskview-switch">';
+    $taskViewSwitch .= '<a class="risk-card-taskview' . ($taskView == 'list' ? ' active' : '') . '" href="' . $taskViewUrl . 'list#riskCardTasks"><i class="fas fa-list"></i> ' . $langs->trans('List') . '</a>';
+    $taskViewSwitch .= '<a class="risk-card-taskview' . ($taskView == 'gantt' ? ' active' : '') . '" href="' . $taskViewUrl . 'gantt#riskCardTasks"><i class="fas fa-stream"></i> ' . $langs->trans('GanttView') . '</a>';
+    $taskViewSwitch .= '</div>';
+
+    print load_fiche_titre($langs->trans('ListingHeaderTask') . ' (' . count($relatedTasks) . ')', $taskViewSwitch, '');
+}
+
+if (getDolGlobalInt('DIGIRISKDOLIBARR_TASK_MANAGEMENT') && $taskView == 'gantt') {
+    // The Gantt of the action plan, fed with the tasks of this risk only
+    require __DIR__ . '/../../actionplan/actionplan_list_gantt.tpl.php';
+} elseif (getDolGlobalInt('DIGIRISKDOLIBARR_TASK_MANAGEMENT')) {
+    print '<div class="div-table-responsive-no-min">';
+    print '<table class="noborder centpercent">';
+    print '<tr class="liste_titre">';
+    print '<th class="liste_titre">' . $langs->trans('Ref') . '</th>';
+    print '<th class="liste_titre">' . $langs->trans('Label') . '</th>';
+    print '<th class="liste_titre">' . $langs->trans('Project') . '</th>';
+    print '<th class="liste_titre">' . $langs->trans('DateStart') . '</th>';
+    print '<th class="liste_titre">' . $langs->trans('DateEnd') . '</th>';
+    print '<th class="liste_titre right">' . $langs->trans('Progress') . '</th>';
+    print '</tr>';
+
+    if (!empty($relatedTasks)) {
+        foreach ($relatedTasks as $relatedTask) {
+            print '<tr class="oddeven">';
+            print '<td class="nowrap">' . $relatedTask->getNomUrl(1, 'withproject') . '</td>';
+            print '<td>' . dol_escape_htmltag($relatedTask->label) . '</td>';
+            print '<td class="nowrap">';
+            if ($relatedTask->fk_project > 0 && $project->fetch($relatedTask->fk_project) > 0) {
+                print $project->getNomUrl(1);
+            }
+            print '</td>';
+            print '<td class="nowrap">' . dol_print_date($relatedTask->date_start, 'day') . '</td>';
+            print '<td class="nowrap">' . dol_print_date($relatedTask->date_end, 'day') . '</td>';
+            print '<td class="right"><span class="' . $relatedTask->getTaskProgressColorClass($relatedTask->progress) . '">' . (int) $relatedTask->progress . ' %</span></td>';
+            print '</tr>';
+        }
+    } else {
+        print '<tr><td colspan="6" class="opacitymedium">' . $langs->trans('NoTaskYet') . '</td></tr>';
+    }
+    print '</table>';
+    print '</div>';
+}
+
+print dol_get_fiche_end();
+
+// Hook to let the other modules add their own block at the bottom of the card
+$parameters = [];
+$reshook    = $hookmanager->executeHooks('riskCardBottom', $parameters, $object, $action);
+print $hookmanager->resPrint;

--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_risklist_view.tpl.php
@@ -1071,13 +1071,13 @@ while ($i < ($limit ? min($num, $limit) : $num)) {
                     <!-- BUTTON MODAL RISK EDIT -->
                     <?php if ($permissiontoadd) : ?>
                         <div><?php
-                            echo $risk->getNomUrl(1, 'nolink'); ?>
+                            echo $risk->getNomUrl(1); ?>
                             <i class="risk-edit wpeo-tooltip-event modal-open fas fa-pencil-alt" aria-label="<?php echo $langs->trans('EditRisk'); ?>" value="<?php echo $risk->id; ?>" id="<?php echo $risk->ref; ?>">
                                 <input type="hidden" class="modal-options" data-modal-to-open="risk_edit<?php echo $risk->id ?>" data-from-id="<?php echo $risk->id ?>" data-from-type="risk" data-from-subtype="" data-from-subdir=""/>
                             </i>
                         </div>
                     <?php else : ?>
-                        <div class="risk-edit-no-perm" value="<?php echo $risk->id ?>"><?php echo $risk->getNomUrl(1, 'nolink'); ?></div>
+                        <div class="risk-edit-no-perm" value="<?php echo $risk->id ?>"><?php echo $risk->getNomUrl(1); ?></div>
                     <?php endif; ?>
                     <!-- RISK EDIT MODAL -->
                     <div id="risk_edit<?php echo $risk->id ?>" class="wpeo-modal modal-risk-<?php echo $risk->id ?>">

--- a/css/scss/page/_page.scss
+++ b/css/scss/page/_page.scss
@@ -10,3 +10,4 @@
 @import "risk-dashboard";
 @import "mobile-quick-create";
 @import "pwa";
+@import "risk-card";

--- a/css/scss/page/_risk-card.scss
+++ b/css/scss/page/_risk-card.scss
@@ -1,0 +1,126 @@
+/* Risk card: the read page of a single risk, where its description and its whole assessment
+   history are shown in full, the list only having room for a truncated version of both. */
+/* Danger category of the risk, read under its ref: a risk carries no label, the family it belongs
+   to is what names it. The banner line is laid out on its own so the picto never drops below. */
+.risk-card-danger-category {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.risk-card-danger-category-pic {
+  width: 32px;
+  height: 32px;
+  flex: none;
+}
+
+.risk-card {
+  .risk-card-cotation-panel {
+    border: 1px solid $color__grey;
+    border-radius: 6px;
+    padding: 12px;
+    background: #fff;
+  }
+
+  .risk-card-cotation-panel-title {
+    font-weight: 600;
+    margin-bottom: 10px;
+  }
+
+  .risk-card-cotation-panel-content {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .risk-card-cotation-level {
+    font-size: 16px;
+    font-weight: 600;
+  }
+
+  .risk-card-cotation-meta {
+    margin-top: 4px;
+  }
+
+  .risk-card-counters {
+    display: flex;
+    gap: 12px;
+    margin-top: 12px;
+  }
+
+  .risk-card-counter {
+    flex: 1;
+    display: block;
+    padding: 10px 12px;
+    border: 1px solid $color__grey;
+    border-radius: 6px;
+    background: #fff;
+    text-align: center;
+    text-decoration: none;
+
+    &:hover {
+      border-color: $color__primary;
+    }
+  }
+
+  .risk-card-counter-value {
+    display: block;
+    font-size: 20px;
+    font-weight: 600;
+  }
+
+  .risk-card-counter-label {
+    display: block;
+  }
+}
+
+/* The description and the comments are read in full: they keep their line breaks and never
+   overflow the block they sit in, however long a word the field holds. */
+.risk-card-description {
+  padding: 10px 12px;
+  border: 1px solid $color__grey;
+  border-radius: 6px;
+  background: #fff;
+  white-space: normal;
+}
+
+/* Table / Gantt switch of the action plan block, sitting on the right of the section title. */
+.risk-card-taskview-switch {
+  display: inline-flex;
+  gap: 4px;
+
+  .risk-card-taskview {
+    padding: 3px 10px;
+    border: 1px solid $color__grey;
+    border-radius: 4px;
+    background: #fff;
+    text-decoration: none;
+
+    &:hover {
+      border-color: $color__primary;
+    }
+
+    &.active {
+      border-color: $color__primary;
+      background: $color__primary;
+      color: $color__primary-text;
+    }
+  }
+}
+
+/* Criteria of an advanced assessment, read next to the cotation they add up to. */
+.risk-card-criteria {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 4px;
+  margin-top: 6px;
+}
+
+.risk-card-criterion {
+  padding: 1px 6px;
+  border-radius: 10px;
+  background: $color__grey;
+  font-size: 11px;
+  white-space: nowrap;
+}

--- a/langs/en_US/digiriskdolibarr.lang
+++ b/langs/en_US/digiriskdolibarr.lang
@@ -593,3 +593,16 @@ ShowPatchNoteAgainDescription = When enabled, the release note of the current ve
 RiskCotation = Rating
 PreventionActions = Prevention actions
 AddingInProgress = Adding in progress...
+
+# RiskCard
+RiskCard = Risk card
+SubCategory = Sub-category
+Evaluation = Rating
+Gravity = Severity
+Occurrence = Occurrence
+Exposition = Exposure
+Formation = Training
+Protection = Protection
+NoRiskAssessmentYet = No assessment for this risk yet
+NoTaskYet = No task for this risk yet
+NoDescription = No description

--- a/langs/fr_FR/digiriskdolibarr.lang
+++ b/langs/fr_FR/digiriskdolibarr.lang
@@ -2418,3 +2418,16 @@ FirePermitMenuVisibilityDescription             = Si l'option est désactivée, 
 AccidentMenuVisibilityDescription               = Si l'option est désactivée, les entrées de menu des accidents (liste et catégories) sont masquées.<br>L'onglet de configuration « Accident » n'est masqué que si les enquêtes accident le sont également.
 AccidentInvestigationMenuVisibilityDescription  = Si l'option est désactivée, l'entrée de menu des enquêtes accident est masquée.<br>L'onglet de configuration « Accident » n'est masqué que si les accidents le sont également.
 ToolsMenuVisibilityDescription                  = Si l'option est désactivée, l'entrée de menu des outils est masquée.
+
+# RiskCard
+RiskCard = Carte du risque
+SubCategory = Sous-catégorie
+Evaluation = Cotation
+Gravity = Gravité
+Occurrence = Occurrence
+Exposition = Exposition
+Formation = Formation
+Protection = Protection
+NoRiskAssessmentYet = Aucune évaluation pour ce risque
+NoTaskYet = Aucune tâche pour ce risque
+NoDescription = Aucune description

--- a/lib/digiriskdolibarr_risk.lib.php
+++ b/lib/digiriskdolibarr_risk.lib.php
@@ -1,0 +1,46 @@
+<?php
+/* Copyright (C) 2021-2026 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    lib/digiriskdolibarr_risk.lib.php
+ * \ingroup digiriskdolibarr
+ * \brief   Library files with common functions for risk
+ */
+
+/**
+ * Prepare risk pages header
+ *
+ * A risk carries neither note nor document nor agenda event: the card is its only tab, the other
+ * modules of the module adding theirs through the hook saturne_object_prepare_head() calls.
+ *
+ * @param  Risk  $object Risk
+ * @return array $head   Array of tabs
+ * @throws Exception
+ */
+function risk_prepare_head(Risk $object): array
+{
+    // Load translation files required by the page
+    saturne_load_langs();
+
+    $head = [];
+
+    $moreParams = [
+        'specialName' => 'RiskCard'
+    ];
+
+    return saturne_object_prepare_head($object, $head, $moreParams, false, false, false, false);
+}

--- a/view/risk/index.php
+++ b/view/risk/index.php
@@ -1,0 +1,2 @@
+<?php
+//Silence is golden apple

--- a/view/risk/risk_card.php
+++ b/view/risk/risk_card.php
@@ -1,0 +1,190 @@
+<?php
+/* Copyright (C) 2021-2026 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ *   	\file       view/risk/risk_card.php
+ *		\ingroup    digiriskdolibarr
+ *		\brief      Page to read a whole risk
+ *
+ * The risk list only has room for a truncated description and for the last assessment of each risk.
+ * This card reads a single risk in full: its whole description, every assessment it went through and
+ * the action plan it opened.
+ */
+
+// Load DigiriskDolibarr environment
+if (file_exists('../../digiriskdolibarr.main.inc.php')) {
+    require_once __DIR__ . '/../../digiriskdolibarr.main.inc.php';
+} elseif (file_exists('../../../digiriskdolibarr.main.inc.php')) {
+    require_once __DIR__ . '/../../../digiriskdolibarr.main.inc.php';
+} else {
+    die('Include of digiriskdolibarr main fails');
+}
+
+// Load Dolibarr libraries
+require_once DOL_DOCUMENT_ROOT . '/core/lib/date.lib.php';
+require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
+require_once DOL_DOCUMENT_ROOT . '/core/lib/images.lib.php';
+require_once DOL_DOCUMENT_ROOT . '/core/class/html.form.class.php';
+require_once DOL_DOCUMENT_ROOT . '/projet/class/project.class.php';
+if (isModEnabled('categorie')) {
+    require_once DOL_DOCUMENT_ROOT . '/categories/class/categorie.class.php';
+}
+
+// Load DigiriskDolibarr libraries
+require_once __DIR__ . '/../../class/digiriskelement.class.php';
+require_once __DIR__ . '/../../class/riskanalysis/risk.class.php';
+require_once __DIR__ . '/../../class/riskanalysis/riskassessment.class.php';
+require_once __DIR__ . '/../../lib/digiriskdolibarr_actionplan.lib.php';
+require_once __DIR__ . '/../../lib/digiriskdolibarr_function.lib.php';
+require_once __DIR__ . '/../../lib/digiriskdolibarr_risk.lib.php';
+
+global $conf, $db, $hookmanager, $langs, $user;
+
+// Load translation files required by the page
+saturne_load_langs(['errors', 'projects']);
+
+// Get parameters
+$id          = GETPOSTINT('id');
+$action      = GETPOST('action', 'aZ09');
+$contextpage = GETPOST('contextpage', 'aZ') ? GETPOST('contextpage', 'aZ') : 'riskcard';
+$backtopage  = GETPOST('backtopage', 'alpha');
+// The action plan of the risk reads either as a table of its tasks or as the Gantt of the module
+$taskView    = GETPOST('taskview', 'aZ09') == 'gantt' ? 'gantt' : 'list';
+
+// Initialize technical objects
+$object          = new Risk($db);
+$riskAssessment  = new RiskAssessment($db);
+$digiriskElement = new DigiriskElement($db);
+$project         = new Project($db);
+$form            = new Form($db);
+
+// Load object
+$object->fetch($id);
+
+// The constructor reads the type from the URL, the card reads it from the risk itself
+if ($object->type == 'riskenvironmental') {
+    $object->picto = 'fontawesome_fa-leaf_fas_#d35968';
+}
+
+$hookmanager->initHooks(['riskcard', 'globalcard']); // Note that conf->hooks_modules contains array
+
+// Security check - Protection if external user
+$permissiontoread   = $user->rights->digiriskdolibarr->risk->read;
+$permissiontoadd    = $user->rights->digiriskdolibarr->risk->write;
+$permissiontodelete = $user->rights->digiriskdolibarr->risk->delete;
+
+saturne_check_access($permissiontoread, $object);
+
+/*
+ * Actions
+ */
+
+$parameters = [];
+$reshook    = $hookmanager->executeHooks('doActions', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
+if ($reshook < 0) {
+    setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+}
+
+/*
+ * View
+ */
+
+$title   = $langs->trans('RiskCard');
+$helpUrl = 'FR:Module_Digirisk';
+
+// The Gantt timeline is wider than the page: #id-right is a table-cell, so its own overflow-x
+// never scrolls and the whole page stretches instead. classforhorizontalscrolloftabs bounds it.
+$moreCssOnBody = $taskView == 'gantt' ? 'classforhorizontalscrolloftabs' : '';
+
+saturne_header(0, '', $title, $helpUrl, '', 0, 0, [], [], '', $moreCssOnBody);
+
+if ($object->id <= 0) {
+    print $langs->trans('ErrorRecordNotFound');
+    llxFooter();
+    $db->close();
+    exit;
+}
+
+// Data of the risk, gathered once for the whole card
+$digiriskElement->fetch($object->fk_element);
+
+// Every assessment the risk went through, the most recent first
+$riskAssessments = $riskAssessment->fetchFromParent($object->id, 0, 'DESC');
+if (!is_array($riskAssessments)) {
+    $riskAssessments = [];
+}
+
+// The cotation of a risk is the one of its last validated assessment
+$lastRiskAssessment = null;
+foreach ($riskAssessments as $riskAssessmentSingle) {
+    if ($riskAssessmentSingle->status == RiskAssessment::STATUS_VALIDATED) {
+        $lastRiskAssessment = $riskAssessmentSingle;
+        break;
+    }
+}
+
+// Action plan opened on the risk
+$relatedTasks = $object->getRelatedTasks($object);
+if (!is_array($relatedTasks)) {
+    $relatedTasks = [];
+}
+
+$usersList = saturne_fetch_all_object_type('User');
+if (!is_array($usersList)) {
+    $usersList = [];
+}
+
+// The Gantt of the action plan reads the tasks in the shape its template expects. Only the keys it
+// uses are built here: the risk is already named by the card, so its badge is left out of the bars.
+$tasksJson     = [];
+$kanbanColumns = [];
+if ($taskView == 'gantt') {
+    $kanbanColumns = digiriskActionPlanGetKanbanColumns($db);
+
+    foreach ($relatedTasks as $relatedTask) {
+        $responsible = [];
+        foreach ($relatedTask->liste_contact(-1, 'internal') as $taskContact) {
+            if ($taskContact['code'] == 'TASKEXECUTIVE') {
+                $responsible[] = [
+                    'id'       => (int) $taskContact['id'],
+                    'fullname' => trim($taskContact['firstname'] . ' ' . $taskContact['lastname']),
+                    'initials' => dol_strtoupper(dol_substr($taskContact['firstname'], 0, 1) . dol_substr($taskContact['lastname'], 0, 1)),
+                    'photo'    => ''
+                ];
+            }
+        }
+
+        $tasksJson[] = [
+            'id'          => $relatedTask->id,
+            'ref'         => $relatedTask->ref,
+            'label'       => $relatedTask->label,
+            'date_start'  => $relatedTask->date_start ? dol_print_date($relatedTask->date_start, 'dayrfc') : '',
+            'date_end'    => $relatedTask->date_end ? dol_print_date($relatedTask->date_end, 'dayrfc') : '',
+            'progress'    => (int) $relatedTask->progress,
+            'risk_ref'    => $object->ref,
+            'risk_nomurl' => '',
+            'responsible' => $responsible,
+            'url'         => DOL_URL_ROOT . '/projet/tasks/task.php?id=' . $relatedTask->id . '&withproject=1'
+        ];
+    }
+}
+
+require_once __DIR__ . '/../../core/tpl/riskanalysis/risk/digiriskdolibarr_riskcard_view.tpl.php';
+
+// End of page
+llxFooter();
+$db->close();


### PR DESCRIPTION
## Contexte

La liste des risques n'a pas la place de tout montrer : la description est tronquée à 120 caractères et seule la dernière évaluation est visible. Il n'existait aucune page permettant de lire un risque en entier — `Risk::getNomUrl()` renvoyait d'ailleurs vers la liste de l'élément parent, et les listes l'appelaient en `'nolink'`.

## Changements

- Nouvelle page de lecture d'un risque : `view/risk/risk_card.php` (contrôleur) + `core/tpl/riskanalysis/risk/digiriskdolibarr_riskcard_view.tpl.php` (écran)
- `risk_prepare_head()` dans `lib/digiriskdolibarr_risk.lib.php` — onglet unique, ni note ni document ni agenda sur un risque
- La carte affiche : famille de risque et sous-catégorie, arborescence complète de l'élément parent, dates et auteurs, tags, dernière évaluation avec sa cotation et son niveau, **description complète non tronquée**, **historique de toutes les évaluations** (cotation, critères de la méthode avancée, commentaire entier, photo, statut) et le plan d'action lié
- Le bloc plan d'action bascule entre une vue Liste et une **vue Gantt**, qui réutilise le Gantt du plan d'action (`core/tpl/actionplan/actionplan_list_gantt.tpl.php` + `js/modules/actionplan_gantt.js`) sans nouvelle dépendance
- `Risk::getNomUrl()` pointe désormais sur la carte, et la réf du risque devient cliquable dans la liste des risques et dans la liste des risques hérités

## Points d'attention

- Le chemin `view/risk/risk_card.php` est imposé par `saturne_object_prepare_head()`, qui construit l'URL de l'onglet en `view/<element>/<element>_card.php`
- La vue Gantt passe `classforhorizontalscrolloftabs` en `$morecssonbody` : `#id-right` est un `table-cell`, sans cette classe la timeline étire toute la page au lieu de défiler dans son cadre
- Les `.min` ne sont pas commités, la CI build-assets s'en charge

## Tests

Rendu vérifié sur RK1 (photo d'évaluation), RK3 (arborescence sur 3 niveaux, méthode avancée), RK11 (sous-catégorie RPS, 7 tâches) et RK18 (risque environnemental) : HTTP 200, aucun warning ou notice PHP, aucune erreur JS, en vue Liste comme en vue Gantt.

Close #1867
