### PR TITLE
#5132 [Document] fix: déplace setDigiriskElementsSegment du rapport d'audit hors de la classe mère

### DIFF
--- a/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/auditreportdocument/doc_auditreportdocument_odt.modules.php
+++ b/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/auditreportdocument/doc_auditreportdocument_odt.modules.php
@@ -69,7 +69,80 @@ class doc_auditreportdocument_odt extends ModeleODTDigiriskDolibarrDocument
             $moreParam['digiriskElementChanges'] = $digiriskElement->loadDigiriskElementChanges($moreParam);
         }
 
-        return parent::fillTagsLines($odfHandler, $outputLangs, $moreParam);
+        $result = parent::fillTagsLines($odfHandler, $outputLangs, $moreParam);
+        if ($result < 0) {
+            return $result;
+        }
+
+        try {
+            static::setDigiriskElementChangesSegment($odfHandler, $outputLangs, $moreParam);
+        } catch (OdfException $e) {
+            $this->error = $e->getMessage();
+            dol_syslog($this->error, LOG_WARNING);
+            return -1;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Set digirisk element changes segment
+     *
+     * Lists the GP/UT added, modified or deleted over the period. The synthesis only ever gave a
+     * count, which does not tell the reader which work unit moved, and the deleted ones vanished
+     * from the report entirely. The segment only exists in the audit report template, so the
+     * method lives here and not in the parent class where its name collided with the risk
+     * assessment document one.
+     *
+     * @param Odf       $odfHandler  Object builder odf library
+     * @param Translate $outputLangs Lang object to use for output
+     * @param array     $moreParam   More param (digiriskElementChanges)
+     *
+     * @throws OdfException
+     * @throws Exception
+     */
+    private static function setDigiriskElementChangesSegment(Odf $odfHandler, Translate $outputLangs, array $moreParam): void
+    {
+        $foundTagForLines = 1;
+        try {
+            $listLines = $odfHandler->setSegment('digiriskElements');
+        } catch (OdfExceptionSegmentNotFound $e) {
+            // We may arrive here if tags for lines not present into template
+            $foundTagForLines = 0;
+            $listLines        = '';
+            dol_syslog($e->getMessage());
+        }
+
+        if ($foundTagForLines) {
+            $digiriskElementChanges = $moreParam['digiriskElementChanges'] ?? [];
+            if (empty($digiriskElementChanges)) {
+                $tmpArray = [
+                    'digiriskElementRefLabel' => ' ',
+                    'digiriskElementType'     => ' ',
+                    'digiriskElementState'    => $outputLangs->transnoentities('NoDigiriskElementChange'),
+                    'digiriskElementDate'     => ' '
+                ];
+
+                static::setTmpArrayVars($tmpArray, $listLines, $outputLangs);
+                $odfHandler->mergeSegment($listLines);
+                return;
+            }
+
+            foreach ($digiriskElementChanges as $digiriskElementChange) {
+                $digiriskElement = $digiriskElementChange['object'];
+                $typeKey         = $digiriskElement->element_type == 'groupment' ? 'Groupment' : 'WorkUnit';
+
+                $tmpArray = [
+                    'digiriskElementRefLabel' => 'S' . $digiriskElement->entity . ' - ' . $digiriskElement->ref . ' - ' . $digiriskElement->label,
+                    'digiriskElementType'     => $outputLangs->transnoentities($typeKey),
+                    'digiriskElementState'    => $outputLangs->transnoentities('DigiriskElement' . $digiriskElementChange['state']),
+                    'digiriskElementDate'     => dol_print_date($digiriskElementChange['date'], 'day', 'tzuser')
+                ];
+
+                static::setTmpArrayVars($tmpArray, $listLines, $outputLangs);
+            }
+            $odfHandler->mergeSegment($listLines);
+        }
     }
 
     /**

--- a/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/modules_digiriskdolibarrdocument.php
+++ b/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/modules_digiriskdolibarrdocument.php
@@ -177,64 +177,6 @@ abstract class ModeleODTDigiriskDolibarrDocument extends SaturneDocumentModel
     }
 
     /**
-     * Set digirisk elements segment — issue #4459
-     *
-     * Lists the GP/UT added, modified or deleted over the period. The synthesis only ever gave a
-     * count, which does not tell the reader which work unit moved, and the deleted ones vanished
-     * from the report entirely.
-     *
-     * @param Odf       $odfHandler  Object builder odf library
-     * @param Translate $outputLangs Lang object to use for output
-     * @param array     $moreParam   More param (digiriskElementChanges)
-     *
-     * @throws OdfException
-     * @throws Exception
-     */
-    protected static function setDigiriskElementsSegment(Odf $odfHandler, Translate $outputLangs, array $moreParam): void
-    {
-        $foundTagForLines = 1;
-        try {
-            $listLines = $odfHandler->setSegment('digiriskElements');
-        } catch (OdfExceptionSegmentNotFound $e) {
-            // We may arrive here if tags for lines not present into template
-            $foundTagForLines = 0;
-            $listLines        = '';
-            dol_syslog($e->getMessage());
-        }
-
-        if ($foundTagForLines) {
-            $digiriskElementChanges = $moreParam['digiriskElementChanges'] ?? [];
-            if (empty($digiriskElementChanges)) {
-                $tmpArray = [
-                    'digiriskElementRefLabel' => ' ',
-                    'digiriskElementType'     => ' ',
-                    'digiriskElementState'    => $outputLangs->transnoentities('NoDigiriskElementChange'),
-                    'digiriskElementDate'     => ' '
-                ];
-
-                static::setTmpArrayVars($tmpArray, $listLines, $outputLangs);
-                $odfHandler->mergeSegment($listLines);
-                return;
-            }
-
-            foreach ($digiriskElementChanges as $digiriskElementChange) {
-                $digiriskElement = $digiriskElementChange['object'];
-                $typeKey         = $digiriskElement->element_type == 'groupment' ? 'Groupment' : 'WorkUnit';
-
-                $tmpArray = [
-                    'digiriskElementRefLabel' => 'S' . $digiriskElement->entity . ' - ' . $digiriskElement->ref . ' - ' . $digiriskElement->label,
-                    'digiriskElementType'     => $outputLangs->transnoentities($typeKey),
-                    'digiriskElementState'    => $outputLangs->transnoentities('DigiriskElement' . $digiriskElementChange['state']),
-                    'digiriskElementDate'     => dol_print_date($digiriskElementChange['date'], 'day', 'tzuser')
-                ];
-
-                static::setTmpArrayVars($tmpArray, $listLines, $outputLangs);
-            }
-            $odfHandler->mergeSegment($listLines);
-        }
-    }
-
-    /**
      * Set risk tasks segment
      *
      * @param Translate $outputLangs Lang object to use for output
@@ -662,8 +604,6 @@ abstract class ModeleODTDigiriskDolibarrDocument extends SaturneDocumentModel
                     }
                 }
             }
-
-            static::setDigiriskElementsSegment($odfHandler, $outputLangs, $moreParam);
 
             $moreParam['riskSigns'] = $loadRiskSignInfos['riskSigns'];
             static::setRiskSignsSegment($odfHandler, $outputLangs, $moreParam);


### PR DESCRIPTION
## Problème

Depuis #4459, la page de génération du DU tombe en erreur fatale et plus aucun document unique ne peut être généré :

```
PHP Fatal error:  Access level to doc_riskassessmentdocument_odt::setDigiriskElementsSegment()
must be protected (as in class ModeleODTDigiriskDolibarrDocument) or weaker
```

`ModeleODTDigiriskDolibarrDocument` a reçu une méthode `setDigiriskElementsSegment()` en `protected`, nom déjà pris par une méthode `private` de `doc_riskassessmentdocument_odt` depuis #4377. PHP refuse de réduire la visibilité héritée : la classe ne se charge plus.

Les deux méthodes n'ont pas la même fonction :

| | classe mère (#4459) | `doc_riskassessmentdocument_odt` |
|---|---|---|
| contenu | GP/UT **modifiés** sur la période | GP/UT du DUER |
| source | `$moreParam['digiriskElementChanges']` | `$moreParam['digiriskElements']` |
| segment ODT | `digiriskElements`, présent uniquement dans le modèle du rapport d'audit | `currentDigiriskElements` / `sharedDigiriskElements` |

## Correction

La méthode est spécifique au rapport d'audit : elle part dans `doc_auditreportdocument_odt` sous le nom `setDigiriskElementChangesSegment()`, avec son appel, au lieu de tourner depuis le `fillTagsLines()` générique pour tous les documents qui héritent de la classe mère. Aucun changement de comportement pour le rapport d'audit.

## Tests

Instance bac à sable sur ce commit, base locale partagée :

- page `digiriskstandard_riskassessmentdocument.php` : plus d'erreur fatale ;
- génération du DU : `20260909_DU11_Evarisk.odt` produit (1 Mo), aucune balise `BEGIN row.*` résiduelle, listes des GP/UT remplies ;
- génération du rapport d'audit : `20260909_DU_ARD1_Evarisk.odt` produit, tableau « Liste des groupements et unités de travail ajoutés, modifiés ou supprimés » toujours rempli.

Closes #5132

🤖 Generated with [Claude Code](https://claude.com/claude-code)
