### PR TITLE
[Mod] release: 23.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ### Version
 
-- Version : 23.2.0
+- Version : 23.2.1
 - PHP : 7.4.33
 - Compatibilité : Dolibarr 23.0.0 - 23.0.3
 - Saturne Framework : 23.1.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-# [Digirisk] [23.2.0] - Vigilance météo - Terrain sur mobile - PAPRIPACT par année
+# [Digirisk] [23.2.1] - Vigilance météo - Terrain sur mobile - PAPRIPACT par année
 
 Description : Cette version sort du bureau. Les plans de prévention et les permis de feu se créent et se signent depuis un téléphone, une application web progressive les regroupe, et un nouveau module de vigilance météo alerte l'établissement en cas d'épisode orange ou rouge. Côté pilotage, le PAPRIPACT s'organise par année avec report des actions en retard, et la carte ticket gagne un véritable fil de conversation.
 
@@ -91,6 +91,7 @@ Description : Cette version sort du bureau. Les plans de prévention et les perm
 * Identifiants convertis avec `GETPOSTINT` sur les plans de prévention et les permis de feu, pour éviter les `TypeError` de `fetch()` sur PHP 8.
 * Correction des erreurs de type à la création de ticket public, au chargement d'un objet sans identifiant, et des avertissements PHP 8 à la création de tâche.
 * Vrais messages d'erreur lors de la génération de l'archive ZIP du document unique.
+* **Correction d'une erreur fatale qui empêchait toute génération du document unique** : une méthode déclarée `protected` dans la classe parente des modèles de document et redéclarée `private` dans le modèle ODT du document unique rendait la classe inchargeable. La méthode a été déplacée dans le modèle du rapport d'audit, à qui elle appartient.
 
 ### Interface
 
@@ -104,4 +105,4 @@ Description : Cette version sort du bureau. Les plans de prévention et les perm
 * Le module s'appuie sur **Saturne 23.1.0**.
 * Les dépendances communes — ECM, Agenda, FCKeditor, Catégories — sont désormais déclarées par Saturne.
 
-## Comparaison des versions [23.1.0](https://github.com/Evarisk/Digirisk/compare/23.1.0...23.2.0) et 23.2.0
+## Comparaison des versions [23.1.0](https://github.com/Evarisk/Digirisk/compare/23.1.0...23.2.1) et 23.2.1

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -49,6 +49,15 @@ Description : Cette version sort du bureau. Les plans de prévention et les perm
 
 ![Le tableau de bord des risques](https://raw.githubusercontent.com/nicolas-eoxia/digiriskdolibarr/assets/release-23.2.0/.shots/23.2.0-tableau-bord-risques.png)
 
+### Fiche produit
+
+* Nouvelle **fiche d'instruction HSE** sur le produit : six chapitres — identification, sécurité, mode d'emploi simplifié, qualification et habilitation, hygiène et nettoyage, maintenance et contrôles — éditables directement dans l'onglet.
+* Chaque chapitre est **configurable** depuis la nouvelle page de configuration produit : libellé, icône, couleur et description par défaut.
+* Onglet **Risques et protections** du produit, avec sa table d'association et les catégories de danger.
+* Le **PDF produit** reprend dynamiquement les risques et protections, ainsi que l'image du produit.
+
+![L'onglet Fiche d'Instruction sur un produit](https://raw.githubusercontent.com/nicolas-eoxia/digiriskdolibarr/assets/issue-5103/.shots/5103-onglet-fiche-instruction.png)
+
 ### Arborescence GP/UT
 
 * **Refonte du panneau de navigation** : glisser-déposer, renommage en ligne, ajout et suppression rapides.

--- a/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/auditreportdocument/doc_auditreportdocument_odt.modules.php
+++ b/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/auditreportdocument/doc_auditreportdocument_odt.modules.php
@@ -69,7 +69,80 @@ class doc_auditreportdocument_odt extends ModeleODTDigiriskDolibarrDocument
             $moreParam['digiriskElementChanges'] = $digiriskElement->loadDigiriskElementChanges($moreParam);
         }
 
-        return parent::fillTagsLines($odfHandler, $outputLangs, $moreParam);
+        $result = parent::fillTagsLines($odfHandler, $outputLangs, $moreParam);
+        if ($result < 0) {
+            return $result;
+        }
+
+        try {
+            static::setDigiriskElementChangesSegment($odfHandler, $outputLangs, $moreParam);
+        } catch (OdfException $e) {
+            $this->error = $e->getMessage();
+            dol_syslog($this->error, LOG_WARNING);
+            return -1;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Set digirisk element changes segment
+     *
+     * Lists the GP/UT added, modified or deleted over the period. The synthesis only ever gave a
+     * count, which does not tell the reader which work unit moved, and the deleted ones vanished
+     * from the report entirely. The segment only exists in the audit report template, so the
+     * method lives here and not in the parent class where its name collided with the risk
+     * assessment document one.
+     *
+     * @param Odf       $odfHandler  Object builder odf library
+     * @param Translate $outputLangs Lang object to use for output
+     * @param array     $moreParam   More param (digiriskElementChanges)
+     *
+     * @throws OdfException
+     * @throws Exception
+     */
+    private static function setDigiriskElementChangesSegment(Odf $odfHandler, Translate $outputLangs, array $moreParam): void
+    {
+        $foundTagForLines = 1;
+        try {
+            $listLines = $odfHandler->setSegment('digiriskElements');
+        } catch (OdfExceptionSegmentNotFound $e) {
+            // We may arrive here if tags for lines not present into template
+            $foundTagForLines = 0;
+            $listLines        = '';
+            dol_syslog($e->getMessage());
+        }
+
+        if ($foundTagForLines) {
+            $digiriskElementChanges = $moreParam['digiriskElementChanges'] ?? [];
+            if (empty($digiriskElementChanges)) {
+                $tmpArray = [
+                    'digiriskElementRefLabel' => ' ',
+                    'digiriskElementType'     => ' ',
+                    'digiriskElementState'    => $outputLangs->transnoentities('NoDigiriskElementChange'),
+                    'digiriskElementDate'     => ' '
+                ];
+
+                static::setTmpArrayVars($tmpArray, $listLines, $outputLangs);
+                $odfHandler->mergeSegment($listLines);
+                return;
+            }
+
+            foreach ($digiriskElementChanges as $digiriskElementChange) {
+                $digiriskElement = $digiriskElementChange['object'];
+                $typeKey         = $digiriskElement->element_type == 'groupment' ? 'Groupment' : 'WorkUnit';
+
+                $tmpArray = [
+                    'digiriskElementRefLabel' => 'S' . $digiriskElement->entity . ' - ' . $digiriskElement->ref . ' - ' . $digiriskElement->label,
+                    'digiriskElementType'     => $outputLangs->transnoentities($typeKey),
+                    'digiriskElementState'    => $outputLangs->transnoentities('DigiriskElement' . $digiriskElementChange['state']),
+                    'digiriskElementDate'     => dol_print_date($digiriskElementChange['date'], 'day', 'tzuser')
+                ];
+
+                static::setTmpArrayVars($tmpArray, $listLines, $outputLangs);
+            }
+            $odfHandler->mergeSegment($listLines);
+        }
     }
 
     /**

--- a/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/modules_digiriskdolibarrdocument.php
+++ b/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/modules_digiriskdolibarrdocument.php
@@ -177,64 +177,6 @@ abstract class ModeleODTDigiriskDolibarrDocument extends SaturneDocumentModel
     }
 
     /**
-     * Set digirisk elements segment — issue #4459
-     *
-     * Lists the GP/UT added, modified or deleted over the period. The synthesis only ever gave a
-     * count, which does not tell the reader which work unit moved, and the deleted ones vanished
-     * from the report entirely.
-     *
-     * @param Odf       $odfHandler  Object builder odf library
-     * @param Translate $outputLangs Lang object to use for output
-     * @param array     $moreParam   More param (digiriskElementChanges)
-     *
-     * @throws OdfException
-     * @throws Exception
-     */
-    protected static function setDigiriskElementsSegment(Odf $odfHandler, Translate $outputLangs, array $moreParam): void
-    {
-        $foundTagForLines = 1;
-        try {
-            $listLines = $odfHandler->setSegment('digiriskElements');
-        } catch (OdfExceptionSegmentNotFound $e) {
-            // We may arrive here if tags for lines not present into template
-            $foundTagForLines = 0;
-            $listLines        = '';
-            dol_syslog($e->getMessage());
-        }
-
-        if ($foundTagForLines) {
-            $digiriskElementChanges = $moreParam['digiriskElementChanges'] ?? [];
-            if (empty($digiriskElementChanges)) {
-                $tmpArray = [
-                    'digiriskElementRefLabel' => ' ',
-                    'digiriskElementType'     => ' ',
-                    'digiriskElementState'    => $outputLangs->transnoentities('NoDigiriskElementChange'),
-                    'digiriskElementDate'     => ' '
-                ];
-
-                static::setTmpArrayVars($tmpArray, $listLines, $outputLangs);
-                $odfHandler->mergeSegment($listLines);
-                return;
-            }
-
-            foreach ($digiriskElementChanges as $digiriskElementChange) {
-                $digiriskElement = $digiriskElementChange['object'];
-                $typeKey         = $digiriskElement->element_type == 'groupment' ? 'Groupment' : 'WorkUnit';
-
-                $tmpArray = [
-                    'digiriskElementRefLabel' => 'S' . $digiriskElement->entity . ' - ' . $digiriskElement->ref . ' - ' . $digiriskElement->label,
-                    'digiriskElementType'     => $outputLangs->transnoentities($typeKey),
-                    'digiriskElementState'    => $outputLangs->transnoentities('DigiriskElement' . $digiriskElementChange['state']),
-                    'digiriskElementDate'     => dol_print_date($digiriskElementChange['date'], 'day', 'tzuser')
-                ];
-
-                static::setTmpArrayVars($tmpArray, $listLines, $outputLangs);
-            }
-            $odfHandler->mergeSegment($listLines);
-        }
-    }
-
-    /**
      * Set risk tasks segment
      *
      * @param Translate $outputLangs Lang object to use for output
@@ -662,8 +604,6 @@ abstract class ModeleODTDigiriskDolibarrDocument extends SaturneDocumentModel
                     }
                 }
             }
-
-            static::setDigiriskElementsSegment($odfHandler, $outputLangs, $moreParam);
 
             $moreParam['riskSigns'] = $loadRiskSignInfos['riskSigns'];
             static::setRiskSignsSegment($odfHandler, $outputLangs, $moreParam);

--- a/core/modules/modDigiriskDolibarr.class.php
+++ b/core/modules/modDigiriskDolibarr.class.php
@@ -387,7 +387,7 @@ class modDigiriskdolibarr extends DolibarrModules
 		$this->descriptionlong = "Digirisk";
 		$this->editor_name     = 'Evarisk';
 		$this->editor_url      = 'https://evarisk.com';
-		$this->version         = '23.2.0';
+		$this->version         = '23.2.1';
 		$this->const_name      = 'MAIN_MODULE_' . strtoupper($this->name);
 		$this->picto           = 'digiriskdolibarr_color@digiriskdolibarr';
 

--- a/core/triggers/interface_99_modDigiriskdolibarr_DigiriskdolibarrTriggers.class.php
+++ b/core/triggers/interface_99_modDigiriskdolibarr_DigiriskdolibarrTriggers.class.php
@@ -72,7 +72,7 @@ class InterfaceDigiriskdolibarrTriggers extends DolibarrTriggers
 		$this->name        = preg_replace('/^Interface/i', '', get_class($this));
 		$this->family      = "demo";
 		$this->description = "Digiriskdolibarr triggers.";
-		$this->version     = '23.2.0';
+		$this->version     = '23.2.1';
 		$this->picto       = 'digiriskdolibarr@digiriskdolibarr';
 	}
 


### PR DESCRIPTION
Publication de la version **23.2.1**, qui remplace la 23.2.0 retiree.

La 23.2.0 livrait un module dont le **document unique ne peut pas etre genere** : collision de visibilite entre une methode `protected` de la classe parente des modeles de document et sa redeclaration `private` dans le modele ODT du DU. Le correctif (#5132) est arrive vingt-cinq minutes apres le tag.

Les notes reprennent l'integralite de la 23.2.0, completees de ce correctif.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
