### PR TITLE
#1912 [Risk] fix: always ask for the user photo picto, showphoto handles the fallback

### DIFF
--- a/core/tpl/riskanalysis/risk/digiriskdolibarr_riskcard_view.tpl.php
+++ b/core/tpl/riskanalysis/risk/digiriskdolibarr_riskcard_view.tpl.php
@@ -81,7 +81,7 @@ print '<tr><td class="titlefield">' . $langs->trans('DateCreation') . '</td><td>
 print dol_print_date($object->date_creation, 'dayhour');
 if (!empty($usersList[$object->fk_user_creat])) {
     $userAuthor = $usersList[$object->fk_user_creat];
-    print ' &nbsp; ' . getNomUrlUser($userAuthor, getUserPhotoPicto($userAuthor));
+    print ' &nbsp; ' . getNomUrlUser($userAuthor, -3);
 }
 print '</td></tr>';
 
@@ -90,7 +90,7 @@ if (!empty($object->tms)) {
     print dol_print_date($object->tms, 'dayhour');
     if (!empty($usersList[$object->fk_user_modif])) {
         $userAuthor = $usersList[$object->fk_user_modif];
-        print ' &nbsp; ' . getNomUrlUser($userAuthor, getUserPhotoPicto($userAuthor));
+        print ' &nbsp; ' . getNomUrlUser($userAuthor, -3);
     }
     print '</td></tr>';
 }
@@ -121,7 +121,7 @@ if (is_object($lastRiskAssessment)) {
     print '<i class="fas fa-calendar-alt"></i> ' . dol_print_date((getDolGlobalInt('DIGIRISKDOLIBARR_SHOW_RISKASSESSMENT_DATE') && !empty($lastRiskAssessment->date_riskassessment)) ? $lastRiskAssessment->date_riskassessment : $lastRiskAssessment->date_creation, 'day');
     if (!empty($usersList[$lastRiskAssessment->fk_user_creat])) {
         $userAuthor = $usersList[$lastRiskAssessment->fk_user_creat];
-        print ' &nbsp; ' . getNomUrlUser($userAuthor, getUserPhotoPicto($userAuthor));
+        print ' &nbsp; ' . getNomUrlUser($userAuthor, -3);
     }
     print '</div>';
     print '</div>';
@@ -192,7 +192,7 @@ if (!empty($riskAssessments)) {
 
         print '<td class="nowrap">' . dol_print_date((getDolGlobalInt('DIGIRISKDOLIBARR_SHOW_RISKASSESSMENT_DATE') && !empty($riskAssessmentSingle->date_riskassessment)) ? $riskAssessmentSingle->date_riskassessment : $riskAssessmentSingle->date_creation, 'day') . '</td>';
 
-        print '<td class="nowrap">' . (!empty($usersList[$riskAssessmentSingle->fk_user_creat]) ? getNomUrlUser($usersList[$riskAssessmentSingle->fk_user_creat], getUserPhotoPicto($usersList[$riskAssessmentSingle->fk_user_creat])) : '') . '</td>';
+        print '<td class="nowrap">' . (!empty($usersList[$riskAssessmentSingle->fk_user_creat]) ? getNomUrlUser($usersList[$riskAssessmentSingle->fk_user_creat], -3) : '') . '</td>';
 
         // The comment is read in full here, the list truncates it to 120 characters
         print '<td class="wordbreak">' . (dol_strlen($riskAssessmentSingle->comment) > 0 ? dol_nl2br(dol_escape_htmltag($riskAssessmentSingle->comment)) : '') . '</td>';

--- a/core/tpl/riskanalysis/riskassessment/digiriskdolibarr_riskassessment_view.tpl.php
+++ b/core/tpl/riskanalysis/riskassessment/digiriskdolibarr_riskassessment_view.tpl.php
@@ -137,7 +137,7 @@ if (is_array($allRiskAssessment) && !empty($allRiskAssessment)) :
 												</span>
 												<span class="risk-evaluation-author">
 													<?php $userAuthor = $usersList[$lastEvaluation->fk_user_creat?:$user->id];
-													echo getNomUrlUser($userAuthor, getUserPhotoPicto($userAuthor)); ?>
+													echo getNomUrlUser($userAuthor, -3); ?>
 												</span>
 											</div>
 											<div class="risk-evaluation-comment">
@@ -401,7 +401,7 @@ $evaluation->method = $lastRiskAssessment->method ?: "standard" ;
 										</span>
 										<span class="risk-evaluation-author">
 											<?php $userAuthor = $usersList[$lastRiskAssessment->fk_user_creat?:$user->id];
-											echo getNomUrlUser($userAuthor, getUserPhotoPicto($userAuthor)); ?>
+											echo getNomUrlUser($userAuthor, -3); ?>
 										</span>
 									</div>
 									<div class="risk-evaluation-comment">

--- a/core/tpl/riskanalysis/riskassessment/digiriskdolibarr_riskassessment_view_single.tpl.php
+++ b/core/tpl/riskanalysis/riskassessment/digiriskdolibarr_riskassessment_view_single.tpl.php
@@ -21,7 +21,7 @@
 					</span>
 					<span class="risk-evaluation-author">
 						<?php $userAuthor = $usersList[$lastEvaluation->fk_user_creat?:$user->id];
-						echo getNomUrlUser($userAuthor, getUserPhotoPicto($userAuthor)); ?>
+						echo getNomUrlUser($userAuthor, -3); ?>
 					</span>
 				</div>
 				<div class="risk-evaluation-comment wordbreak">

--- a/core/tpl/riskanalysis/riskassessmenttask/digiriskdolibarr_riskassessment_task_single_view.tpl.php
+++ b/core/tpl/riskanalysis/riskassessmenttask/digiriskdolibarr_riskassessment_task_single_view.tpl.php
@@ -66,7 +66,7 @@
                         foreach ($taskExecutive as $executive) {
                             $userAuthor = $usersList[$executive['id'] ?: $user->id];
                             echo '<span class="riskassessment-task-author">';
-                            echo getNomUrlUser($userAuthor, getUserPhotoPicto($userAuthor));
+                            echo getNomUrlUser($userAuthor, -3);
                             echo '</span>';
                         }
                     } else {
@@ -77,7 +77,7 @@
                         foreach ($taskContributor as $contributor) {
                             $userAuthor = $usersList[$contributor['id'] ?: $user->id];
                             echo '<span class="riskassessment-task-author">';
-                            echo getNomUrlUser($userAuthor, getUserPhotoPicto($userAuthor));
+                            echo getNomUrlUser($userAuthor, -3);
                             echo '</span>';
                         }
                     } else {

--- a/core/tpl/riskanalysis/riskassessmenttask/digiriskdolibarr_riskassessment_task_view.tpl.php
+++ b/core/tpl/riskanalysis/riskassessmenttask/digiriskdolibarr_riskassessment_task_view.tpl.php
@@ -323,7 +323,7 @@ if (!empty($related_tasks) && is_array($related_tasks)) {
 								<span class="riskassessment-task-reference" value="<?php echo $related_task->ref ?>"><?php echo $related_task->getNomUrl(0, 'withproject'); ?></span>
 								<span class="riskassessment-task-author">
 									<?php $userAuthor = $usersList[$related_task->fk_user_creat > 0 ? $related_task->fk_user_creat : $user->id];
-									echo getNomUrlUser($userAuthor, getUserPhotoPicto($userAuthor)); ?>
+									echo getNomUrlUser($userAuthor, -3); ?>
 								</span>
 								<span class="riskassessment-task-date">
 									<i class="fas fa-calendar-alt"></i> <?php echo date('d/m/Y', (($conf->global->DIGIRISKDOLIBARR_SHOW_TASK_START_DATE && ( ! empty($related_task->dateo))) ? $related_task->dateo : $related_task->datec)) . (($conf->global->DIGIRISKDOLIBARR_SHOW_TASK_END_DATE && ( ! empty($related_task->datee))) ? ' - ' . date('d/m/Y', $related_task->datee) : ''); ?>
@@ -493,7 +493,7 @@ if (!empty($related_tasks) && is_array($related_tasks)) {
 														<div class="table-cell table-padding-0 riskassessment-task-timespent-single">
 															<span class="riskassessment-task-timespent-author">
 																<?php $userAuthor = $usersList[$time_spent->timespent_fk_user?:$user->id];
-																echo getNomUrlUser($userAuthor, getUserPhotoPicto($userAuthor)); ?>
+																echo getNomUrlUser($userAuthor, -3); ?>
 															</span>
 															<span class="riskassessment-task-timespent-date">
 																<i class="fas fa-calendar-alt"></i> <?php echo dol_print_date($time_spent->timespent_datehour, 'dayhour'); ?>

--- a/lib/digiriskdolibarr_function.lib.php
+++ b/lib/digiriskdolibarr_function.lib.php
@@ -566,30 +566,6 @@ function display_recurse_tree_organization($digiriskElementTree, $i = 1, $riskIn
 }
 
 /**
- * Return the picto mode to pass to getNomUrlUser() to display a user avatar
- *
- * The photo is only asked for when the file really exists : llx_user.photo can name a file that
- * is no longer on disk, and Form::showphoto() then falls back on a gravatar. Returning 0 in that
- * case keeps the initials, which stay readable and need no external request.
- *
- * @param  User $object User to display
- * @return int          -3 to show only the photo, 0 to show the initials
- */
-function getUserPhotoPicto(User $object)
-{
-	global $conf;
-
-	if (empty($object->photo)) {
-		return 0;
-	}
-
-	// Same path as the one Form::showphoto() builds for the mini size, so the test matches what will be rendered
-	$photoFile = $conf->user->dir_output . '/' . get_exdir(0, 0, 0, 0, $object, 'user') . 'photos/' . getImageFileNameForSize($object->photo, '_mini');
-
-	return is_file($photoFile) ? -3 : 0;
-}
-
-/**
 *  Return a link to the user card (with optionaly the picto)
 *  Use this->id,this->lastname, this->firstname
 *


### PR DESCRIPTION
## Correction de #5115

Le repli en initiales introduit par #5115 était une mauvaise idée : il court-circuitait la chaîne de repli de `Form::showphoto()`, qui est ce que le reste de Dolibarr affiche déjà partout (fiche utilisateur, liste des utilisateurs, menu haut).

`Form::showphoto()` gère l'absence de fichier toute seule : fichier local, sinon **gravatar** quand le module est actif, sinon l'avatar anonyme (`user_anonymous.png`, `user_man.png`, `user_woman.png`). Sur un poste où `llx_user.photo` nomme des fichiers absents — cas courant d'une base restaurée sans son dossier `documents` — les autres pages affichent donc bien un avatar, alors que la page Risques retombait en initiales. Incohérent, et illisible comme signal : on ne pouvait pas distinguer « cet utilisateur n'a pas de photo » de « le fichier manque ».

- `getUserPhotoPicto()` est supprimée de `lib/digiriskdolibarr_function.lib.php`.
- Les 10 appels de la page Risques passent `-3` en dur, donc demandent toujours le picto photo.

Le SCSS de #5115 est inchangé et reste nécessaire : c'est lui qui fait remplir la pastille ronde par l'image. Le `.min.css` n'est donc pas touché.

Vérifié sur l'onglet Risques d'une unité de travail : chaque auteur d'évaluation, de tâche et de temps passé affiche le même avatar que sur sa fiche utilisateur.

## Fichiers modifiés

- `lib/digiriskdolibarr_function.lib.php`
- `core/tpl/riskanalysis/risk/digiriskdolibarr_riskcard_view.tpl.php`
- `core/tpl/riskanalysis/riskassessment/digiriskdolibarr_riskassessment_view.tpl.php`
- `core/tpl/riskanalysis/riskassessment/digiriskdolibarr_riskassessment_view_single.tpl.php`
- `core/tpl/riskanalysis/riskassessmenttask/digiriskdolibarr_riskassessment_task_view.tpl.php`
- `core/tpl/riskanalysis/riskassessmenttask/digiriskdolibarr_riskassessment_task_single_view.tpl.php`

## Issue

Close #1912
