### PR TITLE
#3214 [Ticket] fix: keep space after TICKET_SERVICE_NAME substitution

### DIFF
--- a/class/actions_digiriskdolibarr.class.php
+++ b/class/actions_digiriskdolibarr.class.php
@@ -565,7 +565,7 @@ class ActionsDigiriskdolibarr
 						let mailContent = $('#message').html()
 						let digiriskElementRefAndLabel = <?php echo json_encode($digiriskelement->ref . ' - ' . $digiriskelement->label); ?>;
 						let digiriskElementId = <?php echo json_encode($digiriskelement->id); ?>;
-						let mailContentWithDigiriskElementLabel = mailContent.replace('__EXTRAFIELD_DIGIRISKDOLIBARR_TICKET_SERVICE_NAME__ ', digiriskElementRefAndLabel);
+						let mailContentWithDigiriskElementLabel = mailContent.replace('__EXTRAFIELD_DIGIRISKDOLIBARR_TICKET_SERVICE_NAME__', digiriskElementRefAndLabel);
 						$('#message').html(mailContentWithDigiriskElementLabel);
 					</script>
 					<?php


### PR DESCRIPTION
## Changements
- L'espace qui suit le tag `__EXTRAFIELD_DIGIRISKDOLIBARR_TICKET_SERVICE_NAME__` dans le modèle de mail était consommé par la substitution : le texte suivant se collait au `REF - Libellé` de l'élément Digirisk.
- La chaîne recherchée ne contient plus l'espace final, il est donc préservé après la valeur substituée.

## Fichiers modifiés
- class/actions_digiriskdolibarr.class.php

## Issue
Close #3214
