### PR TITLE
[Mod] chore: ajoute la fiche produit aux notes de la 23.2.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -49,6 +49,15 @@ Description : Cette version sort du bureau. Les plans de prévention et les perm
 
 ![Le tableau de bord des risques](https://raw.githubusercontent.com/nicolas-eoxia/digiriskdolibarr/assets/release-23.2.0/.shots/23.2.0-tableau-bord-risques.png)
 
+### Fiche produit
+
+* Nouvelle **fiche d'instruction HSE** sur le produit : six chapitres — identification, sécurité, mode d'emploi simplifié, qualification et habilitation, hygiène et nettoyage, maintenance et contrôles — éditables directement dans l'onglet.
+* Chaque chapitre est **configurable** depuis la nouvelle page de configuration produit : libellé, icône, couleur et description par défaut.
+* Onglet **Risques et protections** du produit, avec sa table d'association et les catégories de danger.
+* Le **PDF produit** reprend dynamiquement les risques et protections, ainsi que l'image du produit.
+
+![L'onglet Fiche d'Instruction sur un produit](https://raw.githubusercontent.com/nicolas-eoxia/digiriskdolibarr/assets/issue-5103/.shots/5103-onglet-fiche-instruction.png)
+
 ### Arborescence GP/UT
 
 * **Refonte du panneau de navigation** : glisser-déposer, renommage en ligne, ajout et suppression rapides.


### PR DESCRIPTION
Les notes de la 23.2.0 ne mentionnaient pas la fiche produit, alors que six commits de la version la portent : `feat(product): add product HSE instruction sheet and model`, la creation de la page de configuration produit, la table d'association produit-risque, la reprise dynamique des risques et protections dans le PDF produit et l'ajout de l'image du produit.

La section decrit les six chapitres configurables de la fiche d'instruction, l'onglet risques et protections, et porte une capture de l'onglet sur un produit.

Le corps de la GitHub Release 23.2.0 est mis a jour en parallele, puisqu'il reprend ce fichier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)