### PR TITLE
#5137 [Document] fix: warnings PHP 8 à la génération du document unique

### DIFF
--- a/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/riskassessmentdocument/doc_riskassessmentdocument_odt.modules.php
+++ b/core/modules/digiriskdolibarr/digiriskdolibarrdocuments/riskassessmentdocument/doc_riskassessmentdocument_odt.modules.php
@@ -530,9 +530,9 @@ class doc_riskassessmentdocument_odt extends ModeleODTDigiriskDolibarrDocument
                 $tmpArray['companyName']         = dolibarr_get_const($this->db, 'MAIN_INFO_SOCIETE_NOM', $entity);
                 $tmpArray['siret']               = dolibarr_get_const($this->db, 'MAIN_INFO_SIRET', $entity);
                 $tmpArray['nbEmployeesInvolved'] = $nbEvaluatorByEntities[$entity] ?? 0;
-                $tmpArray['nbTotalRisks']        = $riskByEntity['nbTotalRisks'] ?: 0;
+                $tmpArray['nbTotalRisks']        = $riskByEntity['nbTotalRisks'] ?? 0;
                 foreach ($riskAssessmentCotationTypes as $i => $riskAssessmentCotationType) {
-                    $tmpArray['nb' . $riskAssessmentCotationType] = $riskByEntity[$i] ?: 0;
+                    $tmpArray['nb' . $riskAssessmentCotationType] = $riskByEntity[$i] ?? 0;
                 }
 
                 static::setTmpArrayVars($tmpArray, $listLines, $outputLangs);

--- a/view/digiriskstandard/digiriskstandard_riskassessmentdocument.php
+++ b/view/digiriskstandard/digiriskstandard_riskassessmentdocument.php
@@ -177,7 +177,7 @@ if (empty($resHook)) {
         $outputlangs = $langs;
         $newlang     = '';
 
-        if ($conf->global->MAIN_MULTILANGS && empty($newlang) && GETPOST('lang_id', 'aZ09')) $newlang = GETPOST('lang_id', 'aZ09');
+        if (getDolGlobalInt('MAIN_MULTILANGS') && empty($newlang) && GETPOST('lang_id', 'aZ09')) $newlang = GETPOST('lang_id', 'aZ09');
         if ( ! empty($newlang)) {
             $outputlangs = new Translate("", $conf);
             $outputlangs->setDefaultLang($newlang);

--- a/view/firepermit/firepermit_card.php
+++ b/view/firepermit/firepermit_card.php
@@ -1566,10 +1566,10 @@ if ((empty($action) || ($action != 'create' && $action != 'edit'))) {
         // Define output language
         $outputlangs = $langs;
         $newlang     = '';
-        if ($conf->global->MAIN_MULTILANGS && empty($newlang) && ! empty($_REQUEST['lang_id'])) {
+        if (getDolGlobalInt('MAIN_MULTILANGS') && empty($newlang) && ! empty($_REQUEST['lang_id'])) {
             $newlang = $_REQUEST['lang_id'];
         }
-        if ($conf->global->MAIN_MULTILANGS && empty($newlang)) {
+        if (getDolGlobalInt('MAIN_MULTILANGS') && empty($newlang)) {
             $newlang = $object->thirdparty->default_lang;
         }
 


### PR DESCRIPTION
## Problème

Deux warnings PHP 8 à chaque génération du document unique.

**`Undefined property: stdClass::$MAIN_MULTILANGS`** — la constante n'est pas dans `llx_const` tant que le multilingue n'a pas été activé, et l'accès à la propriété n'était pas gardé. Même motif corrigé sur les deux tests de la fiche permis de feu (`preventionplan_card.php` utilisait déjà `!empty()`).

**`Undefined array key 3`** dans `setRiskByEntitiesSegment()` — les compteurs par cotation étaient lus avec `?:`, qui ne protège pas d'une clé absente. `Risk::loadRiskInfos()` (`risk.class.php:305-306`, `:319`) ne crée la clé d'une cotation que si un risque de ce niveau existe : une entité sans risque rouge déclenchait le warning.

## Correction

`getDolGlobalInt('MAIN_MULTILANGS')` pour le premier, `??` au lieu de `?:` pour le second (y compris sur `nbTotalRisks`, par cohérence).

## Tests

Instance bac à sable sur ce commit, génération complète du DU : les deux warnings ont disparu du `php_error.log` et de la page, le document est produit normalement.

Restent, à la même génération, des warnings qui ne viennent pas de ce module : `Undefined array key "specimen"` dans `saturne/core/modules/saturne/modules_saturne.php:785` et `:807`, et `Undefined array key 2` dans `htdocs/core/lib/functions.lib.php:190` (multidir_output d'une entité multicompany). Ils feront l'objet d'un suivi séparé.

Closes #5137

🤖 Generated with [Claude Code](https://claude.com/claude-code)
