### PR TITLE
#4731 [RiskSign] fix: signalisations héritées et partagées dans les documents

### DIFF
--- a/class/riskanalysis/risksign.class.php
+++ b/class/riskanalysis/risksign.class.php
@@ -122,7 +122,13 @@ class RiskSign extends SaturneObject
     /**
      * Load risk sign infos
      *
-     * @param  array     $moreParam More param (filter)
+     * ShowInheritedRiskSigns and ShowSharedRiskSigns are described as acting on "les documents et
+     * les listings", but they only ever reached the element card: a work unit document listed the
+     * risk signs of that single element while its own template announces the three sources - issue
+     * #4731. They are honoured here, and only for a document scoped on one element: the risk
+     * assessment document passes no element filter and already lists every risk sign of the entity.
+     *
+     * @param  array     $moreParam More param (filter/object)
      * @return array     $array     Array of risk signs
      * @throws Exception
      */
@@ -130,20 +136,102 @@ class RiskSign extends SaturneObject
     {
         $array = [];
 
-        //@todo: missing shared and inherited risksigns
+        $select      = ', d.ref AS digiriskElementRef, d.entity AS digiriskElementEntity, d.label AS digiriskElementLabel';
+        $moreSelects = ['digiriskElementRef', 'digiriskElementEntity', 'digiriskElementLabel'];
+        $join        = ' INNER JOIN ' . MAIN_DB_PREFIX . 'digiriskdolibarr_digiriskelement AS d ON d.rowid = t.fk_element';
+        $status      = 'd.status = ' . DigiriskElement::STATUS_VALIDATED . ' AND t.status = ' . self::STATUS_VALIDATED;
 
-        $select             = ', d.ref AS digiriskElementRef, d.entity AS digiriskElementEntity, d.label AS digiriskElementLabel';
-        $moreSelects        = ['digiriskElementRef', 'digiriskElementEntity', 'digiriskElementLabel'];
-        $join               = ' INNER JOIN ' . MAIN_DB_PREFIX . 'digiriskdolibarr_digiriskelement AS d ON d.rowid = t.fk_element';
-        $filter             = 'd.status = ' . DigiriskElement::STATUS_VALIDATED . ' AND t.status = ' . self::STATUS_VALIDATED . ($moreParam['filter'] ?? '');
-        $array['riskSigns'] = saturne_fetch_all_object_type('RiskSign', '', '', 0, 0, ['customsql' => $filter], 'AND', false, false, false, $join, [], $select, $moreSelects);
-        if (!is_array($array['riskSigns']) || empty($array['riskSigns'])) {
-            $array['riskSigns'] = [];
+        $riskSigns = saturne_fetch_all_object_type('RiskSign', '', '', 0, 0, ['customsql' => $status . ($moreParam['filter'] ?? '')], 'AND', false, false, false, $join, [], $select, $moreSelects);
+        if (!is_array($riskSigns)) {
+            $riskSigns = [];
         }
 
-        $array['nbRiskSigns'] = count($array['riskSigns']);
+        $object = $moreParam['object'] ?? null;
+        if ($object instanceof DigiriskElement && $object->id > 0) {
+            // Both helpers key their result by risk sign id, so the union renders a risk sign
+            // reachable twice - inherited and shared - only once
+            if (getDolGlobalInt('DIGIRISKDOLIBARR_SHOW_INHERITED_RISKSIGNS')) {
+                $riskSigns += self::fetchInheritedRiskSigns($object, $status, $join, $select, $moreSelects);
+            }
+            if (getDolGlobalInt('DIGIRISKDOLIBARR_SHOW_SHARED_RISKSIGNS')) {
+                $riskSigns += self::fetchSharedRiskSigns($object, $status, $join, $select, $moreSelects);
+            }
+        }
+
+        $array['riskSigns']   = $riskSigns;
+        $array['nbRiskSigns'] = count($riskSigns);
 
         return $array;
+    }
+
+    /**
+     * Fetch the risk signs every ancestor of an element carries
+     *
+     * "Inherited" is what the element card shows under the same setting: declared higher in the
+     * tree and applying downwards. The parent chain is read from the validated elements, which one
+     * cached query already holds, so an unvalidated element ends the walk - its own risk signs are
+     * excluded by the status filter anyway, and those of its parents are then left out too.
+     *
+     * @param  DigiriskElement $object      Element the document is generated for
+     * @param  string          $status      Status conditions shared with the caller
+     * @param  string          $join        Join naming the element a risk sign belongs to
+     * @param  string          $select      Extra columns the risk sign segment reads
+     * @param  array           $moreSelects Names of those extra columns
+     * @return array                        Risk signs keyed by id
+     * @throws Exception
+     */
+    private static function fetchInheritedRiskSigns(DigiriskElement $object, string $status, string $join, string $select, array $moreSelects): array
+    {
+        global $db;
+
+        $digiriskElement  = new DigiriskElement($db);
+        $digiriskElements = $digiriskElement->getActiveDigiriskElements('all');
+        if (!is_array($digiriskElements)) {
+            $digiriskElements = [];
+        }
+
+        $ancestorIds = [];
+        $parentId    = (int) $object->fk_parent;
+        // An id already seen means fk_parent forms a cycle: stop rather than loop forever
+        while ($parentId > 0 && !isset($ancestorIds[$parentId])) {
+            $ancestorIds[$parentId] = $parentId;
+            $parentId               = isset($digiriskElements[$parentId]) ? (int) $digiriskElements[$parentId]->fk_parent : 0;
+        }
+
+        if (empty($ancestorIds)) {
+            return [];
+        }
+
+        $filter    = $status . ' AND t.fk_element IN (' . implode(',', $ancestorIds) . ')';
+        $riskSigns = saturne_fetch_all_object_type('RiskSign', '', '', 0, 0, ['customsql' => $filter], 'AND', false, false, false, $join, [], $select, $moreSelects);
+
+        return is_array($riskSigns) ? $riskSigns : [];
+    }
+
+    /**
+     * Fetch the risk signs other entities share with an element
+     *
+     * The link is the one the element card reads: an element_element row from the risk sign to the
+     * element. The owning element stays joined on fk_element so the segment names the entity the
+     * risk sign really belongs to, which is what its "S<entity>" prefix is for.
+     *
+     * @param  DigiriskElement $object      Element the document is generated for
+     * @param  string          $status      Status conditions shared with the caller
+     * @param  string          $join        Join naming the element a risk sign belongs to
+     * @param  string          $select      Extra columns the risk sign segment reads
+     * @param  array           $moreSelects Names of those extra columns
+     * @return array                        Risk signs keyed by id
+     * @throws Exception
+     */
+    private static function fetchSharedRiskSigns(DigiriskElement $object, string $status, string $join, string $select, array $moreSelects): array
+    {
+        $sharedJoin  = ' INNER JOIN ' . MAIN_DB_PREFIX . 'element_element AS ee ON (ee.fk_source = t.rowid AND ee.sourcetype = \'digiriskdolibarr_risksign\' AND ee.targettype = \'digiriskdolibarr_digiriskelement\')';
+        $sharedJoin .= $join;
+
+        $filter    = $status . ' AND ee.fk_target = ' . (int) $object->id;
+        $riskSigns = saturne_fetch_all_object_type('RiskSign', '', '', 0, 0, ['customsql' => $filter], 'AND', false, false, false, $sharedJoin, [], $select, $moreSelects);
+
+        return is_array($riskSigns) ? $riskSigns : [];
     }
 
 	/**


### PR DESCRIPTION
Closes #4731

## Le problème

Le ticket ne montre qu'une capture, et cette capture est celle d'un **document généré** (fiche d'unité de travail), pas d'une liste à l'écran : la section « Liste des signalisations pour cette unité de travail » n'affiche que les signalisations portées par l'UT elle-même.

Le modèle ODT annonce pourtant le contraire en note de bas de page :

> En fonction des réglages cette liste contient les signalisations de l'unité de travail, les signalisations héritées, les signalisations partagées.

Et les libellés des réglages disent la même chose :

```
ShowInheritedRiskSignsDescription  = Afficher les signalisations héritées dans les documents et les listings
ShowSharedRiskSignsDescription     = Afficher les signalisations partagées dans les documents et les listings
```

Or `DIGIRISKDOLIBARR_SHOW_INHERITED_RISKSIGNS` et `DIGIRISKDOLIBARR_SHOW_SHARED_RISKSIGNS` n'étaient lues que par `view/digiriskelement/digiriskelement_risksign.php`, jamais par la génération de documents. `RiskSign::loadRiskSignInfos()` se contentait du filtre de l'appelant — `AND t.fk_element = <id>` — et le disait :

```php
//@todo: missing shared and inherited risksigns
```

Résultat : une UT dont toutes les signalisations sont déclarées plus haut sort un tableau vide.

## Le correctif

`loadRiskSignInfos()` collecte maintenant les deux sources manquantes, en miroir de ce que fait `Risk::loadRiskInfos()` :

- **héritées** : remontée de la chaîne `fk_parent`, puis `t.fk_element IN (ancêtres)` ;
- **partagées** : ligne `element_element` de la signalisation vers l'élément.

Trois points de conception :

- **Uniquement pour un document cadré sur un élément** (`$moreParam['object'] instanceof DigiriskElement`). Le document d'évaluation des risques ne passe pas de filtre d'élément et liste déjà toutes les signalisations de l'entité : l'élargir doublonnerait. À noter, `$object->element` vaut le type d'élément (`workunit`, `groupment`…) et non `digiriskelement`, d'où le test sur la classe.
- **La jointure reste sur `fk_element`** dans les deux requêtes ajoutées, pour que le segment continue de nommer l'entité *propriétaire* de la signalisation — c'est à ça que sert son préfixe `S<entité>`.
- **Union sur les clés d'id**, donc une signalisation atteignable deux fois n'est rendue qu'une.

Le document de groupement passe par le même socle et bénéficie du correctif.

## Vérification

Instance locale montée en multi-société. UT `WU2 Gestion pédagogique` (id 5), dont la chaîne d'ancêtres est `GP3` → `GP1` ; seul `GP1` porte une signalisation (`RS1`, « Disponible à l'accueil »). Même élément, même modèle, document réellement généré puis converti en PDF, avant et après :

**Avant**

![avant](https://raw.githubusercontent.com/nicolas-eoxia/digiriskdolibarr/assets/4731/.assets4731/4731_avant.png)

**Après**

![après](https://raw.githubusercontent.com/nicolas-eoxia/digiriskdolibarr/assets/4731/.assets4731/4731_apres.png)

Les quatre combinaisons de réglages ont été vérifiées sur ce même élément :

| INHERITED | SHARED | signalisations rendues |
|---|---|---|
| off | off | 0 — identique au comportement d'avant, aucune régression |
| on | off | `RS1` (GP1, deux niveaux au-dessus) |
| on | on | `RS1` + `RS3` (entité 2), chacune étiquetée avec son entité propriétaire |
| off | on | `RS3` seule |

Le cas « partagé » n'existait dans aucun jeu de données : la ligne `element_element` a été créée pour le test puis supprimée.

## Hors périmètre, repéré au passage

- `DIGIRISKDOLIBARR_SHOW_INHERITED_RISKS_IN_DOCUMENTS` est déclarée dans le descripteur et exposée dans l'admin, mais **n'est lue nulle part** — les risques hérités passent aujourd'hui par des modèles de document dédiés (`workunitdocumentinherited`). Même écart que celui corrigé ici, mais côté risques.
- `RiskSign::fetchRiskSign()` n'a aucun appelant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
