### PR TITLE
#5120 [Risk] fix: le réglage « Risques hérités - Documents » agit de nouveau

### DIFF
--- a/class/riskanalysis/risk.class.php
+++ b/class/riskanalysis/risk.class.php
@@ -234,6 +234,25 @@ class Risk extends SaturneObject
             $array['current']['riskByRiskAssessmentLevels']    = [];
         }
 
+        // ShowInheritedRisksInDocuments promises "Activez cette option pour les afficher dans les
+        // documents", and the element template says its risk table holds, depending on the
+        // settings, the risks of the unit, the inherited ones and the shared ones. The setting lost
+        // its last reader when this collection was standardised on loadRiskInfos() - issue #5120.
+        // Only for a document scoped on one element: the risk assessment document passes no element
+        // filter and already lists every risk of the entity.
+        $array['inheritedDigiriskElements'] = [];
+        if (getDolGlobalInt('DIGIRISKDOLIBARR_SHOW_INHERITED_RISKS_IN_DOCUMENTS') && ($moreParam['object'] ?? null) instanceof DigiriskElement) {
+            $inherited = $this->fetchInheritedRisks($moreParam, $join, $select, $moreSelects);
+            if (!empty($inherited['risks'])) {
+                // Both sides are keyed by risk id, so a risk reachable twice is kept once. The
+                // template states the table is sorted by descending cotation, which the union of
+                // two already sorted fetches would break
+                $array['current']['risks'] += $inherited['risks'];
+                uasort($array['current']['risks'], fn($first, $second) => $second->riskAssessmentCotation <=> $first->riskAssessmentCotation);
+                $array['inheritedDigiriskElements'] = $inherited['digiriskElements'];
+            }
+        }
+
         if (empty($moreParam['tmparray']['showSharedRisk_nocheck'])) {
             $array['shared']['risks']                         = [];
             $array['shared']['riskByCategories']              = [];
@@ -328,6 +347,68 @@ class Risk extends SaturneObject
         }
 
         return $array;
+    }
+
+    /**
+     * Fetch the risks every ancestor of an element carries
+     *
+     * "Inherited" is what the element card shows under ShowInheritedRisksInListings: declared
+     * higher in the tree and applying downwards. The parent chain is read from the validated
+     * elements, which one cached query already holds, so an unvalidated element ends the walk -
+     * its own risks are excluded by the status filter anyway, and those of its parents are then
+     * left out too.
+     *
+     * @param  array  $moreParam   More param (object/filterRisk/filterRiskDate)
+     * @param  string $join        Join on the owning element and the risk assessment
+     * @param  string $select      Extra columns the risk segments read
+     * @param  array  $moreSelects Names of those extra columns
+     * @return array               ['risks' => risks keyed by id, 'digiriskElements' => the ancestors they belong to]
+     * @throws Exception
+     */
+    private function fetchInheritedRisks(array $moreParam, string $join, string $select, array $moreSelects): array
+    {
+        global $conf;
+
+        $digiriskElement  = new DigiriskElement($this->db);
+        $digiriskElements = $digiriskElement->getActiveDigiriskElements('all');
+        if (!is_array($digiriskElements)) {
+            $digiriskElements = [];
+        }
+
+        $ancestorIds = [];
+        $parentId    = (int) $moreParam['object']->fk_parent;
+        // An id already seen means fk_parent forms a cycle: stop rather than loop forever
+        while ($parentId > 0 && !isset($ancestorIds[$parentId])) {
+            $ancestorIds[$parentId] = $parentId;
+            $parentId               = isset($digiriskElements[$parentId]) ? (int) $digiriskElements[$parentId]->fk_parent : 0;
+        }
+
+        if (empty($ancestorIds)) {
+            return ['risks' => [], 'digiriskElements' => []];
+        }
+
+        // The caller filter carries the element condition this fetch replaces. A date condition is
+        // passed apart, in filterRiskDate, and still applies
+        $filter = 't.status = ' . self::STATUS_VALIDATED
+            . ' AND d.status = ' . DigiriskElement::STATUS_VALIDATED
+            . ' AND ra.status = ' . RiskAssessment::STATUS_VALIDATED
+            . ($moreParam['filterRiskDate'] ?? '')
+            . (!empty($moreParam['filterRisk']) ? $moreParam['filterRisk'] : ' AND t.type = \'risk\'')
+            . ' AND t.entity = ' . $conf->entity
+            . ' AND t.fk_element IN (' . implode(',', $ancestorIds) . ')';
+
+        $risks = saturne_fetch_all_object_type('Risk', 'DESC', 'riskAssessmentCotation', 0, 0, ['customsql' => $filter], 'AND', false, false, false, $join, [], $select, $moreSelects);
+
+        // The row renderer names a risk's element from moreParam['digiriskElements']; a document
+        // scoped on one element only knows that one, and would skip every inherited row
+        $ancestorElements = [];
+        foreach ($ancestorIds as $ancestorId) {
+            if (isset($digiriskElements[$ancestorId])) {
+                $ancestorElements[$ancestorId] = ['object' => $digiriskElements[$ancestorId], 'depth' => 0];
+            }
+        }
+
+        return ['risks' => is_array($risks) ? $risks : [], 'digiriskElements' => $ancestorElements];
     }
 
     /**

--- a/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/modules_digiriskdolibarrdocument.php
+++ b/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/modules_digiriskdolibarrdocument.php
@@ -101,7 +101,7 @@ abstract class ModeleODTDigiriskDolibarrDocument extends SaturneDocumentModel
             }
 
             foreach ($riskByRiskAssessmentLevels[$riskAssessmentLevel] as $risk) {
-                $digiriskElement = $digiriskElements[$risk->fk_element];
+                $digiriskElement = $digiriskElements[$risk->fk_element] ?? null;
                 if (empty($digiriskElement)) {
                     continue; // Skip if digirisk element not found (case of GP/UT fiche with spécific id)
                 }
@@ -623,6 +623,11 @@ abstract class ModeleODTDigiriskDolibarrDocument extends SaturneDocumentModel
                 $digiriskElements[$moreParam['object']->id]['object'] = $moreParam['object'];
                 $digiriskElements[$moreParam['object']->id]['depth']  = 0;
                 $moreParam['digiriskElements']                        = $digiriskElements;
+            }
+            // Inherited risks belong to ancestors a document scoped on one element does not know
+            // about; without their element the row renderer skips every one of them
+            if (!empty($loadRiskInfos['inheritedDigiriskElements'])) {
+                $moreParam['digiriskElements'] += $loadRiskInfos['inheritedDigiriskElements'];
             }
             // The trend column only makes sense against a period, and one query serves every row.
             // The ids are read from the objects: loadRiskInfos() merges the current and shared


### PR DESCRIPTION
Closes #5120

Pendant côté risques du correctif #4731 / #5119.

## Le problème

`DIGIRISKDOLIBARR_SHOW_INHERITED_RISKS_IN_DOCUMENTS` est déclaré dans le descripteur et exposé dans l'admin sous « **Risques hérités - Documents** », avec pour description « Activez cette option pour les afficher dans les documents ». Il n'était **lu nulle part** : l'activer ne changeait rien.

Son dernier lecteur était dans le document de rapport d'audit :

```php
$risks = $risk->fetchRisksOrderedByCotation(0, true,
    getDolGlobalInt('DIGIRISKDOLIBARR_SHOW_INHERITED_RISKS_IN_DOCUMENTS'), ...);
```

Il a disparu le 2025-05-20 dans `e66a1c575` (*#4312 [ODT] fix: improve ODT generation*), quand la collecte a été standardisée sur `Risk::loadRiskInfos()` — laquelle gère les risques **partagés** (`showSharedRisk_nocheck`) mais n'a jamais géré les **hérités**. Perte collatérale d'un refactor. Le pendant `..._IN_LISTINGS`, lui, fonctionne toujours.

Or le modèle d'unité de travail annonce en note de bas de page :

> En fonction des réglages cette liste contient les risques de l'unité de travail, les risques hérités, les risques partagés.

## Le correctif

Deux morceaux étaient nécessaires, et le second n'est pas évident :

1. **`Risk::loadRiskInfos()`** collecte les risques des ancêtres (remontée de `fk_parent`), uniquement pour un document cadré sur un élément — le document d'évaluation des risques ne passe pas de filtre d'élément et liste déjà tout. Le résultat est retrié par cotation décroissante, comme le modèle l'annonce, ce que l'union de deux fetches déjà triés casserait.

2. **Il faut aussi donner leurs éléments au renderer.** `setRiskByRiskAssessmentLevelsSegment()` nomme chaque ligne depuis `$moreParam['digiriskElements']`, qu'un document cadré ne peuple qu'avec son propre élément. Sans ce complément, chaque ligne héritée est silencieusement ignorée — après un `Undefined array key` sur PHP 8, la lecture précédant le test d'existence que le code fait juste après. Ce warning est corrigé au passage (`?? null`) ; en local, `display_errors` étant à On, il s'écrivait dans le flux de génération et tronquait le document.

Le défaut du réglage est `0` : rien ne change sans action explicite.

## Vérification

UT `WU2 Gestion pédagogique` (id 5), 1 risque propre ; ses ancêtres `GP3` et `GP1` en portent 18. Documents réellement générés puis convertis en PDF.

**Avant** — seul `S1 - WU2` / `RK23`

![avant](https://raw.githubusercontent.com/nicolas-eoxia/digiriskdolibarr/assets/5120/.assets5120/5120_avant.png)

**Après** — les risques de `S1 - GP1 - Siège Evarisk` apparaissent, triés par cotation

![après](https://raw.githubusercontent.com/nicolas-eoxia/digiriskdolibarr/assets/5120/.assets5120/5120_apres.png)

| réglage | risques rendus dans le document |
|---|---|
| `0` | 1 — identique au comportement d'avant, aucune régression |
| `1` | 19 (1 propre + 18 hérités), éléments correctement nommés |

Le garde-fou a été vérifié sur les trois formes d'appel :

| `$moreParam['object']` | risques | éléments hérités ajoutés |
|---|---|---|
| `DigiriskStandard` (doc évaluation des risques) | 61 | 0 — intact |
| `DigiriskElement` (fiche UT) | 19 | 2 |
| absent | 1 | 0 |

Chargement sans erreur PHP ni JS du document d'évaluation des risques, de la fiche risques d'une UT et de la fiche élément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
