### PR TITLE
#5143 [DU] add: data model for element-product association

### DIFF
--- a/class/digiriskelement_product.class.php
+++ b/class/digiriskelement_product.class.php
@@ -1,0 +1,163 @@
+﻿<?php
+/**
+ * \file    class/digiriskelement_product.class.php
+ * \ingroup digiriskdolibarr
+ * \brief   Class for associating products to digirisk elements (GP/UT)
+ */
+
+/**
+ * Class DigiriskElementProduct
+ * Stores an association between a Dolibarr product and a DigiriskElement.
+ */
+class DigiriskElementProduct extends CommonObject
+{
+    /** @var string Module name */
+    public $module = 'digiriskdolibarr';
+
+    /** @var string Element type */
+    public $element = 'digiriskelement_product';
+
+    /** @var string Table without prefix */
+    public $table_element = 'digiriskdolibarr_digiriskelement_product';
+
+    /** @var int Does this object support multicompany module? */
+    public $ismultientitymanaged = 1;
+
+    /** @var int FK digiriskelement */
+    public $fk_digiriskelement;
+
+    /** @var int FK product */
+    public $fk_product;
+
+    /**
+     * Constructor
+     * @param DoliDB $db Database handler
+     */
+    public function __construct(DoliDB $db)
+    {
+        $this->db = $db;
+    }
+
+    /**
+     * Create association in database.
+     *
+     * @param  User $user      User object
+     * @return int             rowid on success, <0 on error
+     */
+    public function create(User $user): int
+    {
+        global $conf;
+
+        $this->db->begin();
+
+        $sql = 'INSERT INTO ' . MAIN_DB_PREFIX . $this->table_element . ' (';
+        $sql .= 'entity, date_creation, fk_digiriskelement, fk_product, fk_user_creat';
+        $sql .= ') VALUES (';
+        $sql .= $conf->entity . ',';
+        $sql .= "'" . $this->db->idate(dol_now()) . "',";
+        $sql .= (int) $this->fk_digiriskelement . ',';
+        $sql .= (int) $this->fk_product . ',';
+        $sql .= (int) $user->id;
+        $sql .= ')';
+
+        $resql = $this->db->query($sql);
+        if (!$resql) {
+            $this->db->rollback();
+            $this->error = $this->db->lasterror();
+            return -1;
+        }
+
+        $this->id = $this->db->last_insert_id(MAIN_DB_PREFIX . $this->table_element);
+
+        $this->db->commit();
+        return $this->id;
+    }
+
+    /**
+     * Fetch from database.
+     *
+     * @param  int    $id   rowid
+     * @return int          >0 on success, 0 if not found, <0 on error
+     */
+    public function fetch(int $id): int
+    {
+        $sql = 'SELECT rowid, entity, date_creation, tms,'
+            . ' fk_digiriskelement, fk_product, fk_user_creat, fk_user_modif'
+            . ' FROM ' . MAIN_DB_PREFIX . $this->table_element
+            . ' WHERE rowid = ' . $id;
+
+        $resql = $this->db->query($sql);
+        if (!$resql) {
+            $this->error = $this->db->lasterror();
+            return -1;
+        }
+
+        $obj = $this->db->fetch_object($resql);
+        if (!$obj) {
+            return 0;
+        }
+
+        $this->id                 = (int) $obj->rowid;
+        $this->entity             = (int) $obj->entity;
+        $this->fk_digiriskelement = (int) $obj->fk_digiriskelement;
+        $this->fk_product         = (int) $obj->fk_product;
+        $this->date_creation      = $this->db->jdate($obj->date_creation);
+        $this->tms                = $this->db->jdate($obj->tms);
+        $this->fk_user_creat      = (int) $obj->fk_user_creat;
+        $this->fk_user_modif      = (int) $obj->fk_user_modif;
+
+        return 1;
+    }
+
+    /**
+     * Delete an association.
+     *
+     * @param  User   $user
+     * @param  bool   $notrigger
+     * @return int               >0 on success, <0 on error
+     */
+    public function delete(User $user, bool $notrigger = false): int
+    {
+        $sql = 'DELETE FROM ' . MAIN_DB_PREFIX . $this->table_element
+            . ' WHERE rowid = ' . (int) $this->id;
+
+        $resql = $this->db->query($sql);
+        if (!$resql) {
+            $this->error = $this->db->lasterror();
+            return -1;
+        }
+
+        return 1;
+    }
+
+    /**
+     * Fetch all products associated to an element.
+     *
+     * @param  int   $fk_digiriskelement
+     * @return array Array of DigiriskElementProduct objects, indexed by rowid
+     */
+    public function fetchAllByElement(int $fk_digiriskelement): array
+    {
+        global $conf;
+
+        $sql = 'SELECT rowid FROM ' . MAIN_DB_PREFIX . $this->table_element
+            . ' WHERE fk_digiriskelement = ' . $fk_digiriskelement
+            . ' AND entity = ' . $conf->entity
+            . ' ORDER BY date_creation DESC';
+
+        $resql = $this->db->query($sql);
+        if (!$resql) {
+            $this->error = $this->db->lasterror();
+            return [];
+        }
+
+        $list = [];
+        while ($obj = $this->db->fetch_object($resql)) {
+            $r = new self($this->db);
+            $r->fetch((int) $obj->rowid);
+            $list[$r->id] = $r;
+        }
+
+        return $list;
+    }
+}

--- a/sql/digiriskelement/llx_digiriskdolibarr_digiriskelement_product.key.sql
+++ b/sql/digiriskelement/llx_digiriskdolibarr_digiriskelement_product.key.sql
@@ -1,0 +1,19 @@
+﻿-- Copyright (C) 2021-2023 EVARISK <technique@evarisk.com>
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see https://www.gnu.org/licenses/.
+
+ALTER TABLE llx_digiriskdolibarr_digiriskelement_product ADD INDEX idx_digiriskelement_product_fk_digiriskelement (fk_digiriskelement);
+ALTER TABLE llx_digiriskdolibarr_digiriskelement_product ADD INDEX idx_digiriskelement_product_fk_product (fk_product);
+ALTER TABLE llx_digiriskdolibarr_digiriskelement_product ADD CONSTRAINT fk_digiriskelement_product_digiriskelement FOREIGN KEY (fk_digiriskelement) REFERENCES llx_digiriskdolibarr_digiriskelement (rowid);
+ALTER TABLE llx_digiriskdolibarr_digiriskelement_product ADD CONSTRAINT fk_digiriskelement_product_product FOREIGN KEY (fk_product) REFERENCES llx_product (rowid);

--- a/sql/digiriskelement/llx_digiriskdolibarr_digiriskelement_product.sql
+++ b/sql/digiriskelement/llx_digiriskdolibarr_digiriskelement_product.sql
@@ -1,0 +1,25 @@
+﻿-- Copyright (C) 2021-2023 EVARISK <technique@evarisk.com>
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see https://www.gnu.org/licenses/.
+
+CREATE TABLE llx_digiriskdolibarr_digiriskelement_product(
+	rowid            integer AUTO_INCREMENT PRIMARY KEY NOT NULL,
+	entity           integer DEFAULT 1 NOT NULL,
+	date_creation    datetime NOT NULL,
+	tms              timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+	fk_user_creat    integer NOT NULL,
+	fk_user_modif    integer,
+	fk_digiriskelement integer NOT NULL,
+	fk_product       integer NOT NULL
+) ENGINE=innodb;

--- a/sql/update.sql
+++ b/sql/update.sql
@@ -288,3 +288,20 @@ ALTER TABLE llx_digiriskdolibarr_riskassessment ADD INDEX idx_digiriskdolibarr_r
 
 -- 23.1.x - enable the prefill of the risk description with the danger category name on every entity
 UPDATE llx_const SET value = 1 WHERE name = 'DIGIRISKDOLIBARR_RISK_DESCRIPTION_PREFILL';
+
+-- 23.1.x - product association with digiriskelement (issue #5103)
+CREATE TABLE llx_digiriskdolibarr_digiriskelement_product(
+	rowid            integer AUTO_INCREMENT PRIMARY KEY NOT NULL,
+	entity           integer DEFAULT 1 NOT NULL,
+	date_creation    datetime NOT NULL,
+	tms              timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+	fk_user_creat    integer NOT NULL,
+	fk_user_modif    integer,
+	fk_digiriskelement integer NOT NULL,
+	fk_product       integer NOT NULL
+) ENGINE=innodb;
+
+ALTER TABLE llx_digiriskdolibarr_digiriskelement_product ADD INDEX idx_digiriskelement_product_fk_digiriskelement (fk_digiriskelement);
+ALTER TABLE llx_digiriskdolibarr_digiriskelement_product ADD INDEX idx_digiriskelement_product_fk_product (fk_product);
+ALTER TABLE llx_digiriskdolibarr_digiriskelement_product ADD CONSTRAINT fk_digiriskelement_product_digiriskelement FOREIGN KEY (fk_digiriskelement) REFERENCES llx_digiriskdolibarr_digiriskelement (rowid);
+ALTER TABLE llx_digiriskdolibarr_digiriskelement_product ADD CONSTRAINT fk_digiriskelement_product_product FOREIGN KEY (fk_product) REFERENCES llx_product (rowid);


### PR DESCRIPTION
Fixes #5143

Ajout du modèle de données (table, clés et classe PHP) pour lier un élément Digirisk (GP/UT) à un produit natif Dolibarr.