### PR TITLE
#3096 [Admin] fix: set the module constants to zero instead of deleting them

### DIFF
--- a/admin/config/actionplan.php
+++ b/admin/config/actionplan.php
@@ -46,7 +46,8 @@ $action     = GETPOST('action', 'alpha');
 $backtopage = GETPOST('backtopage', 'alpha');
 
 // Security check - Protection if external user
-$permissiontoread = $user->rights->digiriskdolibarr->adminpage->read;
+$permissiontoread  = $user->rights->digiriskdolibarr->adminpage->read;
+$permissiontowrite = saturne_check_admin_write_access();
 saturne_check_access($permissiontoread);
 
 /*
@@ -75,6 +76,9 @@ if ($action == 'update_kanban') {
     dolibarr_set_const($db, 'DIGIRISKDOLIBARR_KANBAN_COLUMN_SOURCE', $columnSource, 'chaine', 0, '', $conf->entity);
     setEventMessages($langs->trans('SetupSaved'), null, 'mesgs');
 }
+
+// Actions set_mod, update_mask and the set_/del_ switch of the module constants
+require_once __DIR__ . '/../../../saturne/core/tpl/actions/admin_conf_actions.tpl.php';
 
 /*
  * View
@@ -129,7 +133,7 @@ foreach ($actionPlanLogs as $constName => $transKeys) {
     print digiriskdolibarr_tuto_image('actionplan', $transKeys[2], $langs->trans($transKeys[0]));
     print '</td>';
     print '<td class="center">';
-    print ajax_constantonoff($constName);
+    print saturne_constant_onoff($constName, $permissiontowrite);
     print '</td>';
     print '</tr>';
 }
@@ -156,7 +160,7 @@ print $langs->trans('ActionPlanCarryOverLate');
 print '</td><td>';
 print $langs->trans('ActionPlanCarryOverLateDesc');
 print '</td><td class="center">';
-print ajax_constantonoff('DIGIRISKDOLIBARR_ACTIONPLAN_CARRY_OVER_LATE');
+print saturne_constant_onoff('DIGIRISKDOLIBARR_ACTIONPLAN_CARRY_OVER_LATE', $permissiontowrite);
 print '</td></tr>';
 
 print '</table>';

--- a/admin/config/meteovigilance.php
+++ b/admin/config/meteovigilance.php
@@ -50,7 +50,8 @@ $department = GETPOST('MeteoVigilanceDepartment', 'alpha');
 $cacheTtl   = GETPOSTINT('MeteoVigilanceCacheTTL');
 
 // Security check - Protection if external user
-$permissiontoread = $user->rights->digiriskdolibarr->adminpage->read;
+$permissiontoread  = $user->rights->digiriskdolibarr->adminpage->read;
+$permissiontowrite = saturne_check_admin_write_access();
 saturne_check_access($permissiontoread);
 
 /*
@@ -84,6 +85,9 @@ if ($action == 'refresh') {
     }
 }
 
+// Actions set_mod, update_mask and the set_/del_ switch of the module constants
+require_once __DIR__ . '/../../../saturne/core/tpl/actions/admin_conf_actions.tpl.php';
+
 /*
  * View
  */
@@ -113,7 +117,7 @@ print '</tr>';
 
 print '<tr class="oddeven"><td><label>' . $langs->trans('MeteoVigilanceEnabled') . '</label></td>';
 print '<td>' . $langs->trans('MeteoVigilanceEnabledDescription') . '</td>';
-print '<td>' . ajax_constantonoff('DIGIRISKDOLIBARR_METEOFRANCE_VIGILANCE_ENABLED') . '</td></tr>';
+print '<td>' . saturne_constant_onoff('DIGIRISKDOLIBARR_METEOFRANCE_VIGILANCE_ENABLED', $permissiontowrite) . '</td></tr>';
 
 print '<tr class="oddeven"><td><label for="MeteoVigilanceApiKey">' . $langs->trans('MeteoVigilanceApiKey') . '</label></td>';
 print '<td>' . $langs->trans('MeteoVigilanceApiKeyDescription') . '</td>';

--- a/admin/config/preventionplan.php
+++ b/admin/config/preventionplan.php
@@ -60,7 +60,8 @@ if (isModEnabled('project')) {
 $form = new Form($db);
 
 // Security check - Protection if external user
-$permissiontoread = $user->rights->digiriskdolibarr->adminpage->read;
+$permissiontoread  = $user->rights->digiriskdolibarr->adminpage->read;
+$permissiontowrite = saturne_check_admin_write_access();
 saturne_check_access($permissiontoread);
 
 /*
@@ -270,22 +271,22 @@ print '</tr>';
 
 // Count
 print '<tr class="oddeven"><td><label for="DIGIRISKDOLIBARR_SPREAD_SHOW_SIGNATURE_COUNT">' . $langs->trans('MobilePPSpreadShowCount') . '</label></td>';
-print '<td class="center">' . ajax_constantonoff('DIGIRISKDOLIBARR_SPREAD_SHOW_SIGNATURE_COUNT') . '</td>';
+print '<td class="center">' . saturne_constant_onoff('DIGIRISKDOLIBARR_SPREAD_SHOW_SIGNATURE_COUNT', $permissiontowrite) . '</td>';
 print '</tr>';
 
 // Name
 print '<tr class="oddeven"><td><label for="DIGIRISKDOLIBARR_SPREAD_SHOW_SIGNATORY_NAME">' . $langs->trans('MobilePPSpreadShowName') . '</label></td>';
-print '<td class="center">' . ajax_constantonoff('DIGIRISKDOLIBARR_SPREAD_SHOW_SIGNATORY_NAME') . '</td>';
+print '<td class="center">' . saturne_constant_onoff('DIGIRISKDOLIBARR_SPREAD_SHOW_SIGNATORY_NAME', $permissiontowrite) . '</td>';
 print '</tr>';
 
 // Contact
 print '<tr class="oddeven"><td><label for="DIGIRISKDOLIBARR_SPREAD_SHOW_SIGNATORY_CONTACT">' . $langs->trans('MobilePPSpreadShowContact') . '</label></td>';
-print '<td class="center">' . ajax_constantonoff('DIGIRISKDOLIBARR_SPREAD_SHOW_SIGNATORY_CONTACT') . '</td>';
+print '<td class="center">' . saturne_constant_onoff('DIGIRISKDOLIBARR_SPREAD_SHOW_SIGNATORY_CONTACT', $permissiontowrite) . '</td>';
 print '</tr>';
 
 // Hide Public Note
 print '<tr class="oddeven"><td><label for="DIGIRISKDOLIBARR_SPREAD_HIDE_PUBLIC_NOTE">' . $langs->trans('MobilePPSpreadHidePublicNote') . '</label></td>';
-print '<td class="center">' . ajax_constantonoff('DIGIRISKDOLIBARR_SPREAD_HIDE_PUBLIC_NOTE') . '</td>';
+print '<td class="center">' . saturne_constant_onoff('DIGIRISKDOLIBARR_SPREAD_HIDE_PUBLIC_NOTE', $permissiontowrite) . '</td>';
 print '</tr>';
 
 print '</table>';

--- a/admin/config/ticket_kanban.php
+++ b/admin/config/ticket_kanban.php
@@ -46,7 +46,8 @@ $action     = GETPOST('action', 'alpha');
 $backtopage = GETPOST('backtopage', 'alpha');
 
 // Security check
-$permissiontoread = $user->rights->digiriskdolibarr->adminpage->read;
+$permissiontoread  = $user->rights->digiriskdolibarr->adminpage->read;
+$permissiontowrite = saturne_check_admin_write_access();
 saturne_check_access($permissiontoread);
 
 /*
@@ -79,6 +80,9 @@ if ($action == 'set_closed_limit') {
     header('Location: ' . $_SERVER['PHP_SELF']);
     exit;
 }
+
+// Actions set_mod, update_mask and the set_/del_ switch of the module constants
+require_once __DIR__ . '/../../../saturne/core/tpl/actions/admin_conf_actions.tpl.php';
 
 /*
  * View
@@ -136,7 +140,7 @@ foreach ($ticketKanbanLogs as $constName => $transKeys) {
     }
     print '</td>';
     print '<td class="center">';
-    print ajax_constantonoff($constName);
+    print saturne_constant_onoff($constName, $permissiontowrite);
     print '</td>';
     print '</tr>';
 }

--- a/admin/event.php
+++ b/admin/event.php
@@ -39,6 +39,8 @@ require_once __DIR__ . '/../lib/digiriskdolibarr.lib.php';
 
 saturne_check_access($user->admin);
 
+$permissiontowrite = saturne_check_admin_write_access();
+
 // Load translation files required by the page
 saturne_load_langs(['admin', 'other', 'agenda']);
 
@@ -87,6 +89,9 @@ if ($action == "save" && empty($cancel)) {
     }
 }
 
+// Actions set_mod, update_mask and the set_/del_ switch of the module constants
+require_once __DIR__ . '/../../saturne/core/tpl/actions/admin_conf_actions.tpl.php';
+
 /*
  * View
  */
@@ -127,7 +132,7 @@ print $langs->trans('AdvancedTriggersDescription', ucfirst($module));
 print '</td>';
 
 print '<td class="center">';
-print ajax_constantonoff('DIGIRISKDOLIBARR_ADVANCED_TRIGGER');
+print saturne_constant_onoff('DIGIRISKDOLIBARR_ADVANCED_TRIGGER', $permissiontowrite);
 print '</td>';
 print '</tr>';
 print '</table>';

--- a/admin/setup.php
+++ b/admin/setup.php
@@ -54,7 +54,8 @@ $backtopage = GETPOST('backtopage', 'alpha');
 $value      = GETPOST('value', 'alpha');
 
 // Security check - Protection if external user
-$permissiontoread = $user->rights->digiriskdolibarr->adminpage->read;
+$permissiontoread  = $user->rights->digiriskdolibarr->adminpage->read;
+$permissiontowrite = saturne_check_admin_write_access();
 saturne_check_access($permissiontoread);
 
 /*
@@ -98,6 +99,9 @@ if ($action == 'setMediaInfos') {
 		setEventMessages('MediaDimensionSetWithSuccess', []);
 	}
 }
+
+// Actions set_mod, update_mask and the set_/del_ switch of the module constants
+require_once __DIR__ . '/../../saturne/core/tpl/actions/admin_conf_actions.tpl.php';
 
 /*
  * View
@@ -179,7 +183,7 @@ foreach ($digiriskSettings as $constName => $transKeys) {
     }
     print '</td>';
     print '<td class="center">';
-    print ajax_constantonoff($constName);
+    print saturne_constant_onoff($constName, $permissiontowrite);
     print '</td>';
     print '</tr>';
 }
@@ -220,7 +224,8 @@ foreach ($digiriskMenuSettings as $constName => $transKeys) {
     print '</td>';
     print '<td class="center">';
     // Revert the switch: the constant holds the hidden state, the switch shows the visible one
-    print ajax_constantonoff($constName, [], null, 1);
+    // The reverted switch has no saturne_constant_onoff equivalent, so the zero instead of the deletion is asked here
+    print ajax_constantonoff($constName, [], null, 1, 0, 0, 2, 0, 1);
     print '</td>';
     print '</tr>';
 }

--- a/admin/ticket/ticket.php
+++ b/admin/ticket/ticket.php
@@ -68,7 +68,8 @@ $value      = GETPOST('value', 'alpha');
 $pageY      = GETPOST('page_y', 'int');
 
 // Security check - Protection if external user
-$permissiontoread = $user->rights->digiriskdolibarr->adminpage->read;
+$permissiontoread  = $user->rights->digiriskdolibarr->adminpage->read;
+$permissiontowrite = saturne_check_admin_write_access();
 saturne_check_access($permissiontoread);
 
 /*
@@ -358,6 +359,9 @@ if ($action == 'set_multi_company_ticket_public_interface') {
     exit;
 }
 
+// Actions set_mod, update_mask and the set_/del_ switch of the module constants
+require_once __DIR__ . '/../../../saturne/core/tpl/actions/admin_conf_actions.tpl.php';
+
 /*
  * View
  */
@@ -457,7 +461,7 @@ if ($conf->global->DIGIRISKDOLIBARR_TICKET_ENABLE_PUBLIC_INTERFACE == 1) {
     print digiriskdolibarr_tuto_image('ticket_sst', 'company_logo', $langs->transnoentities("TicketShowCompanyLogo"));
     print '</td>';
     print '<td class="center">';
-    print ajax_constantonoff('DIGIRISKDOLIBARR_TICKET_SHOW_COMPANY_LOGO');
+    print saturne_constant_onoff('DIGIRISKDOLIBARR_TICKET_SHOW_COMPANY_LOGO', $permissiontowrite);
     print '</td>';
     print '<td class="center">';
     print '';
@@ -473,7 +477,7 @@ if ($conf->global->DIGIRISKDOLIBARR_TICKET_ENABLE_PUBLIC_INTERFACE == 1) {
 	print digiriskdolibarr_tuto_image('ticket_sst', 'hide_ref', $langs->transnoentities("TicketDigiriskElementHideRef"));
 	print '</td>';
 	print '<td class="center">';
-	print ajax_constantonoff('DIGIRISKDOLIBARR_TICKET_DIGIRISKELEMENT_HIDE_REF');
+	print saturne_constant_onoff('DIGIRISKDOLIBARR_TICKET_DIGIRISKELEMENT_HIDE_REF', $permissiontowrite);
 	print '</td>';
 	print '<td class="center">';
 	print '';
@@ -488,7 +492,8 @@ if ($conf->global->DIGIRISKDOLIBARR_TICKET_ENABLE_PUBLIC_INTERFACE == 1) {
 		print '<tr class="oddeven"><td>' . $langs->transnoentities("ShowSelectorOnTicketPublicInterface") . '</td>';
 		print '<td class="center"></td>';
 		print '<td class="center">';
-		print ajax_constantonoff('DIGIRISKDOLIBARR_SHOW_MULTI_ENTITY_SELECTOR_ON_TICKET_PUBLIC_INTERFACE', [], 0);
+		// The constant is shared by every entity, so it keeps the ajax component and only asks for the zero instead of the deletion
+		print ajax_constantonoff('DIGIRISKDOLIBARR_SHOW_MULTI_ENTITY_SELECTOR_ON_TICKET_PUBLIC_INTERFACE', [], 0, 0, 0, 0, 2, 0, 1);
 		print '</a>';
 		print '</td>';
 		print '<td class="center">';
@@ -504,7 +509,7 @@ if ($conf->global->DIGIRISKDOLIBARR_TICKET_ENABLE_PUBLIC_INTERFACE == 1) {
 	print '<tr class="oddeven"><td>' . $langs->transnoentities("SendEmailOnTicketSubmit") . '</td>';
 	print '<td class="center"></td>';
 	print '<td class="center">';
-	print ajax_constantonoff('DIGIRISKDOLIBARR_SEND_EMAIL_ON_TICKET_SUBMIT');
+	print saturne_constant_onoff('DIGIRISKDOLIBARR_SEND_EMAIL_ON_TICKET_SUBMIT', $permissiontowrite);
 	print '</td>';
 	print '<td class="center">';
 	print '';


### PR DESCRIPTION
## Contexte

`ajax_constantonoff()` **supprime** la constante quand on bascule l'interrupteur sur OFF. Or `DolibarrModules::insert_const()` ne recree une constante que si sa ligne est absente : un reglage desactive est donc remis a sa valeur par defaut (souvent 1) a la prochaine activation ou mise a jour du module. Le reglage se rallume tout seul, sans que personne n'y touche.

Deux effets de bord supplementaires :
- on ne distingue plus « jamais configure » de « desactive volontairement » ;
- en multi-entite, `constantonoff.php` supprime aussi l'entite 0 quand on travaille sur l'entite 1.

## Changements

- Les interrupteurs des pages d'administration passent par `saturne_constant_onoff()`, qui appelle `ajax_constantonoff()` avec `$setzeroinsteadofdel = 1` : la constante est mise a `0` au lieu d'etre supprimee.
- Les pages concernees declarent `$permissiontowrite = saturne_check_admin_write_access()` et incluent `admin_conf_actions.tpl.php`, qui traite les liens `set_` / `del_` et ecrit lui aussi un `0`. Un utilisateur qui n'a que la lecture voit desormais l'etat du reglage au lieu d'un interrupteur qui ne repondait pas (le composant ajax de Dolibarr est reserve aux admins).
- Deux cas gardent `ajax_constantonoff()` avec le seul parametre `$setzeroinsteadofdel` :
  - `admin/setup.php` (visibilite des menus) parce que l'interrupteur est inverse (`$revertonoff`), ce que l'aide saturne ne sait pas rendre ;
  - `admin/ticket/ticket.php` (selecteur d'entite de l'interface publique) parce que la constante est partagee par toutes les entites (`entity = 0`).

Les conditions de menu utilisent `!getDolGlobalInt('..._MENU_HIDDEN')` : une constante a `0` s'y comporte exactement comme une constante absente, la visibilite des menus est donc inchangee.

## Fichiers modifies

- `admin/config/actionplan.php`
- `admin/config/meteovigilance.php`
- `admin/config/preventionplan.php`
- `admin/config/ticket_kanban.php`
- `admin/event.php`
- `admin/setup.php`
- `admin/ticket/ticket.php`

## Issue

Close #3096
