### PR TITLE
[Mod] chore: version 23.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@
 
 ### Version
 
-- Version : 23.2.1
+- Version : 23.2.2
 - PHP : 7.4.33
 - Compatibilité : Dolibarr 23.0.0 - 23.0.3
-- Saturne Framework : 23.1.0
+- Saturne Framework : 23.1.1
 
 ## Liens
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,108 +1,18 @@
-# [Digirisk] [23.2.1] - Vigilance météo - Terrain sur mobile - PAPRIPACT par année
+# [Digirisk] [23.2.2] - Pages de configuration réparées
 
-Description : Cette version sort du bureau. Les plans de prévention et les permis de feu se créent et se signent depuis un téléphone, une application web progressive les regroupe, et un nouveau module de vigilance météo alerte l'établissement en cas d'épisode orange ou rouge. Côté pilotage, le PAPRIPACT s'organise par année avec report des actions en retard, et la carte ticket gagne un véritable fil de conversation.
+Description : Version corrective. Elle rétablit l'accès aux sept pages de configuration du module, inaccessibles depuis la 23.2.0, et supprime les avertissements PHP 8 restants à la génération du document unique.
 
-## Nouvelles fonctionnalités et innovations
-
-### Vigilance météo
-
-* Nouveau **suivi de la vigilance Météo-France** : lecture du flux DPVigilance, résolution du département de l'établissement et mise en cache avec durée de vie réglable.
-* **Carte de vigilance sur le tableau de bord** : panneau coloré, pastille par phénomène, et bouton de rafraîchissement manuel.
-* **Bandeau d'alerte orange ou rouge** affiché en haut des pages via un hook, pour que personne ne passe à côté.
-* Page de configuration dédiée — clé d'API, département, durée du cache — et activation par un simple interrupteur.
-
-<!-- 📸 Ajouter une screenshot ici -->
-
-### Le terrain sur mobile
-
-* **Création et mise à jour d'un plan de prévention depuis un téléphone**, avec adresse de l'entreprise extérieure, champs obligatoires du responsable, et **signature de l'entreprise extérieure directement sur l'appareil**.
-* **Même parcours pour le permis de feu**, aligné sur celui du plan de prévention.
-* **Application web progressive** listant et créant les deux objets, avec un écran de réussite offrant le lien de diffusion et son QR code.
-* Les droits utilisés sont ceux des objets eux-mêmes (`preventionplan/write`, `firepermit/write`) plutôt que des droits dédiés, et l'en-tête affiche le logo carré, le nom de la société et un avatar cliquable.
-
-<!-- 📸 Ajouter une screenshot ici -->
-
-### PAPRIPACT par année
-
-* **Onglets « année en cours » et « années précédentes »** sur le plan d'action.
-* **Report des actions en retard** sur l'année en cours, en option.
-* **Barre de progression globale** au-dessus du Kanban, et **exports CSV et A3** depuis la vue.
-* **Filtres par GP/UT, niveau de risque et tags**, et **colonnes du Kanban pilotées par un dictionnaire** plutôt que codées en dur.
-* Chargement des cartes **colonne par colonne** et réglages d'affichage exposés dans la configuration.
-
-![Le PAPRIPACT par annee, avec ses filtres, sa barre de progression et son Kanban](https://raw.githubusercontent.com/nicolas-eoxia/digiriskdolibarr/assets/release-23.2.0/.shots/23.2.0-papripact-annees.png)
-
-### Tickets
-
-* **Fil de conversation sur la carte** : notes et messages publics, envoi d'email, pièces jointes, édition, suppression, citation et mentions `@`.
-* **Boîte de fichiers joints** en colonne gauche, fondée sur le widget natif de Dolibarr — génération, liste, aperçu et suppression.
-* **Édition en ligne du tiers et du projet** directement dans le bandeau, et sélecteur d'assigné avec recherche sur la carte Kanban.
-* **Toute modification faite depuis la carte est journalisée** comme événement d'agenda.
-* **Statistiques de pilotage** avec graphes cliquables, catégories de tickets affichées dans les documents, et entrée dédiée dans le menu Digirisk.
-
-### Risques
-
-* **Carte de lecture complète du risque**, et **tableau de bord des risques** sur la page des risques professionnels.
-* **Compteurs de cotation dans le bandeau**, description de l'élément éditable en ligne, et élément parent affiché comme lien.
-* **Refonte du front de la modale des risques psychosociaux**, et préremplissage de la description activé d'office.
-* **Archivage des risques et des GP/UT** plutôt que suppression.
-
-![Le tableau de bord des risques](https://raw.githubusercontent.com/nicolas-eoxia/digiriskdolibarr/assets/release-23.2.0/.shots/23.2.0-tableau-bord-risques.png)
-
-### Fiche produit
-
-* Nouvelle **fiche d'instruction HSE** sur le produit : six chapitres — identification, sécurité, mode d'emploi simplifié, qualification et habilitation, hygiène et nettoyage, maintenance et contrôles — éditables directement dans l'onglet.
-* Chaque chapitre est **configurable** depuis la nouvelle page de configuration produit : libellé, icône, couleur et description par défaut.
-* Onglet **Risques et protections** du produit, avec sa table d'association et les catégories de danger.
-* Le **PDF produit** reprend dynamiquement les risques et protections, ainsi que l'image du produit.
-
-![L'onglet Fiche d'Instruction sur un produit](https://raw.githubusercontent.com/nicolas-eoxia/digiriskdolibarr/assets/issue-5103/.shots/5103-onglet-fiche-instruction.png)
-
-### Arborescence GP/UT
-
-* **Refonte du panneau de navigation** : glisser-déposer, renommage en ligne, ajout et suppression rapides.
-* **Éditeur enrichi sur la description** des GP/UT.
-* Un élément introuvable renvoie désormais vers l'arborescence au lieu d'une erreur.
-
-### Documents
-
-* **Listing des risques en PDF** avec mini document unique, et **fiche « tous les risques »** regroupant les risques propres, hérités et partagés.
-* **Fiches des risques hérités et partagés** sur la fiche d'un GP/UT.
-* **Rapport de temps passé par utilisateur et par période** en PDF.
-* Le modèle du PAPRIPACT se choisit **depuis la configuration des documents** au lieu d'être figé.
-* Le rapport d'audit liste les **GP/UT modifiés et l'évolution des risques**.
-
-### Administration et recherche
-
-* **Masquer les entrées de menu objet par objet** depuis la configuration.
-* **Images de tutoriel** sur les pages de réglages, conseils sur l'API REST et les modules d'export/import.
-* Les objets Digirisk apparaissent dans la **recherche globale** de Dolibarr.
+**Cette version demande Saturne 23.1.1 ou supérieur.**
 
 ## Améliorations & corrections
 
-### Performance
+### Configuration
 
-* Suppression des requêtes N+1 sur le Kanban du plan d'action, et regroupement des requêtes de contacts de tâches.
-* Chargement des cartes du Kanban à la demande, colonne par colonne.
+* Les sept pages de configuration — configuration générale, événements, tickets, plan d'action, vigilance météo, plan de prévention et kanban des tickets — sont de nouveau accessibles. Elles appelaient deux fonctions d'aide qui n'avaient jamais été ajoutées à Saturne, et se terminaient toutes par une erreur fatale.
+* Éteindre un réglage écrit désormais un `0` au lieu de supprimer la constante. Une constante supprimée était recréée à sa valeur par défaut à la prochaine activation ou mise à jour du module : le réglage se rallumait tout seul, sans que personne n'y touche.
 
-### Robustesse et PHP 8
+### Document unique
 
-* Plus d'erreur fatale sur la liste des modules quand Saturne est absent.
-* Identifiants convertis avec `GETPOSTINT` sur les plans de prévention et les permis de feu, pour éviter les `TypeError` de `fetch()` sur PHP 8.
-* Correction des erreurs de type à la création de ticket public, au chargement d'un objet sans identifiant, et des avertissements PHP 8 à la création de tâche.
-* Vrais messages d'erreur lors de la génération de l'archive ZIP du document unique.
-* **Correction d'une erreur fatale qui empêchait toute génération du document unique** : une méthode déclarée `protected` dans la classe parente des modèles de document et redéclarée `private` dans le modèle ODT du document unique rendait la classe inchargeable. La méthode a été déplacée dans le modèle du rapport d'audit, à qui elle appartient.
+* Correction des avertissements PHP 8 à la génération du document unique.
 
-### Interface
-
-* Jauge d'avancement de la configuration de nouveau visible lorsque l'affichage des erreurs est actif.
-* Styles de la modale d'ajout de risque sortis du gabarit et passés en SCSS.
-* La carte laisse Saturne traiter le cas de l'enregistrement introuvable, au lieu de dupliquer la garde.
-
-### Socle et compatibilité
-
-* La compatibilité annoncée est resserrée sur **Dolibarr 23**.
-* Le module s'appuie sur **Saturne 23.1.0**.
-* Les dépendances communes — ECM, Agenda, FCKeditor, Catégories — sont désormais déclarées par Saturne.
-
-## Comparaison des versions [23.1.0](https://github.com/Evarisk/Digirisk/compare/23.1.0...23.2.1) et 23.2.1
+## Comparaison des versions [23.2.1](https://github.com/Evarisk/Digirisk/compare/23.2.1...23.2.2) et 23.2.2

--- a/core/modules/modDigiriskDolibarr.class.php
+++ b/core/modules/modDigiriskDolibarr.class.php
@@ -387,7 +387,7 @@ class modDigiriskdolibarr extends DolibarrModules
 		$this->descriptionlong = "Digirisk";
 		$this->editor_name     = 'Evarisk';
 		$this->editor_url      = 'https://evarisk.com';
-		$this->version         = '23.2.1';
+		$this->version         = '23.2.2';
 		$this->const_name      = 'MAIN_MODULE_' . strtoupper($this->name);
 		$this->picto           = 'digiriskdolibarr_color@digiriskdolibarr';
 

--- a/core/triggers/interface_99_modDigiriskdolibarr_DigiriskdolibarrTriggers.class.php
+++ b/core/triggers/interface_99_modDigiriskdolibarr_DigiriskdolibarrTriggers.class.php
@@ -72,7 +72,7 @@ class InterfaceDigiriskdolibarrTriggers extends DolibarrTriggers
 		$this->name        = preg_replace('/^Interface/i', '', get_class($this));
 		$this->family      = "demo";
 		$this->description = "Digiriskdolibarr triggers.";
-		$this->version     = '23.2.1';
+		$this->version     = '23.2.2';
 		$this->picto       = 'digiriskdolibarr@digiriskdolibarr';
 	}
 


### PR DESCRIPTION
Bump de version pour la 23.2.2 et réécriture des notes de version.

- `core/modules/modDigiriskDolibarr.class.php`, `core/triggers/interface_99_modDigiriskdolibarr_DigiriskdolibarrTriggers.class.php` : `23.2.1` → `23.2.2`
- `README.md` : ligne `- Version` et ligne `- Saturne Framework` alignée sur la 23.1.1 qui vient de sortir
- `RELEASE_NOTES.md` : notes de la 23.2.2

Version corrective : les sept pages de configuration, fatales depuis la 23.2.0 faute des deux fonctions d'aide jamais ajoutées à Saturne (corrigé par Saturne#1588, livré dans Saturne 23.1.1), et les avertissements PHP 8 à la génération du document unique (#5137).

🤖 Generated with [Claude Code](https://claude.com/claude-code)