### PR TITLE
#5124 [DigiriskElement] fix: l'onglet Registre définit les paramètres de liste qu'il consomme

### DIFF
--- a/view/digiriskelement/digiriskelement_register.php
+++ b/view/digiriskelement/digiriskelement_register.php
@@ -53,6 +53,23 @@ $subaction  = GETPOST('subaction', 'aZ09');
 $cancel     = GETPOST('cancel', 'aZ09');
 $backtopage = GETPOST('backtopage', 'alpha');
 
+// Get list parameters
+$massaction                                 = GETPOST('massaction', 'alpha'); // The bulk action (combo box choice into lists)
+$toselect                                   = [];
+[$confirm, $contextpage, $optioncss, $mode] = ['', '', '', ''];
+$listParameters                             = saturne_load_list_parameters('digiriskelementregister');
+foreach ($listParameters as $listParameterKey => $listParameter) {
+    $$listParameterKey = $listParameter;
+}
+
+// Get pagination parameters
+[$limit, $page, $offset] = [0, 0, 0];
+[$sortfield, $sortorder] = ['', ''];
+$paginationParameters    = saturne_load_pagination_parameters();
+foreach ($paginationParameters as $paginationParameterKey => $paginationParameter) {
+    $$paginationParameterKey = $paginationParameter;
+}
+
 // Initialize technical objects
 $object           = new DigiriskElement($db);
 $extrafields      = new ExtraFields($db);
@@ -112,6 +129,7 @@ if ($object->id > 0) {
 	$search_array_options = $extrafields->getOptionalsFromPost($object->table_element, '', 'search_');
 	$search_array_options['search_options_digiriskdolibarr_ticket_service'] = $id;
 
+	$searchCategories = [];
 	if (isModEnabled('categorie')) {
 		$searchCategories = GETPOST('search_category_' . $object->element . '_list', 'array');
 	}


### PR DESCRIPTION
Closes #5124

## Le problème

`view/digiriskelement/digiriskelement_register.php` inclut les six templates de liste générique de Saturne (`objectfields_list_*.tpl.php`) **sans définir les variables qu'ils consomment**. Sur PHP 8, l'onglet Registre affiche des pavés de warnings à la place de sa liste.

Aucune affectation de `$massaction`, `$toselect`, `$contextpage`, `$optioncss`, `$mode`, `$limit`, `$offset` ni `$page` dans le fichier, alors que les templates les lisent des dizaines de fois — `$searchCategories` à lui seul y apparaît 14 fois.

Piège de reproduction : il faut un `id` explicite (`?id=1`). Sans lui, `$object->id` vaut 0, tout le bloc est sauté, et la page paraît saine à tort.

## Le correctif

Le bootstrap qu'utilise déjà **`view/accidentinvestigation/accidentinvestigation_list.php`**, l'autre vue du module qui inclut ces mêmes templates :

```php
$listParameters       = saturne_load_list_parameters('digiriskelementregister');
$paginationParameters = saturne_load_pagination_parameters();
```

Des deux vues concernées, `digiriskelement_register.php` était la seule à ne pas l'avoir. Le correctif n'introduit donc pas de motif nouveau, il aligne la vue sur ce qui se fait déjà à côté.

S'y ajoute une init `$searchCategories = []` avant le bloc `isModEnabled('categorie')` : sans elle la variable reste indéfinie quand le module Catégories est désactivé, alors que les templates la lisent.

## Vérification

Même URL, même élément (`?id=1`, le GP1, qui porte un registre) :

| | warnings dans la page |
|---|---|
| `develop` | **34** (66 sur un élément sans registre) |
| avec ce correctif | **0** |

**Avant**

![avant](https://raw.githubusercontent.com/nicolas-eoxia/digiriskdolibarr/assets/5124/.assets5124/register_avant.png)

**Après**

![après](https://raw.githubusercontent.com/nicolas-eoxia/digiriskdolibarr/assets/5124/.assets5124/register_fix.png)

La liste rend maintenant sa ligne (`TS2410-0365`), avec filtre Tag/catégorie, colonnes triables, case de sélection de masse et compteur de filtres.

Également exercés, tous à 0 warning et 0 erreur JS : un élément sans registre (`?id=5`), et un tri + pagination explicites (`?id=1&sortfield=t.ref&sortorder=DESC&limit=10&page=0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
