### PR TITLE
[Mod] chore: version 23.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ### Version
 
-- Version : 23.2.0
+- Version : 23.2.1
 - PHP : 7.4.33
 - Compatibilité : Dolibarr 23.0.0 - 23.0.3
 - Saturne Framework : 23.1.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-# [Digirisk] [23.2.0] - Vigilance météo - Terrain sur mobile - PAPRIPACT par année
+# [Digirisk] [23.2.1] - Vigilance météo - Terrain sur mobile - PAPRIPACT par année
 
 Description : Cette version sort du bureau. Les plans de prévention et les permis de feu se créent et se signent depuis un téléphone, une application web progressive les regroupe, et un nouveau module de vigilance météo alerte l'établissement en cas d'épisode orange ou rouge. Côté pilotage, le PAPRIPACT s'organise par année avec report des actions en retard, et la carte ticket gagne un véritable fil de conversation.
 
@@ -91,6 +91,7 @@ Description : Cette version sort du bureau. Les plans de prévention et les perm
 * Identifiants convertis avec `GETPOSTINT` sur les plans de prévention et les permis de feu, pour éviter les `TypeError` de `fetch()` sur PHP 8.
 * Correction des erreurs de type à la création de ticket public, au chargement d'un objet sans identifiant, et des avertissements PHP 8 à la création de tâche.
 * Vrais messages d'erreur lors de la génération de l'archive ZIP du document unique.
+* **Correction d'une erreur fatale qui empêchait toute génération du document unique** : une méthode déclarée `protected` dans la classe parente des modèles de document et redéclarée `private` dans le modèle ODT du document unique rendait la classe inchargeable. La méthode a été déplacée dans le modèle du rapport d'audit, à qui elle appartient.
 
 ### Interface
 
@@ -104,4 +105,4 @@ Description : Cette version sort du bureau. Les plans de prévention et les perm
 * Le module s'appuie sur **Saturne 23.1.0**.
 * Les dépendances communes — ECM, Agenda, FCKeditor, Catégories — sont désormais déclarées par Saturne.
 
-## Comparaison des versions [23.1.0](https://github.com/Evarisk/Digirisk/compare/23.1.0...23.2.0) et 23.2.0
+## Comparaison des versions [23.1.0](https://github.com/Evarisk/Digirisk/compare/23.1.0...23.2.1) et 23.2.1

--- a/core/modules/modDigiriskDolibarr.class.php
+++ b/core/modules/modDigiriskDolibarr.class.php
@@ -387,7 +387,7 @@ class modDigiriskdolibarr extends DolibarrModules
 		$this->descriptionlong = "Digirisk";
 		$this->editor_name     = 'Evarisk';
 		$this->editor_url      = 'https://evarisk.com';
-		$this->version         = '23.2.0';
+		$this->version         = '23.2.1';
 		$this->const_name      = 'MAIN_MODULE_' . strtoupper($this->name);
 		$this->picto           = 'digiriskdolibarr_color@digiriskdolibarr';
 

--- a/core/triggers/interface_99_modDigiriskdolibarr_DigiriskdolibarrTriggers.class.php
+++ b/core/triggers/interface_99_modDigiriskdolibarr_DigiriskdolibarrTriggers.class.php
@@ -72,7 +72,7 @@ class InterfaceDigiriskdolibarrTriggers extends DolibarrTriggers
 		$this->name        = preg_replace('/^Interface/i', '', get_class($this));
 		$this->family      = "demo";
 		$this->description = "Digiriskdolibarr triggers.";
-		$this->version     = '23.2.0';
+		$this->version     = '23.2.1';
 		$this->picto       = 'digiriskdolibarr@digiriskdolibarr';
 	}
 


### PR DESCRIPTION
Correctif de publication : la **23.2.0 est retiree**, son zip livrait un module dont le document unique ne peut pas etre genere.

La classe parente des modeles de document declarait `setDigiriskElementsSegment()` en `protected`, le modele ODT du document unique la redeclarait en `private` : PHP refuse de charger la classe, et plus aucun DU ne sort. Le correctif (#5132 / PR #5133, merge `3738b581`) a deplace la methode dans le modele du rapport d'audit ; il est arrive vingt-cinq minutes apres la publication du tag 23.2.0.

Les notes de la 23.2.0 sont reprises **telles quelles** — la 23.2.1 devient la publication effective de tout ce travail — et completees d'une ligne sur ce correctif.

🤖 Generated with [Claude Code](https://claude.com/claude-code)